### PR TITLE
Fix race condition in Docker publish CI gate

### DIFF
--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -46,32 +46,42 @@ jobs:
         with:
           script: |
             const sha = context.sha;
+            const ciCheckNames = ['Engine Build & Tests', 'Go Quality Suite'];
+            const maxAttempts = 10;
+            const intervalMs = 30000;
+
             console.log(`Checking CI status for commit ${sha}`);
+            console.log(`Will poll up to ${maxAttempts} times (${maxAttempts * intervalMs / 1000}s) for: ${ciCheckNames.join(', ')}`);
 
-            // Get check runs for this commit
-            const { data: checkRuns } = await github.rest.checks.listForRef({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              ref: sha,
-            });
+            for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+              const { data: checkRuns } = await github.rest.checks.listForRef({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: sha,
+              });
 
-            // Look for the CI workflow
-            const ciCheck = checkRuns.check_runs.find(
-              run => run.name === 'Engine Build & Tests' || run.name === 'Go Quality Suite'
-            );
+              const ciCheck = checkRuns.check_runs.find(
+                run => ciCheckNames.includes(run.name)
+              );
 
-            if (!ciCheck) {
-              console.log('Warning: CI check not found. Ensure CI has run for this commit.');
-              console.log('Available checks:', checkRuns.check_runs.map(r => r.name).join(', '));
-              // Don't fail - CI may use different check names or may not have run yet
-              return;
+              if (!ciCheck) {
+                console.log(`Attempt ${attempt}/${maxAttempts}: CI check not found yet. Available: ${checkRuns.check_runs.map(r => r.name).join(', ') || '(none)'}`);
+              } else if (ciCheck.conclusion === 'success') {
+                console.log(`CI check "${ciCheck.name}" passed.`);
+                return;
+              } else if (ciCheck.conclusion) {
+                core.setFailed(`CI check "${ciCheck.name}" failed (conclusion: ${ciCheck.conclusion}). Cannot publish image.`);
+                return;
+              } else {
+                console.log(`Attempt ${attempt}/${maxAttempts}: CI check "${ciCheck.name}" still in progress...`);
+              }
+
+              if (attempt < maxAttempts) {
+                await new Promise(r => setTimeout(r, intervalMs));
+              }
             }
 
-            if (ciCheck.conclusion !== 'success') {
-              core.setFailed(`CI check "${ciCheck.name}" has not passed (status: ${ciCheck.conclusion}). Cannot publish image.`);
-            } else {
-              console.log(`CI check "${ciCheck.name}" passed.`);
-            }
+            core.setFailed(`CI checks did not complete within ${maxAttempts * intervalMs / 1000}s. Re-run this workflow after CI passes.`);
 
   prepare:
     name: Prepare Version

--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -47,7 +47,7 @@ jobs:
           script: |
             const sha = context.sha;
             const ciCheckNames = ['Engine Build & Tests', 'Go Quality Suite'];
-            const maxAttempts = 10;
+            const maxAttempts = 30;
             const intervalMs = 30000;
 
             console.log(`Checking CI status for commit ${sha}`);


### PR DESCRIPTION
## Summary
- Fix Docker publish workflow failing on tag pushes due to CI not being complete yet

## Problem
The `verify-ci` job in `docker-publish.yaml` checks CI status with a single API call. Since the Docker publish workflow triggers on the same `push` event as CI, the check runs concurrently and finds CI status as `null` (in progress), causing an immediate failure. This has been a recurring issue (failed on v5.3.0 and v5.1.1 releases).

## Fix
Replace the one-shot CI status check with a polling loop:
- Polls GitHub Checks API every 30 seconds
- Up to 10 attempts (5 minutes total)
- Returns immediately on success or definitive failure
- Times out with a clear error message if CI doesn't complete

## Test plan
- [ ] Workflow syntax is valid (CI will validate)
- [ ] Next tag push should show polling behavior in workflow logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)