### PR TITLE
Fix version sync: update defaults.yaml to 5.1.0 and add validation

### DIFF
--- a/engine/config/defaults.yaml
+++ b/engine/config/defaults.yaml
@@ -109,7 +109,7 @@ run:
   node: false
   port: 9999
   scenario: null
-  version: 5.0.2
+  version: 5.1.0
 
 log:
   level: info

--- a/engine/core/spt-base/src/main/resources/config/defaults.yaml
+++ b/engine/core/spt-base/src/main/resources/config/defaults.yaml
@@ -115,7 +115,7 @@ run:
   node: false
   port: 9999
   scenario: null
-  version: 5.0.2
+  version: 5.1.0
 
 log:
   level: info

--- a/scripts/release/check_version_sync.sh
+++ b/scripts/release/check_version_sync.sh
@@ -78,6 +78,23 @@ check_contains "engine/bundle/build.gradle" "rootProject.ext.SPT_VERSION"
 check_contains "engine/bundle/Dockerfile" "ARG SPT_VERSION="
 check_contains "engine/bundle/Dockerfile" "LABEL version=\"\${SPT_VERSION}\""
 
+# Check that defaults.yaml contains the correct version
+# This is critical because spt-base/build.gradle reads version from defaults.yaml
+check_version_in_yaml() {
+	local file="$1"
+	if [[ ! -f "${ROOT_DIR}/${file}" ]]; then
+		errors+=("Expected file ${file} not found")
+		return
+	fi
+	local yaml_version
+	yaml_version=$(grep -E '^\s*version:\s*' "${ROOT_DIR}/${file}" | tail -1 | sed 's/.*version:\s*//' | tr -d '[:space:]')
+	if [[ -n "${REPO_VERSION}" && "${yaml_version}" != "${REPO_VERSION}" ]]; then
+		errors+=("Version in ${file} is '${yaml_version}' but VERSION file has '${REPO_VERSION}'")
+	fi
+}
+
+check_version_in_yaml "engine/core/spt-base/src/main/resources/config/defaults.yaml"
+
 if [[ "${#errors[@]}" -gt 0 ]]; then
 	printf 'Version sync check failed:\n' >&2
 	for err in "${errors[@]}"; do


### PR DESCRIPTION
## Summary
- Update version in both `defaults.yaml` files to 5.1.0
- Add `check_version_in_yaml()` validation to version sync script to prevent this issue in future releases

## Problem
The Docker publish workflow for v5.1.0 failed because the JAR was built with version `5.0.2` from `defaults.yaml` instead of `5.1.0` from the `VERSION` file.

The `spt-base/build.gradle` reads the version from `defaults.yaml` via `defineVersion()`, which was not updated when the VERSION file was bumped to 5.1.0.

## Fix
1. Updated `engine/config/defaults.yaml` and `engine/core/spt-base/src/main/resources/config/defaults.yaml` to version 5.1.0
2. Added a new validation function to `scripts/release/check_version_sync.sh` that verifies the version in `defaults.yaml` matches the VERSION file

## Test plan
- [x] `scripts/release/check_version_sync.sh` passes
- [ ] After merge, re-run Docker publish workflow for v5.1.0 tag
- [ ] Verify Docker image is published to GHCR with correct version