### PR TITLE
wire load.service.threads from CLI to engine for VT carrier tuning

### DIFF
--- a/cli/cmd/envdefaults.go
+++ b/cli/cmd/envdefaults.go
@@ -99,6 +99,18 @@ func applyEnvDefaultsToRunFlags(cmd *cobra.Command) error {
 		}
 	}
 
+	// Engine VT parallelism: --service-threads or SPT_SERVICE_THREADS
+	if f := cmd.Flags().Lookup("service-threads"); f != nil && !cmd.Flags().Changed("service-threads") {
+		if v := strings.TrimSpace(os.Getenv(constants.EnvServiceThreads)); v != "" {
+			if _, err := strconv.Atoi(v); err != nil {
+				return fmt.Errorf("invalid %s value %q: %w", constants.EnvServiceThreads, v, err)
+			}
+			if err := cmd.Flags().Set("service-threads", v); err != nil {
+				return err
+			}
+		}
+	}
+
 	// RDMA string settings
 	_ = setIf("rdma-local-ip", constants.EnvRdmaLocalIP)
 	_ = setIf("rdma-device", constants.EnvRdmaDevice)

--- a/cli/cmd/envdefaults_test.go
+++ b/cli/cmd/envdefaults_test.go
@@ -27,6 +27,7 @@ func newRunLikeCmd() *cobra.Command {
 	c.Flags().String("rdma-device", "auto", "")
 	c.Flags().String("rdma-log-level", "WARN", "")
 	c.Flags().Int64("rdma-timeout-ms", 30000, "")
+	c.Flags().Int("service-threads", 0, "")
 	return c
 }
 
@@ -343,5 +344,53 @@ func TestApplyEnvDefaultsToVerifyFlags_RdmaFromEnv(t *testing.T) {
 
 	if v, _ := cmd.Flags().GetBool("use-rdma"); !v {
 		t.Fatal("use-rdma not applied from SPT_RDMA env for verify")
+	}
+}
+
+func TestApplyEnvDefaultsToRunFlags_ServiceThreadsFromEnv(t *testing.T) {
+	cmd := newRunLikeCmd()
+
+	os.Setenv(constants.EnvServiceThreads, "32")
+	t.Cleanup(func() { os.Unsetenv(constants.EnvServiceThreads) })
+
+	if err := applyEnvDefaultsToRunFlags(cmd); err != nil {
+		t.Fatalf("applyEnvDefaultsToRunFlags error: %v", err)
+	}
+
+	if v, _ := cmd.Flags().GetInt("service-threads"); v != 32 {
+		t.Errorf("service-threads not applied from env, got %d, want 32", v)
+	}
+}
+
+func TestApplyEnvDefaultsToRunFlags_ServiceThreadsFlagOverridesEnv(t *testing.T) {
+	cmd := newRunLikeCmd()
+
+	os.Setenv(constants.EnvServiceThreads, "32")
+	t.Cleanup(func() { os.Unsetenv(constants.EnvServiceThreads) })
+
+	// Simulate explicit flag usage
+	_ = cmd.Flags().Set("service-threads", "16")
+
+	if err := applyEnvDefaultsToRunFlags(cmd); err != nil {
+		t.Fatalf("applyEnvDefaultsToRunFlags error: %v", err)
+	}
+
+	if v, _ := cmd.Flags().GetInt("service-threads"); v != 16 {
+		t.Errorf("explicit flag should override env, got %d, want 16", v)
+	}
+}
+
+func TestApplyEnvDefaultsToRunFlags_ServiceThreadsInvalidEnv(t *testing.T) {
+	cmd := newRunLikeCmd()
+
+	os.Setenv(constants.EnvServiceThreads, "not-a-number")
+	t.Cleanup(func() { os.Unsetenv(constants.EnvServiceThreads) })
+
+	err := applyEnvDefaultsToRunFlags(cmd)
+	if err == nil {
+		t.Fatal("expected error for invalid SPT_SERVICE_THREADS value")
+	}
+	if !strings.Contains(err.Error(), constants.EnvServiceThreads) {
+		t.Errorf("error should mention env var name, got: %v", err)
 	}
 }

