### PR TITLE
fix SIGBUS crash when JDK/JAR runs from NFS mount

### DIFF
--- a/engine/bundle/build.gradle
+++ b/engine/bundle/build.gradle
@@ -133,6 +133,12 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 # Spt version
 VERSION="''' + sptReleaseVersion + '''"
 
+# Ensure HOME is set (some CI/QA environments leave it unset, which breaks
+# the extensions directory path and can affect JVM class-data-sharing)
+if [ -z "$HOME" ]; then
+    export HOME="$(eval echo ~$(whoami))" 2>/dev/null || export HOME="/tmp"
+fi
+
 # Set up extension directory in user home
 EXT_DIR="$HOME/.spt/$VERSION/ext"
 echo "Setting up extensions in: $EXT_DIR"
@@ -152,8 +158,17 @@ if [ -d "$SCRIPT_DIR/ext" ]; then
     done
 fi
 
+# JVM options
+# -Xshare:off disables Class Data Sharing to avoid SIGBUS crashes when the
+#   JDK or JAR resides on NFS (the JVM memory-maps the CDS archive and a
+#   stale NFS handle turns the page fault into SIGBUS)
+# -XX:UseAVX=2 avoids AVX-512 EVEX encoded instructions which trigger a
+#   known glibc crash (__strncpy_evex SIGBUS) on certain kernel/microcode
+#   combinations
+SPT_JAVA_OPTS="${SPT_JAVA_OPTS:--Xshare:off -XX:UseAVX=2}"
+
 # Run Spt with all arguments passed to this script
-java -jar "$SCRIPT_DIR/spt.jar" "$@"
+java $SPT_JAVA_OPTS -jar "$SCRIPT_DIR/spt.jar" "$@"
 '''
 		scriptFile.setExecutable(true)
 		


### PR DESCRIPTION
QA environment crashes immediately at JVM startup with `SIGBUS (0x7)` in `libc __strncpy_evex` when the JDK and spt.jar reside on an NFS mount.

Updates the generated `run.sh` to add default JVM flags via `SPT_JAVA_OPTS`:
- `-Xshare:off` -- disables CDS to prevent SIGBUS from mmap'd NFS-backed archive
- `-XX:UseAVX=2` -- avoids AVX-512 EVEX glibc code paths with known crash bugs

Also adds a `$HOME` fallback since the QA environment had it unset, causing the extensions directory to resolve to `/.spt/` instead of `~/.spt/`.

Operators can override with `SPT_JAVA_OPTS="" ./run.sh ...` if the defaults aren't needed.