### PR TITLE
Fix: remote metrics artifacts retrieval

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -126,6 +126,7 @@ engine/.mvn/wrapper/maven-wrapper.jar
 # Temporary files
 engine/tmp/
 *.tmp
+engine/tools/log/
 
 # Miscellaneous engine logs
 engine/logs/

--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -65,8 +65,9 @@ var (
 	newRunTrackerFunc = func(baseURL string) autoResultsRunTracker {
 		return &runTrackerAdapter{portcheck.NewRunTracker(baseURL)}
 	}
-	discoverStepIDsFunc   = results.DiscoverStepIDs
-	newResultsFetcherFunc = func(baseURL, outputDir string) autoResultsFetcher {
+	discoverStepIDsFunc      = results.DiscoverStepIDs
+	discoverFleetStepIDsFunc = results.DiscoverFleetStepIDs
+	newResultsFetcherFunc    = func(baseURL, outputDir string) autoResultsFetcher {
 		return &fetcherAdapter{results.NewFetcher(baseURL, outputDir)}
 	}
 	generateRunSummaryFunc = generateRunSummary
@@ -157,8 +158,10 @@ func startAutoResults(baseURL, label, resultsDir string, expectedStepIDs []strin
 		tracker.SetDebug(debug)
 		// While we wait, continuously discover step IDs so we have exact IDs on completion
 		var discovered []string
+		var fleetDiscovered []string
 		var mu sync.Mutex
 		seen := make(map[string]struct{})
+		fleetSeen := make(map[string]struct{})
 		stopCh := make(chan struct{})
 		go func() {
 			ticker := time.NewTicker(500 * time.Millisecond)
@@ -188,11 +191,47 @@ func startAutoResults(baseURL, label, resultsDir string, expectedStepIDs []strin
 							logging.LogDebug("auto-results", "discover", "steps", strings.Join(snapshot, ","))
 						}
 					}
+					// Also poll fleet endpoint for distributed step IDs
+					if fids, err := discoverFleetStepIDsFunc(baseURL); err == nil && len(fids) > 0 {
+						mu.Lock()
+						updated := false
+						for _, id := range fids {
+							if id == "" {
+								continue
+							}
+							if _, ok := fleetSeen[id]; ok {
+								continue
+							}
+							fleetSeen[id] = struct{}{}
+							fleetDiscovered = append(fleetDiscovered, id)
+							updated = true
+						}
+						snapshot := append([]string(nil), fleetDiscovered...)
+						mu.Unlock()
+						if debug && updated && len(snapshot) > 0 {
+							logging.LogDebug("auto-results", "discover-fleet", "steps", strings.Join(snapshot, ","))
+						}
+					}
 				}
 			}
 		}()
 		_, _ = tracker.WaitForCompletion(ctx, expectedStepIDs)
 		close(stopCh)
+		// One final fleet discovery after completion (may not have been picked up during polling)
+		if fids, err := discoverFleetStepIDsFunc(baseURL); err == nil && len(fids) > 0 {
+			mu.Lock()
+			for _, id := range fids {
+				if id == "" {
+					continue
+				}
+				if _, ok := fleetSeen[id]; ok {
+					continue
+				}
+				fleetSeen[id] = struct{}{}
+				fleetDiscovered = append(fleetDiscovered, id)
+			}
+			mu.Unlock()
+		}
 		writeProgress("Auto-results: completion detected; fetching artifacts to %s...\n", root)
 
 		// Discover step IDs from JSON metrics.