--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -849,6 +849,7 @@ func init() {
 	runCmd.Flags().Int("auto-terminate-seconds", 0, "Automatically terminate headless runs after N seconds (0 = unlimited)")
 	runCmd.Flags().Bool("keep-scenario", false, "Keep the scenario file after the test completes (default: delete on success)")
 	runCmd.Flags().Bool("force", false, "Automatically resolve port conflicts without user interaction")
+	runCmd.Flags().Int("service-threads", 0, "Engine virtual-thread carrier parallelism (0 = JVM default, env: SPT_SERVICE_THREADS)")
 	runCmd.Flags().String("api-port", "", "Spt API port (defaults to 9999, legacy: 43234)")
 	runCmd.Flags().Bool(flagSkipImagePull, false, "Use the locally cached Docker image without pulling the latest tag (env: SPT_SKIP_IMAGE_PULL)")
 
@@ -1017,6 +1018,9 @@ func buildScenarioParams(workloadType string, cmd *cobra.Command) (scenario.Para
 
 	keepScenario, _ := cmd.Flags().GetBool("keep-scenario")
 	params.KeepScenario = keepScenario
+
+	serviceThreads, _ := cmd.Flags().GetInt("service-threads")
+	params.ServiceThreads = serviceThreads
 
 	// S3 Tables parameters
 	if workloadType == WorkloadTypeTables {

--- a/cli/cmd/run_scenario_test.go
+++ b/cli/cmd/run_scenario_test.go
@@ -431,6 +431,7 @@ func TestBuildScenarioParams(t *testing.T) {
 			cmd.Flags().String("duration", "", "")
 			cmd.Flags().Bool("cleanup", false, "")
 			cmd.Flags().Bool("create-prefix", false, "")
+			cmd.Flags().Int("service-threads", 0, "")
 
 			// Set the flag values from the test case
 			for flagName, value := range tt.flags {
@@ -551,6 +552,45 @@ func TestBuildScenarioParamsEdgeCases(t *testing.T) {
 
 			// Validate the result
 			tt.validate(t, params)
+		})
+	}
+}
+
+func TestBuildScenarioParamsServiceThreads(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    int
+		expected int
+	}{
+		{"zero keeps default", 0, 0},
+		{"positive value passed through", 32, 32},
+		{"small value passed through", 2, 2},
+		{"large value passed through", 256, 256},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := &cobra.Command{}
+			cmd.Flags().String("endpoint", "", "")
+			cmd.Flags().String("access-key", "", "")
+			cmd.Flags().String("secret-key", "", "")
+			cmd.Flags().String("bucket", "", "")
+			cmd.Flags().Int("auth-version", 4, "")
+			cmd.Flags().Int("threads", 0, "")
+			cmd.Flags().String("object-size", "", "")
+			cmd.Flags().Int("object-count", 0, "")
+			cmd.Flags().String("duration", "", "")
+			cmd.Flags().Int("service-threads", 0, "")
+
+			_ = cmd.Flags().Set("service-threads", fmt.Sprintf("%d", tt.value))
+
+			params, err := buildScenarioParams("mock", cmd)
+			if err != nil {
+				t.Fatalf("buildScenarioParams() unexpected error: %v", err)
+			}
+			if params.ServiceThreads != tt.expected {
+				t.Errorf("ServiceThreads = %d, want %d", params.ServiceThreads, tt.expected)
+			}
 		})
 	}
 }

--- a/cli/docs/SPT_SYNTAX.md
+++ b/cli/docs/SPT_SYNTAX.md
@@ -38,6 +38,7 @@ You can use these variables to avoid repeating sensitive or commonly used parame
 - **Hosts:** `HOSTS` (comma-separated list of `[user@]host`)
 - **Workload:** `THREADS` (parallel client threads)
 - **Docker:** `SPT_SKIP_IMAGE_PULL` (skip pulling the engine image)