@@ -202,6 +241,7 @@ func startAutoResults(baseURL, label, resultsDir string, expectedStepIDs []strin
 		// we intersect rather than union to prevent stale IDs from reaching FetchArtifactsForSteps.
 		mu.Lock()
 		cachedDiscovered := append([]string(nil), discovered...)
+		cachedFleet := append([]string(nil), fleetDiscovered...)
 		mu.Unlock()
 		if len(expectedStepIDs) > 0 {
 			expectedSet := make(map[string]struct{}, len(expectedStepIDs))
@@ -216,19 +256,25 @@ func startAutoResults(baseURL, label, resultsDir string, expectedStepIDs []strin
 			}
 			cachedDiscovered = filtered
 		}
-		stepIDs := uniqueStepIDs(expectedStepIDs, cachedDiscovered)
+		// Fleet-discovered IDs bypass the stale-ID intersection filter because they
+		// represent the engine's actual runtime step IDs (which may differ from
+		// CLI-generated expected IDs in distributed/multi-host mode due to timestamp
+		// reassignment). Fleet IDs go first so they take precedence when present.
+		stepIDs := uniqueStepIDs(cachedFleet, expectedStepIDs, cachedDiscovered)
 		var discoverErr error
 		if len(stepIDs) == 0 {
 			var fallback []string
 			fallback, discoverErr = discoverStepIDsFunc(baseURL)
-			stepIDs = uniqueStepIDs(stepIDs, fallback)
+			// Also try fleet endpoint as fallback
+			fleetFallback, _ := discoverFleetStepIDsFunc(baseURL)
+			stepIDs = uniqueStepIDs(fleetFallback, stepIDs, fallback)
 		}
 		if len(stepIDs) == 0 {
 			var logErr error
 			if discoverErr != nil {
 				logErr = fmt.Errorf("discover step IDs: %w", discoverErr)
 			} else {
-				logErr = fmt.Errorf("no steps reported by metrics/json")
+				logErr = fmt.Errorf("no steps reported by metrics/json or metrics/fleet/json")
 			}
 			logging.LogError("auto-results", "no step IDs discovered; skipping fetch", logErr)
 			return
@@ -237,7 +283,7 @@ func startAutoResults(baseURL, label, resultsDir string, expectedStepIDs []strin
 
 		if metadata != nil {
 			metadata.ActualStepIDs = append([]string(nil), stepIDs...)
-			metadata.DiscoveredStepIDs = uniqueStepIDs(metadata.DiscoveredStepIDs, cachedDiscovered, stepIDs)
+			metadata.DiscoveredStepIDs = uniqueStepIDs(metadata.DiscoveredStepIDs, cachedFleet, cachedDiscovered, stepIDs)
 			if err := writeRunMetadata(metadata, root); err != nil {
 				logging.LogError("auto-results", "write run metadata", err, "dest", root)
 			}

--- a/cli/cmd/run_auto_results_test.go
+++ b/cli/cmd/run_auto_results_test.go
@@ -73,17 +73,22 @@ func (f *fakeFetcher) FetchArtifactsForSteps(ctx context.Context, stepIDs []stri
 func TestStartAutoResults_StaleDiscoveredIDsFromPriorRun(t *testing.T) {
 	origRunTracker := newRunTrackerFunc
 	origDiscover := discoverStepIDsFunc
+	origFleetDiscover := discoverFleetStepIDsFunc
 	origFetcher := newResultsFetcherFunc
 	origSummary := generateRunSummaryFunc
 	defer func() {
 		newRunTrackerFunc = origRunTracker
 		discoverStepIDsFunc = origDiscover
+		discoverFleetStepIDsFunc = origFleetDiscover
 		newResultsFetcherFunc = origFetcher
 		generateRunSummaryFunc = origSummary
 	}()
 
 	tracker := &fakeRunTracker{}
 	newRunTrackerFunc = func(baseURL string) autoResultsRunTracker { return tracker }
+
+	// Fleet endpoint unavailable (older engine)
+	discoverFleetStepIDsFunc = func(baseURL string) ([]string, error) { return nil, nil }
 
 	// Stale IDs from a prior aborted run (timestamp .367), current run has timestamp .368.
 	staleIDs := []string{
@@ -158,11 +163,13 @@ func TestStartAutoResults_DiscoveredIDsFilteredToExpectedSet(t *testing.T) {
 
 	origRunTracker := newRunTrackerFunc
 	origDiscover := discoverStepIDsFunc
+	origFleetDiscover := discoverFleetStepIDsFunc
 	origFetcher := newResultsFetcherFunc
 	origSummary := generateRunSummaryFunc
 	defer func() {
 		newRunTrackerFunc = origRunTracker
 		discoverStepIDsFunc = origDiscover
+		discoverFleetStepIDsFunc = origFleetDiscover
 		newResultsFetcherFunc = origFetcher
 		generateRunSummaryFunc = origSummary
 	}()
@@ -174,6 +181,9 @@ func TestStartAutoResults_DiscoveredIDsFilteredToExpectedSet(t *testing.T) {
 		}
 		return tracker
 	}
+
+	// Fleet endpoint unavailable (older engine)
+	discoverFleetStepIDsFunc = func(baseURL string) ([]string, error) { return nil, nil }
 
 	// Discovery returns the expected ID mixed in with a foreign one from another run.
 	discoverCalls := 0
@@ -236,5 +246,148 @@ func TestStartAutoResults_DiscoveredIDsFilteredToExpectedSet(t *testing.T) {
 	}
 	if discoverCalls == 0 {
 		t.Fatal("discoverStepIDsFunc was never called")
+	}
+}
+
+// TestStartAutoResults_FleetDiscoveryPreferred verifies that when the fleet endpoint
+// returns step IDs different from expected IDs (the distributed mode step-ID mismatch),
+// the fleet-discovered IDs are used for fetching instead of the CLI-generated expected IDs.
+func TestStartAutoResults_FleetDiscoveryPreferred(t *testing.T) {
+	origRunTracker := newRunTrackerFunc
+	origDiscover := discoverStepIDsFunc
+	origFleetDiscover := discoverFleetStepIDsFunc
+	origFetcher := newResultsFetcherFunc
+	origSummary := generateRunSummaryFunc
+	defer func() {
+		newRunTrackerFunc = origRunTracker
+		discoverStepIDsFunc = origDiscover
+		discoverFleetStepIDsFunc = origFleetDiscover
+		newResultsFetcherFunc = origFetcher
+		generateRunSummaryFunc = origSummary
+	}()
+
+	tracker := &fakeRunTracker{}
+	newRunTrackerFunc = func(baseURL string) autoResultsRunTracker { return tracker }
+
+	// CLI-generated expected IDs (with timestamp .519)
+	expectedIDs := []string{
+		"mt-001-20260312.192453.519-create",
+		"mt-002-20260312.192453.519-delete",
+	}
+
+	// Engine's actual IDs (with timestamp .387) — returned by fleet endpoint
+	fleetIDs := []string{
+		"mt-001-20260312.192454.387-create",
+		"mt-002-20260312.192454.387-delete",
+	}
+
+	// Node-local /metrics/json returns nothing useful in distributed mode
+	discoverStepIDsFunc = func(baseURL string) ([]string, error) { return nil, nil }
+
+	// Fleet endpoint returns the engine's actual step IDs
+	discoverFleetStepIDsFunc = func(baseURL string) ([]string, error) {
+		return fleetIDs, nil
+	}
+
+	fetcher := &fakeFetcher{}
+	newResultsFetcherFunc = func(baseURL, outputDir string) autoResultsFetcher {
+		fetcher.baseURL = baseURL
+		fetcher.output = outputDir
+		return fetcher
+	}
+	generateRunSummaryFunc = func(ctx context.Context, runDir string, out io.Writer) error { return nil }
+
+	tmpDir := t.TempDir()
+	done := startAutoResults("http://example", "mt", tmpDir, expectedIDs, false, nil, "", false, 0, "", nil, io.Discard, io.Discard)
+
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("startAutoResults did not complete in time")
+	}
+
+	fetcher.mu.Lock()
+	defer fetcher.mu.Unlock()
+
+	// Fleet IDs should be present in the fetched step IDs
+	fleetSet := make(map[string]bool, len(fleetIDs))
+	for _, id := range fleetIDs {
+		fleetSet[id] = true
+	}
+	foundFleet := 0
+	for _, id := range fetcher.stepIDs {
+		if fleetSet[id] {
+			foundFleet++
+		}
+	}
+	if foundFleet != len(fleetIDs) {
+		t.Fatalf("expected all %d fleet IDs in fetcher.stepIDs, found %d; got %v", len(fleetIDs), foundFleet, fetcher.stepIDs)
+	}
+}
+
+// TestStartAutoResults_FleetUnavailableFallback verifies that when the fleet endpoint
+// is unavailable (404, older engine), the system falls back to expected IDs.
+func TestStartAutoResults_FleetUnavailableFallback(t *testing.T) {
+	origRunTracker := newRunTrackerFunc
+	origDiscover := discoverStepIDsFunc
+	origFleetDiscover := discoverFleetStepIDsFunc
+	origFetcher := newResultsFetcherFunc
+	origSummary := generateRunSummaryFunc
+	defer func() {
+		newRunTrackerFunc = origRunTracker
+		discoverStepIDsFunc = origDiscover
+		discoverFleetStepIDsFunc = origFleetDiscover
+		newResultsFetcherFunc = origFetcher
+		generateRunSummaryFunc = origSummary
+	}()
+
+	tracker := &fakeRunTracker{}
+	newRunTrackerFunc = func(baseURL string) autoResultsRunTracker { return tracker }
+
+	expectedIDs := []string{
+		"mt-001-20260312.192453.519-create",
+		"mt-002-20260312.192453.519-delete",
+	}
+
+	// Node-local returns matching IDs (non-distributed mode)
+	discoverStepIDsFunc = func(baseURL string) ([]string, error) {
+		return expectedIDs, nil
+	}
+
+	// Fleet endpoint unavailable (404)
+	discoverFleetStepIDsFunc = func(baseURL string) ([]string, error) { return nil, nil }
+
+	fetcher := &fakeFetcher{}
+	newResultsFetcherFunc = func(baseURL, outputDir string) autoResultsFetcher {
+		fetcher.baseURL = baseURL
+		fetcher.output = outputDir
+		return fetcher
+	}
+	generateRunSummaryFunc = func(ctx context.Context, runDir string, out io.Writer) error { return nil }
+
+	tmpDir := t.TempDir()
+	done := startAutoResults("http://example", "mt", tmpDir, expectedIDs, false, nil, "", false, 0, "", nil, io.Discard, io.Discard)
+
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("startAutoResults did not complete in time")
+	}
+
+	fetcher.mu.Lock()
+	defer fetcher.mu.Unlock()
+
+	// Should fall back to expected IDs when fleet is unavailable
+	if len(fetcher.stepIDs) != len(expectedIDs) {
+		t.Fatalf("expected %d step IDs, got %d: %v", len(expectedIDs), len(fetcher.stepIDs), fetcher.stepIDs)
+	}
+	expectedSet := make(map[string]bool, len(expectedIDs))
+	for _, id := range expectedIDs {
+		expectedSet[id] = true
+	}
+	for _, id := range fetcher.stepIDs {
+		if !expectedSet[id] {
+			t.Fatalf("unexpected step ID %q in fetcher.stepIDs; got %v", id, fetcher.stepIDs)
+		}
 	}
 }

--- a/cli/internal/results/discovery.go
+++ b/cli/internal/results/discovery.go
@@ -10,21 +10,46 @@ import (
 )
 
 // DiscoverStepIDs fetches /metrics/json and returns unique step IDs found.
+// This endpoint returns node-local (non-distributed) metrics contexts, which
+// may NOT include the correct step IDs in multi-host distributed runs.
+// For distributed runs, prefer DiscoverFleetStepIDs.
 func DiscoverStepIDs(baseURL string) ([]string, error) {
+	return discoverStepIDsFromPath(baseURL, "/metrics/json")
+}
+
+// DiscoverFleetStepIDs fetches /metrics/fleet/json and returns unique step IDs
+// from the fleet/cluster aggregated metrics. In distributed (multi-host) mode,
+// this endpoint exposes DistributedMetricsContext entries that contain the
+// engine's actual runtime step IDs — which may differ from the CLI-generated
+// expected step IDs due to timestamp reassignment.
+//
+// Returns (nil, nil) if the fleet endpoint is unavailable (404) so callers can
+// fall back gracefully.
+func DiscoverFleetStepIDs(baseURL string) ([]string, error) {
+	return discoverStepIDsFromPath(baseURL, "/metrics/fleet/json")
+}
+
+// discoverStepIDsFromPath is the shared implementation for both node and fleet
+// step-ID discovery endpoints.
+func discoverStepIDsFromPath(baseURL, metricsPath string) ([]string, error) {
 	client := &http.Client{Timeout: 5 * time.Second}
-	resp, err := client.Get(strings.TrimSuffix(baseURL, "/") + "/metrics/json")
+	resp, err := client.Get(strings.TrimSuffix(baseURL, "/") + metricsPath)
 	if err != nil {
-		return nil, fmt.Errorf("fetch metrics/json: %w", err)
+		return nil, fmt.Errorf("fetch %s: %w", metricsPath, err)
 	}
 	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode == http.StatusNotFound {
+		// Fleet endpoint may not be available on all engine versions.
+		return nil, nil
+	}
 	if resp.StatusCode != 200 {
-		return nil, fmt.Errorf("metrics/json status: %d", resp.StatusCode)
+		return nil, fmt.Errorf("%s status: %d", metricsPath, resp.StatusCode)
 	}
 	var steps []struct {
 		StepID string `json:"step_id"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&steps); err != nil {
-		return nil, fmt.Errorf("decode metrics/json: %w", err)
+		return nil, fmt.Errorf("decode %s: %w", metricsPath, err)
 	}
 	seen := map[string]bool{}
 	out := make([]string, 0, len(steps))

--- a/cli/internal/results/discovery_test.go
+++ b/cli/internal/results/discovery_test.go
@@ -24,3 +24,112 @@ func TestDiscoverStepIDs(t *testing.T) {
 		t.Fatalf("expected 2 ids, got %d", len(ids))
 	}
 }
+
+func TestDiscoverFleetStepIDs(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/metrics/fleet/json", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[
+          {"step_id":"fleet-001-20250101.000000.000-create"},
+          {"step_id":"fleet-002-20250101.000000.000-delete"}
+        ]`))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	ids, err := DiscoverFleetStepIDs(srv.URL)
+	if err != nil {
+		t.Fatalf("DiscoverFleetStepIDs error: %v", err)
+	}
+	if len(ids) != 2 {
+		t.Fatalf("expected 2 ids, got %d", len(ids))
+	}
+	if ids[0] != "fleet-001-20250101.000000.000-create" {
+		t.Fatalf("expected first id fleet-001-20250101.000000.000-create, got %s", ids[0])
+	}
+	if ids[1] != "fleet-002-20250101.000000.000-delete" {
+		t.Fatalf("expected second id fleet-002-20250101.000000.000-delete, got %s", ids[1])
+	}
+}
+
+func TestDiscoverFleetStepIDs_NotFound(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/metrics/fleet/json", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	ids, err := DiscoverFleetStepIDs(srv.URL)
+	if err != nil {
+		t.Fatalf("expected nil error on 404, got: %v", err)
+	}
+	if ids != nil {
+		t.Fatalf("expected nil ids on 404, got: %v", ids)
+	}
+}
+
+func TestDiscoverStepIDs_EmptyStepIDs(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[
+          {"step_id":""},
+          {"step_id":""},
+          {"step_id":""}
+        ]`))
+	}))
+	defer srv.Close()
+
+	ids, err := DiscoverStepIDs(srv.URL)
+	if err != nil {
+		t.Fatalf("DiscoverStepIDs error: %v", err)
+	}
+	if len(ids) != 0 {
+		t.Fatalf("expected 0 ids, got %d: %v", len(ids), ids)
+	}
+}
+
+func TestDiscoverStepIDs_DeduplicatesAndSorts(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[
+          {"step_id":"zebra-step"},
+          {"step_id":"alpha-step"},
+          {"step_id":"zebra-step"},
+          {"step_id":"middle-step"},
+          {"step_id":"alpha-step"}
+        ]`))
+	}))
+	defer srv.Close()
+
+	ids, err := DiscoverStepIDs(srv.URL)
+	if err != nil {
+		t.Fatalf("DiscoverStepIDs error: %v", err)
+	}
+	if len(ids) != 3 {
+		t.Fatalf("expected 3 unique ids, got %d: %v", len(ids), ids)
+	}
+	expected := []string{"alpha-step", "middle-step", "zebra-step"}
+	for i, want := range expected {
+		if ids[i] != want {
+			t.Fatalf("ids[%d] = %q, want %q", i, ids[i], want)
+		}
+	}
+}
+
+func TestDiscoverFleetStepIDs_ServerError(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/metrics/fleet/json", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	ids, err := DiscoverFleetStepIDs(srv.URL)
+	if err == nil {
+		t.Fatalf("expected error on 500, got nil with ids: %v", ids)
+	}
+	if ids != nil {
+		t.Fatalf("expected nil ids on error, got: %v", ids)
+	}
+}

--- a/cli/internal/results/fetcher.go
+++ b/cli/internal/results/fetcher.go
@@ -310,7 +310,28 @@ type stepIndexItem struct {
 }
 
 // fetchStepIndex retrieves /logs/<stepId>/index.json and returns a map logger->item.
+// It retries up to Retries times when the response is empty (engine may still be
+// flushing log files shortly after completion).
 func (f *Fetcher) fetchStepIndex(ctx context.Context, stepID string) (map[string]stepIndexItem, error) {
+	for attempt := 0; attempt < max(1, f.Retries); attempt++ {
+		out, err := f.doFetchStepIndex(ctx, stepID)
+		if err != nil {
+			return nil, err
+		}
+		if len(out) > 0 {
+			return out, nil
+		}
+		// Empty index — engine may still be flushing; retry after delay.
+		if attempt < f.Retries-1 && f.RetryDelay > 0 && f.Sleeper != nil {
+			f.Sleeper(f.RetryDelay)
+		}
+	}
+	// All retries exhausted with empty response — return empty map.
+	return make(map[string]stepIndexItem), nil
+}
+
+// doFetchStepIndex performs a single HTTP request for the step index.
+func (f *Fetcher) doFetchStepIndex(ctx context.Context, stepID string) (map[string]stepIndexItem, error) {
 	u, err := url.Parse(f.BaseURL)
 	if err != nil {
 		return nil, fmt.Errorf("parse base url: %w", err)

--- a/cli/internal/results/fetcher_test.go
+++ b/cli/internal/results/fetcher_test.go
@@ -219,6 +219,86 @@ func TestFetcher_RetryOnServerError(t *testing.T) {
 	_ = man
 }
 
+func TestFetcher_IndexRetrySucceeds(t *testing.T) {
+	step := "mt-001-20250101.000000.000-create"
+	var indexCalls int32
+	srv := newTestServer(t, map[string]http.HandlerFunc{
+		"/logs/" + step + "/index.json": func(w http.ResponseWriter, r *http.Request) {
+			n := atomic.AddInt32(&indexCalls, 1)
+			if n < 3 {
+				// Return empty items array for first two attempts
+				_ = json.NewEncoder(w).Encode(map[string]any{"step_id": step, "items": []map[string]any{}})
+				return
+			}
+			idx := map[string]any{
+				"step_id": step,
+				"items": []map[string]any{
+					{"logger": "metrics.FileTotal", "href": "/logs/" + step + "/metrics.FileTotal", "size": 5},
+					{"logger": "Config", "href": "/logs/" + step + "/Config", "size": 3},
+					{"logger": "Cli", "href": "/logs/" + step + "/Cli", "size": 3},
+					{"logger": "Messages", "href": "/logs/" + step + "/Messages", "size": 4},
+					{"logger": "Errors", "href": "/logs/" + step + "/Errors", "size": 4},
+				},
+			}
+			_ = json.NewEncoder(w).Encode(idx)
+		},
+		"/logs/" + step + "/metrics.FileTotal": func(w http.ResponseWriter, r *http.Request) { _, _ = w.Write([]byte("total")) },
+		"/logs/" + step + "/Config":            func(w http.ResponseWriter, r *http.Request) { _, _ = w.Write([]byte("cfg")) },
+		"/logs/" + step + "/Cli":               func(w http.ResponseWriter, r *http.Request) { _, _ = w.Write([]byte("cli")) },
+		"/logs/" + step + "/Messages":          func(w http.ResponseWriter, r *http.Request) { _, _ = w.Write([]byte("msgs")) },
+		"/logs/" + step + "/Errors":            func(w http.ResponseWriter, r *http.Request) { _, _ = w.Write([]byte("errs")) },
+	})
+	defer srv.Close()
+
+	out := t.TempDir()
+	f := NewFetcher(srv.URL, out)
+	f.Sleeper = func(time.Duration) {}
+	f.Retries = 5
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	man, err := f.FetchArtifactsForSteps(ctx, []string{step})
+	if err != nil {
+		t.Fatalf("FetchArtifactsForSteps error: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(out, step+".metrics.total.csv")); err != nil {
+		t.Fatalf("metrics.total.csv not found after index retry: %v", err)
+	}
+	if atomic.LoadInt32(&indexCalls) < 3 {
+		t.Fatalf("expected at least 3 index calls for retry, got %d", atomic.LoadInt32(&indexCalls))
+	}
+	_ = man
+}
+
+func TestFetcher_IndexRetryExhausted(t *testing.T) {
+	step := "mt-001-20250101.000000.000-create"
+	srv := newTestServer(t, map[string]http.HandlerFunc{
+		"/logs/" + step + "/index.json": func(w http.ResponseWriter, r *http.Request) {
+			// Always return empty items
+			_ = json.NewEncoder(w).Encode(map[string]any{"step_id": step, "items": []map[string]any{}})
+		},
+	})
+	defer srv.Close()
+
+	out := t.TempDir()
+	f := NewFetcher(srv.URL, out)
+	f.Sleeper = func(time.Duration) {}
+	f.Retries = 3
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	man, err := f.FetchArtifactsForSteps(ctx, []string{step})
+	if err == nil {
+		t.Fatal("expected error when all retries exhausted with empty index, got nil")
+	}
+	// Manifest should still be returned with missing files
+	if man == nil {
+		t.Fatal("expected non-nil manifest even on error")
+	}
+}
+
 func TestFetcher_UsesIndexJsonForDiscovery(t *testing.T) {
 	step := "mt-001-20250101.000000.000-create"
 	// Provide index.json listing required artifacts; serve those endpoints; omit optionals

--- a/engine/build.gradle
+++ b/engine/build.gradle
@@ -114,11 +114,13 @@ task jacocoRootReport(type: JacocoReport) {
     description = 'Generate aggregate JaCoCo coverage report for all subprojects'
     group = 'verification'
     
-    // Depend on all subproject test tasks
+    // Depend on all subproject test tasks and compilation tasks to fix Gradle 8 implicit dependency errors
     def javaProjects = subprojects.findAll { 
         it.name != 'bundle' && it.plugins.hasPlugin('java') 
     }
     dependsOn javaProjects.test
+    dependsOn javaProjects.compileJava
+    dependsOn javaProjects.processResources
     
     // Aggregate source sets
     sourceDirectories.setFrom(files(javaProjects.sourceSets.main.allSource.srcDirs))

--- a/engine/bundle/Dockerfile
+++ b/engine/bundle/Dockerfile
@@ -50,6 +50,7 @@ RUN apt-get update && \
 # Note: We set the home directory to /home/spt (not /opt/spt)
 RUN useradd --home-dir /home/spt --create-home --shell /bin/bash spt && \
     mkdir -p /opt/spt && \
+    chown spt:spt /opt/spt && \
     mkdir -p /home/spt/.spt
 
 # Copy the pre-built bundle artifacts

--- a/engine/core/spt-base/src/main/java/com/dell/spt/base/Main.java
+++ b/engine/core/spt-base/src/main/java/com/dell/spt/base/Main.java
@@ -97,7 +97,7 @@ public final class Main {
 		final var coreResources = new CoreResourcesToInstall();
 		final var appHomePath = coreResources.appHomePath();
 		final var initialStepId = "none-" + LogUtil.getDateTimeStamp();
-		
+
 		LogUtil.init(resolveLogPath(), initialStepId);
 		try {
 			// install the core resources

--- a/engine/core/spt-base/src/main/java/com/dell/spt/base/Main.java
+++ b/engine/core/spt-base/src/main/java/com/dell/spt/base/Main.java
@@ -72,6 +72,18 @@ import org.eclipse.jetty.servlet.ServletHolder;
 
 public final class Main {
 
+	static String resolveLogPath() {
+		final String logDirEnv = System.getenv("SPT_LOG_DIR");
+		final String logDirProp = System.getProperty("spt.log.dir");
+		if (logDirEnv != null && !logDirEnv.isEmpty()) {
+			return logDirEnv;
+		} else if (logDirProp != null && !logDirProp.isEmpty()) {
+			return logDirProp;
+		} else {
+			return System.getProperty("user.dir");
+		}
+	}
+
 	public static void main(final String... args) {
 
 		// Check for version flag early
@@ -85,7 +97,8 @@ public final class Main {
 		final var coreResources = new CoreResourcesToInstall();
 		final var appHomePath = coreResources.appHomePath();
 		final var initialStepId = "none-" + LogUtil.getDateTimeStamp();
-		LogUtil.init(appHomePath.toString(), initialStepId);
+		
+		LogUtil.init(resolveLogPath(), initialStepId);
 		try {
 			// install the core resources
 			coreResources.install(appHomePath);

--- a/engine/core/spt-base/src/test/java/com/dell/spt/base/MainTest.java
+++ b/engine/core/spt-base/src/test/java/com/dell/spt/base/MainTest.java
@@ -38,7 +38,7 @@ class MainTest {
 			assertEquals("/custom/log/path", Main.resolveLogPath(), "spt.log.dir property should override default log path");
 
 			System.clearProperty("spt.log.dir");
-			
+
 			// Testing env var is tricky, but we can verify it falls back to user.dir
 			// if neither the env var nor property are set (assuming env var is not set in test env)
 			if (System.getenv("SPT_LOG_DIR") == null || System.getenv("SPT_LOG_DIR").isEmpty()) {

--- a/engine/core/spt-base/src/test/java/com/dell/spt/base/MainTest.java
+++ b/engine/core/spt-base/src/test/java/com/dell/spt/base/MainTest.java
@@ -30,6 +30,30 @@ class MainTest {
 	}
 
 	@Test
+	void testResolveLogPath() {
+		// Test that SPT_LOG_DIR property overrides the default
+		final String originalProp = System.getProperty("spt.log.dir");
+		try {
+			System.setProperty("spt.log.dir", "/custom/log/path");
+			assertEquals("/custom/log/path", Main.resolveLogPath(), "spt.log.dir property should override default log path");
+
+			System.clearProperty("spt.log.dir");
+			
+			// Testing env var is tricky, but we can verify it falls back to user.dir
+			// if neither the env var nor property are set (assuming env var is not set in test env)
+			if (System.getenv("SPT_LOG_DIR") == null || System.getenv("SPT_LOG_DIR").isEmpty()) {
+				assertEquals(System.getProperty("user.dir"), Main.resolveLogPath(), "Should fallback to user.dir");
+			}
+		} finally {
+			if (originalProp != null) {
+				System.setProperty("spt.log.dir", originalProp);
+			} else {
+				System.clearProperty("spt.log.dir");
+			}
+		}
+	}
+
+	@Test
 	void applyLogLevelHonorsDebugSetting() throws Exception {
 		final var schema = Map.<String, Object> of("log", Map.of("level", String.class));
 		final var values = Map.<String, Object> of("log", Map.of("level", "debug"));


### PR DESCRIPTION
- Add DiscoverFleetStepIDs hitting /metrics/fleet/json (nil on 404)
- Poll both endpoints during WaitForCompletion; fleet IDs bypass
  the stale-ID intersection filter and take merge precedence
- Retry fetchStepIndex on empty response (engine flush race)