+- **Engine tuning:** `SPT_SERVICE_THREADS` (virtual-thread carrier parallelism)
 - **RDMA:** `SPT_RDMA_ENABLED`, `RDMA_LOCAL_IP`, `RDMA_DEVICE`, `RDMA_LOG_LEVEL`, `RDMA_THRESHOLD_BYTES`, `RDMA_TIMEOUT_MS`, `RDMA_FALLBACK_ENABLED`
 
 Variable expansion: use `$VAR` or `${VAR}`. Command substitutions like `$(pwd)` are not supported; use `$PWD` instead.
@@ -104,6 +105,7 @@ Required for S3 workloads, optional/ignored for `mock`.
 | `--api-port` | | `9999` | SPT engine API port |
 | `--skip-image-pull` | | `false` | Use locally cached Docker image without pulling |
 | `--output-dir` | `-O` | `""` | Local directory to save detailed SPT report files |
+| `--service-threads` | | `0` | Engine virtual-thread carrier parallelism (0 = JVM default `max(2, cpus/4)`) |
 
 #### 4. Results Retrieval Options
 

--- a/cli/internal/constants/envvars.go
+++ b/cli/internal/constants/envvars.go
@@ -2,16 +2,16 @@ package constants
 
 // Environment variable keys used by spt
 const (
-	EnvSptImage      = "SPT_IMAGE"
-	EnvHosts         = "HOSTS"
-	EnvS3Endpoint    = "S3_ENDPOINT"
-	EnvS3AccessKey   = "S3_ACCESS_KEY" // #nosec G101 -- env var names only
-	EnvS3SecretKey   = "S3_SECRET_KEY" // #nosec G101 -- env var names only
-	EnvS3Bucket      = "S3_BUCKET"
-	EnvS3AuthVersion = "S3_AUTH_VERSION"
-	EnvSkipImagePull = "SPT_SKIP_IMAGE_PULL"
-	EnvRdmaEnabled      = "SPT_RDMA"
-	EnvServiceThreads   = "SPT_SERVICE_THREADS"
+	EnvSptImage       = "SPT_IMAGE"
+	EnvHosts          = "HOSTS"
+	EnvS3Endpoint     = "S3_ENDPOINT"
+	EnvS3AccessKey    = "S3_ACCESS_KEY" // #nosec G101 -- env var names only
+	EnvS3SecretKey    = "S3_SECRET_KEY" // #nosec G101 -- env var names only
+	EnvS3Bucket       = "S3_BUCKET"
+	EnvS3AuthVersion  = "S3_AUTH_VERSION"
+	EnvSkipImagePull  = "SPT_SKIP_IMAGE_PULL"
+	EnvRdmaEnabled    = "SPT_RDMA"
+	EnvServiceThreads = "SPT_SERVICE_THREADS"
 
 	// RDMA configuration environment variables
 	EnvRdmaLocalIP   = "RDMA_LOCAL_IP"

--- a/cli/internal/constants/envvars.go
+++ b/cli/internal/constants/envvars.go
@@ -10,7 +10,8 @@ const (
 	EnvS3Bucket      = "S3_BUCKET"
 	EnvS3AuthVersion = "S3_AUTH_VERSION"
 	EnvSkipImagePull = "SPT_SKIP_IMAGE_PULL"
-	EnvRdmaEnabled   = "SPT_RDMA"
+	EnvRdmaEnabled      = "SPT_RDMA"
+	EnvServiceThreads   = "SPT_SERVICE_THREADS"
 
 	// RDMA configuration environment variables
 	EnvRdmaLocalIP   = "RDMA_LOCAL_IP"

--- a/cli/internal/scenario/defaults.go
+++ b/cli/internal/scenario/defaults.go
@@ -19,6 +19,7 @@ const (
 type DefaultsConfig struct {
 	Storage StorageConfig `yaml:"storage"`
 	Output  OutputConfig  `yaml:"output"`
+	Load    *LoadConfig   `yaml:"load,omitempty"` // pointer so omitted when nil
 }
 
 // StorageConfig represents storage configuration
@@ -88,6 +89,16 @@ type MetricsConfig struct {
 // AverageConfig represents average metrics configuration
 type AverageConfig struct {
 	Period string `yaml:"period"`
+}
+
+// LoadConfig represents engine load configuration
+type LoadConfig struct {
+	Service ServiceConfig `yaml:"service"`
+}
+
+// ServiceConfig represents the service thread pool configuration
+type ServiceConfig struct {
+	Threads int `yaml:"threads"`
 }
 
 // GenerateDefaults creates a defaults.yaml configuration from scenario parameters
@@ -311,6 +322,13 @@ func GenerateDefaults(params Params) ([]byte, error) {
 
 	default:
 		return nil, fmt.Errorf("unsupported workload type: %s", params.WorkloadType)
+	}
+
+	// Engine tuning: VT carrier parallelism
+	if params.ServiceThreads > 0 {
+		config.Load = &LoadConfig{
+			Service: ServiceConfig{Threads: params.ServiceThreads},
+		}
 	}
 
 	// Marshal to YAML

--- a/cli/internal/scenario/defaults_test.go
+++ b/cli/internal/scenario/defaults_test.go
@@ -508,6 +508,116 @@ func TestGenerateDefaults(t *testing.T) {
 				}
 			},
 		},
+		{
+			name: "S3 write with ServiceThreads sets load.service.threads",
+			params: Params{
+				WorkloadType:   "write",
+				Endpoint:       "http://minio:9000",
+				AccessKey:      "testkey",
+				SecretKey:      "testsecret",
+				Bucket:         "testbucket",
+				Threads:        4,
+				ServiceThreads: 32,
+			},
+			wantErr: false,
+			checkOutput: func(t *testing.T, data []byte) {
+				t.Helper()
+				var config DefaultsConfig
+				if err := yaml.Unmarshal(data, &config); err != nil {
+					t.Fatalf("Failed to unmarshal YAML: %v", err)
+				}
+				if config.Load == nil {
+					t.Fatal("Expected load section to be present when ServiceThreads > 0")
+				}
+				if config.Load.Service.Threads != 32 {
+					t.Errorf("Expected load.service.threads 32, got %d", config.Load.Service.Threads)
+				}
+				// Verify the raw YAML path matches engine schema
+				if !strings.Contains(string(data), "load:") {
+					t.Error("Expected raw YAML to contain 'load:' top-level key")
+				}
+				if !strings.Contains(string(data), "service:") {
+					t.Error("Expected raw YAML to contain 'service:' key under load")
+				}
+				if !strings.Contains(string(data), "threads: 32") {
+					t.Error("Expected raw YAML to contain 'threads: 32'")
+				}
+			},
+		},
+		{
+			name: "ServiceThreads zero omits load section",
+			params: Params{
+				WorkloadType:   "write",
+				Endpoint:       "http://minio:9000",
+				AccessKey:      "testkey",
+				SecretKey:      "testsecret",
+				Bucket:         "testbucket",
+				Threads:        4,
+				ServiceThreads: 0,
+			},
+			wantErr: false,
+			checkOutput: func(t *testing.T, data []byte) {
+				t.Helper()
+				var config DefaultsConfig
+				if err := yaml.Unmarshal(data, &config); err != nil {
+					t.Fatalf("Failed to unmarshal YAML: %v", err)
+				}
+				if config.Load != nil {
+					t.Error("Expected no load section when ServiceThreads is 0")
+				}
+				if strings.Contains(string(data), "load:") {
+					t.Error("Raw YAML should not contain 'load:' when ServiceThreads is 0")
+				}
+			},
+		},
+		{
+			name: "ServiceThreads negative omits load section",
+			params: Params{
+				WorkloadType:   "write",
+				Endpoint:       "http://minio:9000",
+				AccessKey:      "testkey",
+				SecretKey:      "testsecret",
+				Bucket:         "testbucket",
+				Threads:        4,
+				ServiceThreads: -1,
+			},
+			wantErr: false,
+			checkOutput: func(t *testing.T, data []byte) {
+				t.Helper()
+				var config DefaultsConfig
+				if err := yaml.Unmarshal(data, &config); err != nil {
+					t.Fatalf("Failed to unmarshal YAML: %v", err)
+				}
+				if config.Load != nil {
+					t.Error("Expected no load section when ServiceThreads is negative")
+				}
+			},
+		},
+		{
+			name: "Mock workload with ServiceThreads still sets load section",
+			params: Params{
+				WorkloadType:   "mock",
+				Threads:        8,
+				ServiceThreads: 16,
+			},
+			wantErr: false,
+			checkOutput: func(t *testing.T, data []byte) {
+				t.Helper()
+				var config DefaultsConfig
+				if err := yaml.Unmarshal(data, &config); err != nil {
+					t.Fatalf("Failed to unmarshal YAML: %v", err)
+				}
+				if config.Storage.Driver.Type != "dummy-mock" {
+					t.Errorf("Expected dummy-mock driver, got %s", config.Storage.Driver.Type)
+				}
+				if config.Load == nil {
+					t.Fatal("Expected load section for mock workload when ServiceThreads > 0")
+				}
+				if config.Load.Service.Threads != 16 {
+					t.Errorf("Expected load.service.threads 16, got %d", config.Load.Service.Threads)
+				}
+			},
+		},
 	}
 
 	// S3 Tables cases

--- a/cli/internal/scenario/types.go
+++ b/cli/internal/scenario/types.go
@@ -16,6 +16,9 @@ type Params struct {
 	AuthVersion  int
 	Cleanup      bool // Automatically delete created objects after test
 	KeepScenario bool // Keep the scenario file after test completes
+	// Engine tuning
+	ServiceThreads int // VT carrier thread parallelism (0 = JVM default)
+
 	// Multi-endpoint controls
 	SliceEndpoints bool // Partition endpoint list across nodes in distributed runs
 

--- a/engine/core/spt-base/src/main/java/com/dell/spt/base/Main.java
+++ b/engine/core/spt-base/src/main/java/com/dell/spt/base/Main.java
@@ -120,6 +120,9 @@ public final class Main {
 					LogUtil.exception(Level.ERROR, e, "Failed to load the defaults");
 					throw e;
 				}
+
+				applyVtParallelism(configWithArgs);
+
 				// init the metrics manager
 				final MetricsManager metricsMgr = new MetricsManagerImpl(ServiceTaskExecutor.VT_EXECUTOR);
 				// go on
@@ -133,6 +136,18 @@ public final class Main {
 			Loggers.MSG.debug("Interrupted", e);
 		} catch (final Exception e) {
 			LogUtil.trace(Loggers.ERR, Level.FATAL, e, "Unexpected failure");
+		}
+	}
+
+	static void applyVtParallelism(final Config config) {
+		try {
+			final int vtParallelism = config.intVal("load-service-threads");
+			if (vtParallelism > 0) {
+				System.setProperty("jdk.virtualThreadScheduler.parallelism", String.valueOf(vtParallelism));
+				Loggers.MSG.info("Set virtual thread scheduler parallelism to: {}", vtParallelism);
+			}
+		} catch (Exception e) {
+			Loggers.ERR.warn("Failed to set virtual thread parallelism from config", e);
 		}
 	}
 

--- a/engine/core/spt-base/src/main/java/com/dell/spt/base/concurrent/VirtualThreadExecutor.java
+++ b/engine/core/spt-base/src/main/java/com/dell/spt/base/concurrent/VirtualThreadExecutor.java
@@ -8,9 +8,9 @@ import java.util.concurrent.TimeUnit;
  * Runs Task instances on Virtual Threads.
  * <p>
  * Tunes the VT carrier ForkJoinPool parallelism to avoid excessive work-stealing
- * overhead. SPT runs only a handful of VTs (LoadGenerator, MetricsManager, etc.)
- * that spend most of their time waiting on queues/conditions,
- * so the default carrier count of availableProcessors() is wasteful on large machines.
+ * overhead. SPT runs only a handful of active VTs (LoadGenerator,
+ * OperationDispatchTask, MetricsManager, etc.) so the JVM default of
+ * availableProcessors() carrier threads is wasteful on large machines.
  * Override with {@code -Djdk.virtualThreadScheduler.parallelism=N} if needed.
  */
 public class VirtualThreadExecutor implements AutoCloseable {
@@ -19,7 +19,7 @@ public class VirtualThreadExecutor implements AutoCloseable {
 
 	static {
 		if (System.getProperty(VT_PARALLELISM_PROP) == null) {
-			final int parallelism = Math.max(2, Runtime.getRuntime().availableProcessors() / 4);
+			final int parallelism = Math.min(4, Runtime.getRuntime().availableProcessors());
 			System.setProperty(VT_PARALLELISM_PROP, String.valueOf(parallelism));
 		}
 	}

--- a/engine/core/spt-base/src/main/java/com/dell/spt/base/concurrent/VirtualThreadExecutor.java
+++ b/engine/core/spt-base/src/main/java/com/dell/spt/base/concurrent/VirtualThreadExecutor.java
@@ -11,7 +11,8 @@ import java.util.concurrent.TimeUnit;
  * overhead. SPT runs only a handful of active VTs (LoadGenerator,
  * OperationDispatchTask, MetricsManager, etc.) so the JVM default of
  * availableProcessors() carrier threads is wasteful on large machines.
- * Override with {@code -Djdk.virtualThreadScheduler.parallelism=N} if needed.
+ * Override with {@code -Djdk.virtualThreadScheduler.parallelism=N} or
+ * set {@code load.service.threads} in the SPT config.
  */
 public class VirtualThreadExecutor implements AutoCloseable {
 
@@ -19,7 +20,7 @@ public class VirtualThreadExecutor implements AutoCloseable {
 
 	static {
 		if (System.getProperty(VT_PARALLELISM_PROP) == null) {
-			final int parallelism = Math.min(4, Runtime.getRuntime().availableProcessors());
+			final int parallelism = Math.max(2, Runtime.getRuntime().availableProcessors() / 4);
 			System.setProperty(VT_PARALLELISM_PROP, String.valueOf(parallelism));
 		}
 	}

--- a/engine/core/spt-base/src/main/java/com/dell/spt/base/load/step/LoadStepBase.java
+++ b/engine/core/spt-base/src/main/java/com/dell/spt/base/load/step/LoadStepBase.java
@@ -115,14 +115,6 @@ public abstract class LoadStepBase extends DaemonBase implements LoadStep, Runna
 
 			doStartWrapped();
 
-			final var svcThreadCount = config.intVal("load-service-threads");
-			if (svcThreadCount > 0) {
-				Loggers.MSG.warn(
-								"'load.service.threads' ({}) is no longer used — the legacy thread pool has been replaced "
-												+ "by Virtual Threads. This parameter will be ignored.",
-								svcThreadCount);
-			}
-
 			final long t;
 			final var loadStepLimitTimeRaw = config.val("load-step-limit-time");
 			if (loadStepLimitTimeRaw instanceof String) {

--- a/engine/core/spt-base/src/test/java/com/dell/spt/base/MainTest.java
+++ b/engine/core/spt-base/src/test/java/com/dell/spt/base/MainTest.java
@@ -73,6 +73,49 @@ class MainTest {
 		assertEquals(false, Loggers.MSG.isEnabled(Level.DEBUG));
 	}
 
+	@Test
+	void testApplyVtParallelismSetsSystemProperty() throws Exception {
+		final var schema = Map.<String, Object> of("load", Map.of("service", Map.of("threads", Integer.class)));
+		final var values = Map.<String, Object> of("load", Map.of("service", Map.of("threads", 16)));
+		final var config = new BasicConfig("-", schema, values);
+
+		final String originalProp = System.getProperty("jdk.virtualThreadScheduler.parallelism");
+		try {
+			Main.applyVtParallelism(config);
+			assertEquals("16", System.getProperty("jdk.virtualThreadScheduler.parallelism"));
+		} finally {
+			if (originalProp != null) {
+				System.setProperty("jdk.virtualThreadScheduler.parallelism", originalProp);
+			} else {
+				System.clearProperty("jdk.virtualThreadScheduler.parallelism");
+			}
+		}
+	}
+
+	@Test
+	void testApplyVtParallelismIgnoresZeroOrNegative() throws Exception {
+		final var schema = Map.<String, Object> of("load", Map.of("service", Map.of("threads", Integer.class)));
+		final var values = Map.<String, Object> of("load", Map.of("service", Map.of("threads", 0)));
+		final var config = new BasicConfig("-", schema, values);
+
+		final String originalProp = System.getProperty("jdk.virtualThreadScheduler.parallelism");
+		try {
+			System.clearProperty("jdk.virtualThreadScheduler.parallelism");
+			Main.applyVtParallelism(config);
+			assertEquals(null, System.getProperty("jdk.virtualThreadScheduler.parallelism"));
+
+			final var configNeg = new BasicConfig("-", schema, Map.of("load", Map.of("service", Map.of("threads", -1))));
+			Main.applyVtParallelism(configNeg);
+			assertEquals(null, System.getProperty("jdk.virtualThreadScheduler.parallelism"));
+		} finally {
+			if (originalProp != null) {
+				System.setProperty("jdk.virtualThreadScheduler.parallelism", originalProp);
+			} else {
+				System.clearProperty("jdk.virtualThreadScheduler.parallelism");
+			}
+		}
+	}
+
 	private static void invokeApplyLogLevel(final com.github.akurilov.confuse.Config config)
 					throws Exception {
 		final Method method = Main.class.getDeclaredMethod("applyLogLevel", com.github.akurilov.confuse.Config.class);

--- a/engine/core/spt-base/src/test/java/com/dell/spt/base/concurrent/VirtualThreadExecutorTest.java
+++ b/engine/core/spt-base/src/test/java/com/dell/spt/base/concurrent/VirtualThreadExecutorTest.java
@@ -38,12 +38,12 @@ class VirtualThreadExecutorTest {
 	@Test
 	void setsCarrierParallelismIfNotConfigured() {
 		// The static initializer sets jdk.virtualThreadScheduler.parallelism
-		// to min(4, availableProcessors) when no explicit value is provided.
+		// to max(2, availableProcessors/4) when no explicit value is provided.
 		final var prop = System.getProperty("jdk.virtualThreadScheduler.parallelism");
 		assertNotNull(prop, "VT parallelism system property should be set");
 		final int value = Integer.parseInt(prop);
-		final int expected = Math.min(4, Runtime.getRuntime().availableProcessors());
-		assertEquals(expected, value, "Parallelism should be min(4, processors)");
+		final int expected = Math.max(2, Runtime.getRuntime().availableProcessors() / 4);
+		assertEquals(expected, value, "Parallelism should be max(2, processors/4)");
 	}
 
 	@Test

--- a/engine/core/spt-base/src/test/java/com/dell/spt/base/concurrent/VirtualThreadExecutorTest.java
+++ b/engine/core/spt-base/src/test/java/com/dell/spt/base/concurrent/VirtualThreadExecutorTest.java
@@ -38,12 +38,12 @@ class VirtualThreadExecutorTest {
 	@Test
 	void setsCarrierParallelismIfNotConfigured() {
 		// The static initializer sets jdk.virtualThreadScheduler.parallelism
-		// to max(2, availableProcessors/4) when no explicit value is provided.
+		// to min(4, availableProcessors) when no explicit value is provided.
 		final var prop = System.getProperty("jdk.virtualThreadScheduler.parallelism");
 		assertNotNull(prop, "VT parallelism system property should be set");
 		final int value = Integer.parseInt(prop);
-		final int expected = Math.max(2, Runtime.getRuntime().availableProcessors() / 4);
-		assertEquals(expected, value, "Parallelism should be max(2, processors/4)");
+		final int expected = Math.min(4, Runtime.getRuntime().availableProcessors());
+		assertEquals(expected, value, "Parallelism should be min(4, processors)");
 	}
 
 	@Test


### PR DESCRIPTION
wire load.service.threads from CLI to engine for VT carrier tuning

Add --service-threads flag (env: SPT_SERVICE_THREADS) so users can control virtual-thread carrier parallelism from the CLI. The value flows through defaults.yaml as load.service.threads and is applied by Main.applyVtParallelism() before any VTs are created. Default 0 preserves the JVM's max(2, cpus/4) formula.
