### PR TITLE
Remove /home/mike/.spt directory dependency; fix latency epoch-timestamp leak

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ Thumbs.db
 
 # Log and coverage artifacts
 *.log
+/log/
 coverage.*
 coverage.html
 coverage.out
@@ -127,6 +128,7 @@ engine/.mvn/wrapper/maven-wrapper.jar
 engine/tmp/
 *.tmp
 engine/tools/log/
+engine/log/
 
 # Miscellaneous engine logs
 engine/logs/

--- a/engine/README.md
+++ b/engine/README.md
@@ -89,7 +89,7 @@ run.bat --version     # Windows
   --load-op-limit-count=1000
 ```
 
-Note: The run scripts automatically handle setting up the extensions in the correct location (`~/.spt/<version>/ext/`).
+Note: Extensions are loaded from the `ext/` directory next to `spt.jar`.
 
 ### Common Command-Line Options
 
@@ -114,9 +114,8 @@ After building, the distribution contains:
 - **run.sh/run.bat** - Platform-specific launcher scripts that properly configure the classpath
 
 The launcher scripts handle:
-- Setting up the correct extension directory structure
-- Linking/copying extensions to `~/.spt/<version>/ext/`
-- Launching SPT with the proper classpath configuration
+- Setting up the correct classpath configuration
+- Launching SPT with extensions loaded from the adjacent `ext/` directory
 
 ### IDE Integration
 

--- a/engine/bundle/Dockerfile
+++ b/engine/bundle/Dockerfile
@@ -47,11 +47,9 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # Create spt user and directories
-# Note: We set the home directory to /home/spt (not /opt/spt)
 RUN useradd --home-dir /home/spt --create-home --shell /bin/bash spt && \
     mkdir -p /opt/spt && \
-    chown spt:spt /opt/spt && \
-    mkdir -p /home/spt/.spt
+    chown spt:spt /opt/spt
 
 # Copy the pre-built bundle artifacts
 # These are created by running './gradlew :bundle:build'
@@ -62,15 +60,6 @@ COPY --chown=spt:spt docker/entrypoint.sh /opt/spt/
 # Copy example scenarios from the distribution
 # These provide ready-to-use test scenarios for common use cases
 COPY --chown=spt:spt build/dist/scenarios /opt/spt/scenarios
-
-# Set up the extensions directory structure
-# Spt expects extensions in ~/.spt/<version>/ext/
-RUN mkdir -p /home/spt/.spt/${SPT_RELEASE_VERSION}/ext && \
-    cd /home/spt/.spt/${SPT_RELEASE_VERSION}/ext && \
-    for ext in /opt/spt/ext/*.jar; do \
-        ln -s "$ext" "$(basename "$ext")"; \
-    done && \
-    chown -R spt:spt /home/spt/.spt
 
 # Make entrypoint executable
 RUN chmod +x /opt/spt/entrypoint.sh

--- a/engine/bundle/build.gradle
+++ b/engine/bundle/build.gradle
@@ -130,28 +130,6 @@ task createRunScript {
 # Get the directory where this script is located
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-# Spt version
-VERSION="''' + sptReleaseVersion + '''"
-
-# Set up extension directory in user home
-EXT_DIR="$HOME/.spt/$VERSION/ext"
-echo "Setting up extensions in: $EXT_DIR"
-mkdir -p "$EXT_DIR"
-
-# Link or copy extensions from local ext/ to expected location
-if [ -d "$SCRIPT_DIR/ext" ]; then
-    for ext in "$SCRIPT_DIR/ext"/*.jar; do
-        if [ -f "$ext" ]; then
-            ext_name=$(basename "$ext")
-            # Create symlink if it doesn't exist
-            if [ ! -e "$EXT_DIR/$ext_name" ]; then
-                echo "Linking extension: $ext_name"
-                ln -sf "$ext" "$EXT_DIR/$ext_name" 2>/dev/null || cp "$ext" "$EXT_DIR/$ext_name"
-            fi
-        fi
-    done
-fi
-
 # Run Spt with all arguments passed to this script
 java -jar "$SCRIPT_DIR/spt.jar" "$@"
 '''
@@ -164,23 +142,6 @@ rem Spt run script for Windows
 
 rem Get the directory where this script is located
 set SCRIPT_DIR=%~dp0
-
-rem Detect Spt version from JAR (default to ${sptReleaseVersion})
-set VERSION=${sptReleaseVersion}
-for /f "tokens=3" %%i in ('java -jar "%SCRIPT_DIR%spt.jar" --version 2^>^&1 ^| findstr "spt v"') do set VERSION=%%i
-
-rem Set up extension directory in user home
-set EXT_DIR=%USERPROFILE%\\.spt\\%VERSION%\\ext
-if not exist "%EXT_DIR%" mkdir "%EXT_DIR%"
-
-rem Copy extensions from local ext\\ to expected location
-if exist "%SCRIPT_DIR%ext" (
-    for %%f in ("%SCRIPT_DIR%ext\\*.jar") do (
-        if not exist "%EXT_DIR%\\%%~nxf" (
-            copy "%%f" "%EXT_DIR%\\%%~nxf" >nul
-        )
-    )
-)
 
 rem Run Spt with all arguments passed to this script
 java -jar "%SCRIPT_DIR%spt.jar" %*

--- a/engine/bundle/docker/entrypoint.sh
+++ b/engine/bundle/docker/entrypoint.sh
@@ -33,14 +33,6 @@ if [ -n "$SPT_JAVA_OPTS" ]; then
     export JAVA_OPTS="$JAVA_OPTS $SPT_JAVA_OPTS"
 fi
 
-# Ensure the spt user owns the home directory
-# This helps with scenarios where volumes are mounted
-if [ -w "/home/spt" ]; then
-    # Only try to change ownership if we have write permission
-    # This will fail if running as non-root, which is fine
-    chown -R spt:spt /home/spt/.spt 2>/dev/null || true
-fi
-
 # If no arguments provided, show help
 if [ $# -eq 0 ]; then
     set -- --help

--- a/engine/core/spt-base/ci/docker/Dockerfile
+++ b/engine/core/spt-base/ci/docker/Dockerfile
@@ -39,8 +39,6 @@ ADD ci/docker/entrypoint.sh /opt/spt/entrypoint.sh
 
 
 RUN ln -s /opt/spt/spt-*.jar /opt/spt/spt.jar; \
-    mkdir ${HOME}/.spt; \
-    chmod -R ugo+rwx ${HOME}/.spt; \
     chmod -R +x /opt/spt/bin; \
     chmod +x /opt/spt/entrypoint.sh;
 

--- a/engine/core/spt-base/ci/docker/Dockerfile.scripting-groovy
+++ b/engine/core/spt-base/ci/docker/Dockerfile.scripting-groovy
@@ -2,5 +2,5 @@ ARG SPT_VERSION
 
 FROM ghcr.io/dell/storage-performance-tool:${SPT_VERSION}
 
-ADD ["http://central.maven.org/maven2/org/codehaus/groovy/groovy/2.4.15/groovy-2.4.15.jar", "/root/.spt/${SPT_VERSION}/ext/groovy.jar"]
-ADD ["http://central.maven.org/maven2/org/codehaus/groovy/groovy-jsr223/2.4.15/groovy-jsr223-2.4.15.jar", "/root/.spt/${SPT_VERSION}/ext/groovy-jsr223.jar"]
+ADD ["http://central.maven.org/maven2/org/codehaus/groovy/groovy/2.4.15/groovy-2.4.15.jar", "/opt/spt/ext/groovy.jar"]
+ADD ["http://central.maven.org/maven2/org/codehaus/groovy/groovy-jsr223/2.4.15/groovy-jsr223-2.4.15.jar", "/opt/spt/ext/groovy-jsr223.jar"]

--- a/engine/core/spt-base/ci/docker/Dockerfile.scripting-jython
+++ b/engine/core/spt-base/ci/docker/Dockerfile.scripting-jython
@@ -2,4 +2,4 @@ ARG SPT_VERSION
 
 FROM ghcr.io/dell/storage-performance-tool:${SPT_VERSION}
 
-ADD ["http://central.maven.org/maven2/org/python/jython-standalone/2.7.1/jython-standalone-2.7.1.jar", "/root/.spt/${SPT_VERSION}/ext/jython-standalone.jar"]
+ADD ["http://central.maven.org/maven2/org/python/jython-standalone/2.7.1/jython-standalone-2.7.1.jar", "/opt/spt/ext/jython-standalone.jar"]

--- a/engine/core/spt-base/doc/deployment/README.md
+++ b/engine/core/spt-base/doc/deployment/README.md
@@ -144,12 +144,12 @@ docker run \
 #### Logs Sharing
 
 The example below mounts the host's directory `./log` to the container's
-`/root/.spt/<VERSION>/log` (where spt holds its log files).
+`/opt/spt/log` (where spt holds its log files).
 
 ```bash
 docker run \
     --network host \
-    --mount type=bind,source="$(pwd)"/log,target=/root/.spt/<VERSION>/log
+    --mount type=bind,source="$(pwd)"/log,target=/opt/spt/log
     ghcr.io/dell/storage-performance-tool \
     [<SPT CLI ARGS>]
 ```

--- a/engine/core/spt-base/doc/design/installer/README.md
+++ b/engine/core/spt-base/doc/design/installer/README.md
@@ -8,7 +8,7 @@
 
 # Introduction
 
-To use any Spt extension it should be placed to the `<USER_HOME_DIR>/.spt/<VERSION>/ext` directory.
+To use any Spt extension it should be placed in the `ext/` directory next to the `spt.jar` file.
 Any file under this directory having the filename suffix `.jar` either `.zip` is loaded by the Spt's classloader
 and its content becomes available in the runtime. This allows to use not only Spt's extensions but also the 
 3rd party scenario engine implementations or credential providers.
@@ -22,7 +22,7 @@ required/supplementary files are already installed and their content is the same
 ### Stages
 
 0. Installer loads the default configuration from the resources to determine the version. The version is used to
-determine the Spt home path which is `<USER_HOME_DIR>/.spt/<VERSION>`.
+determine the Spt home path (a temporary directory used for extracted resources).
 
 1. Installer copies the required and supplementary files into the Spt home. These files are default configuration,
 custom content files, scenarios and extensions.
@@ -34,10 +34,10 @@ has the same MD5 checksum.
 
 3. Initial default configuration is being loaded.
 
-4. Installer copies the resolved Spt extensions to the `<USER_HOME_DIR>/.spt/<VERSION>/ext` directory.
+4. Installer copies the resolved Spt extensions to the `ext/` directory next to the JAR.
 
 5. Then each extension installs itself. The Spt home directory is passed as an argument for the extension installer
 hook. The extension inherits the basic installer functionality to copy the specific files for the given extension.
 
 6. Each extension provides its own defaults configuration (if any) from the installed file
-(usually `<USER_HOME_DIR>/.spt/<VERSION>/config/defaults****.yaml`).
+(usually `config/defaults****.yaml` in the Spt home directory).

--- a/engine/core/spt-base/doc/design/modes/copy_mode/README.md
+++ b/engine/core/spt-base/doc/design/modes/copy_mode/README.md
@@ -68,4 +68,4 @@ In order to perform a copy load step it's necessary:
 * Specify `--item-output-path` (the target container/bucket/directory) to a proper value.
 
 For details, see the example scenario located at:
-`<USER_HOME_DIR>/.spt/<VERSION>/example/scenario/js/types/additional/copy_load_using_env_vars.js`.
+`example/scenario/js/types/additional/copy_load_using_env_vars.js` in the Spt home directory.

--- a/engine/core/spt-base/doc/usage/input/scenarios/README.md
+++ b/engine/core/spt-base/doc/usage/input/scenarios/README.md
@@ -59,7 +59,7 @@ Generally, to define a scenario a user should:
 Javascript scenarios are supported out-of-the-box (the corresponding
 engine is included in the JVM by default). So the examples below are in
 Javascript. It's necessary to put the custom JSR-223 implementation jar
-to the `<USER_HOME_DIR>/.spt/<VERSION>/ext` directory to use other scripting languages for
+in the `ext/` directory next to `spt.jar` to use other scripting languages for
 scenarios.
 
 ### 2.1. Load Step
@@ -78,7 +78,7 @@ steps.
 
     Configure the load step. Merge the specified configuration parameters dictionary with already existing step's
     configuration. An argument should be a dictionary with a structure equivalent to the configuration structure (see
-    `<USER_HOME_DIR>/.spt/<VERSION>/config/defaults.yaml` file for the reference). Returns the copied instance with
+    the `config/defaults.yaml` file in the Spt home directory for the reference). Returns the copied instance with
     the new configuration.
 
 2. ```append(config)```
@@ -517,7 +517,7 @@ should be set externally.
 The ```config``` method appends the configuration structure element to
 the step. An argument should be a dictionary/map with a structure
 equivalent to the configuration structure (see
-`<USER_HOME_DIR>/.spt/<VERSION>/config/defaults.yaml` file for the
+the `config/defaults.yaml` file in the Spt home directory for the
 reference). Subsequent calls on the same step appends the configuration
 structure to the list. **Returns** the new step instance of the same
 type so the call may be included into the call chain.

--- a/engine/core/spt-base/src/main/java/com/dell/spt/base/Constants.java
+++ b/engine/core/spt-base/src/main/java/com/dell/spt/base/Constants.java
@@ -7,7 +7,6 @@ import java.util.Locale;
 public interface Constants {
 
 	String APP_NAME = "spt";
-	String USER_HOME = System.getProperty("user.home");
 	String DIR_CONFIG = "config";
 	String DIR_EXAMPLE = "example";
 	String DIR_EXT = "ext";

--- a/engine/core/spt-base/src/main/java/com/dell/spt/base/Main.java
+++ b/engine/core/spt-base/src/main/java/com/dell/spt/base/Main.java
@@ -4,7 +4,6 @@ import static com.dell.spt.base.Constants.APP_NAME;
 import static com.dell.spt.base.Constants.DIR_EXT;
 import static com.dell.spt.base.Constants.MIB;
 import static com.dell.spt.base.Constants.PATH_DEFAULTS;
-import static com.dell.spt.base.Constants.USER_HOME;
 import static com.dell.spt.base.Exceptions.throwUncheckedIfInterrupted;
 import static com.dell.spt.base.config.CliArgUtil.ARG_PATH_SEP;
 import static com.dell.spt.base.config.CliArgUtil.allCliArgs;
@@ -104,8 +103,10 @@ public final class Main {
 			coreResources.install(appHomePath);
 			// load the defaults
 			final var defaultConfig = loadDefaultConfig(appHomePath);
-			// extensions
-			try (final var extClsLoader = Extension.extClassLoader(Paths.get(appHomePath.toString(), DIR_EXT).toFile())) {
+			// extensions: prefer ext/ next to the JAR, fall back to appHomePath/ext (IDE/dev)
+			final var extDir = Extension.resolveExtDir();
+			final var extDirFile = extDir != null ? extDir : Paths.get(appHomePath.toString(), DIR_EXT).toFile();
+			try (final var extClsLoader = Extension.extClassLoader(extDirFile)) {
 				final var extensions = Extension.load(extClsLoader);
 				// install the extensions
 				installExtensions(extensions, appHomePath);
@@ -447,19 +448,23 @@ public final class Main {
 			final var pad = StringUtils.repeat("#", (120 - msg.length()) / 2);
 			System.out.println(pad + msg + pad);
 
-			// Load and print extensions
-			final var appHomePath = Paths.get(USER_HOME, "." + APP_NAME, appVersion);
-			try (final var extClsLoader = Extension.extClassLoader(Paths.get(appHomePath.toString(), DIR_EXT).toFile())) {
-				final var extensions = Extension.load(extClsLoader);
-				if (!extensions.isEmpty()) {
-					System.out.println("\nAvailable extensions:");
-					extensions.forEach(ext -> {
-						final var extId = ext.id();
-						System.out.printf("\t%-30s %s%n", extId, ext.getClass().getCanonicalName());
-					});
-				} else {
-					System.out.println("\nNo extensions loaded.");
+			// Load and print extensions from ext/ next to the JAR
+			final var extDir = Extension.resolveExtDir();
+			if (extDir != null) {
+				try (final var extClsLoader = Extension.extClassLoader(extDir)) {
+					final var extensions = Extension.load(extClsLoader);
+					if (!extensions.isEmpty()) {
+						System.out.println("\nAvailable extensions:");
+						extensions.forEach(ext -> {
+							final var extId = ext.id();
+							System.out.printf("\t%-30s %s%n", extId, ext.getClass().getCanonicalName());
+						});
+					} else {
+						System.out.println("\nNo extensions loaded.");
+					}
 				}
+			} else {
+				System.out.println("\nNo extensions loaded (ext/ directory not found next to JAR).");
 			}
 
 			// Print additional info

--- a/engine/core/spt-base/src/main/java/com/dell/spt/base/env/CoreResourcesToInstall.java
+++ b/engine/core/spt-base/src/main/java/com/dell/spt/base/env/CoreResourcesToInstall.java
@@ -1,7 +1,6 @@
 package com.dell.spt.base.env;
 
 import static com.dell.spt.base.Constants.APP_NAME;
-import static com.dell.spt.base.Constants.USER_HOME;
 import static com.dell.spt.base.Exceptions.throwUncheckedIfInterrupted;
 import static com.dell.spt.base.config.CliArgUtil.ARG_PATH_SEP;
 
@@ -13,8 +12,11 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -24,6 +26,7 @@ import org.apache.commons.lang3.StringUtils;
 public final class CoreResourcesToInstall extends InstallableJarResources {
 
 	public static final String RESOURCES_FILE_NAME = "/install_resources.txt";
+	private static final String ENV_SPT_HOME = "SPT_HOME";
 	private final Path appHomePath;
 
 	public CoreResourcesToInstall() {
@@ -39,11 +42,53 @@ public final class CoreResourcesToInstall extends InstallableJarResources {
 		final var msg = " " + APP_NAME + " v " + appVersion + " ";
 		final var pad = StringUtils.repeat("#", (120 - msg.length()) / 2);
 		System.out.println(pad + msg + pad);
-		appHomePath = Paths.get(USER_HOME, "." + APP_NAME, appVersion);
+		appHomePath = resolveAppHome(appVersion);
 	}
 
 	public final Path appHomePath() {
 		return appHomePath;
+	}
+
+	/**
+	 * Resolve the application home directory for config/resource extraction.
+	 * <ol>
+	 *   <li>{@code $SPT_HOME} environment variable (explicit override)</li>
+	 *   <li>A temporary directory, auto-removed on JVM shutdown</li>
+	 * </ol>
+	 */
+	private static Path resolveAppHome(final String appVersion) {
+		final var envHome = System.getenv(ENV_SPT_HOME);
+		if (envHome != null && !envHome.isEmpty()) {
+			return Path.of(envHome);
+		}
+		try {
+			final var tmpDir = Files.createTempDirectory("spt-");
+			Runtime.getRuntime().addShutdownHook(new Thread(() -> deleteRecursively(tmpDir)));
+			return tmpDir;
+		} catch (final IOException e) {
+			throw new IllegalStateException("Failed to create temporary app-home directory", e);
+		}
+	}
+
+	/** Best-effort recursive delete; ignores errors (temp dir cleanup). */
+	static void deleteRecursively(final Path dir) {
+		try {
+			Files.walkFileTree(dir, new SimpleFileVisitor<>() {
+				@Override
+				public FileVisitResult visitFile(final Path file, final BasicFileAttributes attrs) throws IOException {
+					Files.delete(file);
+					return FileVisitResult.CONTINUE;
+				}
+
+				@Override
+				public FileVisitResult postVisitDirectory(final Path d, final IOException exc) throws IOException {
+					Files.delete(d);
+					return FileVisitResult.CONTINUE;
+				}
+			});
+		} catch (final IOException ignored) {
+			// best-effort cleanup
+		}
 	}
 
 	@Override

--- a/engine/core/spt-base/src/main/java/com/dell/spt/base/env/Extension.java
+++ b/engine/core/spt-base/src/main/java/com/dell/spt/base/env/Extension.java
@@ -4,6 +4,7 @@ import com.github.akurilov.confuse.Config;
 import com.github.akurilov.confuse.SchemaProvider;
 import java.io.File;
 import java.net.MalformedURLException;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.file.Path;
@@ -54,6 +55,28 @@ public interface Extension extends Installable {
 			}
 		}
 		return extClsLoader;
+	}
+
+	/**
+	 * Resolve the extension directory by looking for {@code ext/} next to the JAR file.
+	 * Returns {@code null} if the JAR location cannot be determined or no {@code ext/}
+	 * directory exists there (e.g. running from an IDE).
+	 */
+	static File resolveExtDir() {
+		try {
+			final var codeSource = Extension.class.getProtectionDomain().getCodeSource();
+			if (codeSource != null) {
+				final var location = codeSource.getLocation();
+				final var jarPath = Path.of(location.toURI());
+				final var extDir = jarPath.getParent().resolve("ext").toFile();
+				if (extDir.isDirectory()) {
+					return extDir;
+				}
+			}
+		} catch (final URISyntaxException | SecurityException e) {
+			LOG.warning("Failed to resolve ext directory from JAR location: " + e);
+		}
+		return null;
 	}
 
 	static boolean isJarFile(final File f) {

--- a/engine/core/spt-base/src/main/java/com/dell/spt/base/item/op/OperationImpl.java
+++ b/engine/core/spt-base/src/main/java/com/dell/spt/base/item/op/OperationImpl.java
@@ -224,6 +224,9 @@ public class OperationImpl<I extends Item> implements Operation<I> {
 
 	@Override
 	public final long latency() {
+		if (reqTimeDone == 0 || respTimeStart == 0) {
+			return 0;
+		}
 		return respTimeStart - reqTimeDone;
 	}
 

--- a/engine/core/spt-base/src/main/java/com/dell/spt/base/item/op/data/DataOperationImpl.java
+++ b/engine/core/spt-base/src/main/java/com/dell/spt/base/item/op/data/DataOperationImpl.java
@@ -334,6 +334,9 @@ public class DataOperationImpl<T extends DataItem> extends OperationImpl<T>
 
 	@Override
 	public final long dataLatency() {
+		if (reqTimeDone == 0 || respDataTimeStart == 0) {
+			return 0;
+		}
 		return respDataTimeStart - reqTimeDone;
 	}
 }

--- a/engine/core/spt-base/src/test/java/com/dell/spt/base/env/CoreResourcesToInstallTest.java
+++ b/engine/core/spt-base/src/test/java/com/dell/spt/base/env/CoreResourcesToInstallTest.java
@@ -1,14 +1,22 @@
 package com.dell.spt.base.env;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.LineNumberReader;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Objects;
+
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 class CoreResourcesToInstallTest {
 
@@ -23,6 +31,68 @@ class CoreResourcesToInstallTest {
 						var reader = new LineNumberReader(new InputStreamReader(in, StandardCharsets.UTF_8))) {
 			final var expected = reader.lines().toList();
 			assertEquals(expected, actual, "Resource manifest should be read using UTF-8 without loss");
+		}
+	}
+
+	@Test
+	void appHomePath_returnsTempDir_byDefault() {
+		// Skip if $SPT_HOME is set in the environment — that overrides the temp-dir path
+		final var sptHome = System.getenv("SPT_HOME");
+		if (sptHome != null && !sptHome.isEmpty()) {
+			return;
+		}
+		final var underTest = new CoreResourcesToInstall();
+		final var path = underTest.appHomePath();
+		assertNotNull(path, "appHomePath should not be null");
+		assertTrue(Files.isDirectory(path), "appHomePath should be an existing directory");
+		assertTrue(path.getFileName().toString().startsWith("spt-"),
+						"Temp dir name should start with 'spt-', was: " + path.getFileName());
+	}
+
+	@Test
+	void appHomePath_usesSptHomeEnvVar_ifSet() {
+		final var sptHome = System.getenv("SPT_HOME");
+		if (sptHome == null || sptHome.isEmpty()) {
+			// Cannot test env-var branch without $SPT_HOME set; covered by appHomePath_returnsTempDir
+			return;
+		}
+		final var underTest = new CoreResourcesToInstall();
+		assertEquals(Path.of(sptHome), underTest.appHomePath(),
+						"Should use $SPT_HOME when set");
+	}
+
+	@Nested
+	class DeleteRecursively {
+
+		@Test
+		void removesDirectoryTree(@TempDir Path tmpDir) throws IOException {
+			// Build a small tree: tmpDir/a/b/file.txt and tmpDir/a/other.txt
+			final var dirA = tmpDir.resolve("a");
+			final var dirB = dirA.resolve("b");
+			Files.createDirectories(dirB);
+			Files.writeString(dirB.resolve("file.txt"), "hello");
+			Files.writeString(dirA.resolve("other.txt"), "world");
+
+			CoreResourcesToInstall.deleteRecursively(dirA);
+
+			assertFalse(Files.exists(dirA), "Directory tree should be fully removed");
+		}
+
+		@Test
+		void handlesEmptyDirectory(@TempDir Path tmpDir) throws IOException {
+			final var emptyDir = tmpDir.resolve("empty");
+			Files.createDirectory(emptyDir);
+
+			CoreResourcesToInstall.deleteRecursively(emptyDir);
+
+			assertFalse(Files.exists(emptyDir), "Empty directory should be removed");
+		}
+
+		@Test
+		void doesNotThrowOnNonExistentPath(@TempDir Path tmpDir) {
+			final var missing = tmpDir.resolve("does-not-exist");
+			// Should not throw — best-effort cleanup
+			CoreResourcesToInstall.deleteRecursively(missing);
 		}
 	}
 }

--- a/engine/core/spt-base/src/test/java/com/dell/spt/base/env/ExtensionResolveExtDirTest.java
+++ b/engine/core/spt-base/src/test/java/com/dell/spt/base/env/ExtensionResolveExtDirTest.java
@@ -1,0 +1,69 @@
+package com.dell.spt.base.env;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+class ExtensionResolveExtDirTest {
+
+	private Path createdExtDir;
+
+	@AfterEach
+	void cleanUp() throws IOException {
+		if (createdExtDir != null && Files.exists(createdExtDir)) {
+			Files.delete(createdExtDir);
+		}
+	}
+
+	/** Resolve the parent directory that resolveExtDir() will check for ext/. */
+	private static Path codeSourceParent() throws URISyntaxException {
+		final var codeSource = Extension.class.getProtectionDomain().getCodeSource();
+		assertNotNull(codeSource, "CodeSource should be available in test environment");
+		return Path.of(codeSource.getLocation().toURI()).getParent();
+	}
+
+	@Test
+	void returnsNull_whenNoExtDirNextToCodeSource() throws URISyntaxException {
+		final var parent = codeSourceParent();
+		final var extPath = parent.resolve("ext");
+		// Precondition: ext/ should not exist in the build tree normally
+		if (Files.exists(extPath)) {
+			// If it happens to exist, skip this test rather than assert incorrectly
+			return;
+		}
+		assertNull(Extension.resolveExtDir(), "Should return null when ext/ directory does not exist");
+	}
+
+	@Test
+	void returnsExtDir_whenExtDirExists() throws URISyntaxException, IOException {
+		final var parent = codeSourceParent();
+		createdExtDir = parent.resolve("ext");
+		Files.createDirectories(createdExtDir);
+
+		final File result = Extension.resolveExtDir();
+
+		assertNotNull(result, "Should return non-null when ext/ exists next to code source");
+		assertTrue(result.isDirectory(), "Returned file should be a directory");
+		assertEquals(createdExtDir.toFile().getAbsolutePath(), result.getAbsolutePath());
+	}
+
+	@Test
+	void returnsNull_whenExtPathIsFileNotDirectory() throws URISyntaxException, IOException {
+		final var parent = codeSourceParent();
+		createdExtDir = parent.resolve("ext");
+		// Create ext as a regular file, not a directory
+		Files.writeString(createdExtDir, "not a directory");
+
+		assertNull(Extension.resolveExtDir(), "Should return null when ext is a file, not a directory");
+	}
+}

--- a/engine/core/spt-base/src/test/java/com/dell/spt/base/item/op/OperationImplTest.java
+++ b/engine/core/spt-base/src/test/java/com/dell/spt/base/item/op/OperationImplTest.java
@@ -53,4 +53,92 @@ class OperationImplTest {
 						clone.hashCode(),
 						"Copying the operation should preserve the hashCode");
 	}
+
+	@Test
+	void latencyReturnsZeroWhenReqTimeDoneNotSet() {
+		final var op = new OperationImpl<>(0, OpType.CREATE, new ItemImpl("item"), null, null, null);
+		// Only startRequest + startResponse, no finishRequest
+		op.startRequest();
+		op.startResponse();
+		op.finishResponse();
+		assertEquals(0, op.latency(), "latency must be 0 when finishRequest was never called");
+	}
+
+	@Test
+	void latencyReturnsZeroWhenRespTimeStartNotSet() {
+		final var op = new OperationImpl<>(0, OpType.CREATE, new ItemImpl("item"), null, null, null);
+		// Only startRequest + finishRequest, no startResponse
+		op.startRequest();
+		op.finishRequest();
+		assertEquals(0, op.latency(), "latency must be 0 when startResponse was never called");
+	}
+
+	@Test
+	void latencyReturnsPositiveWhenBothTimestampsSet() {
+		final var op = new OperationImpl<>(0, OpType.READ, new ItemImpl("item"), null, null, null);
+		op.startRequest();
+		op.finishRequest();
+		op.startResponse();
+		op.finishResponse();
+		assertTrue(op.latency() >= 0, "latency must be non-negative when both timestamps are set");
+		assertTrue(op.latency() < 1_000_000, "latency must be reasonable (< 1 second) for in-JVM timing");
+	}
+
+	@Test
+	void durationReturnsPositiveAfterFullLifecycle() {
+		final var op = new OperationImpl<>(0, OpType.READ, new ItemImpl("item"), null, null, null);
+		op.startRequest();
+		op.finishRequest();
+		op.startResponse();
+		op.finishResponse();
+		assertTrue(op.duration() >= 0, "duration must be non-negative");
+		assertTrue(op.duration() < 1_000_000, "duration must be reasonable (< 1 second) for in-JVM timing");
+	}
+
+	/**
+	 * Invariant: latency() must never return an epoch-scale timestamp.
+	 * <p>
+	 * Before the fix, when finishRequest() was not called (reqTimeDone == 0), latency()
+	 * returned {@code respTimeStart - 0} which is an absolute wall-clock timestamp in
+	 * microseconds (~1.77e15). This test covers every possible call-ordering permutation
+	 * and asserts that latency never exceeds a sane bound.
+	 */
+	@Test
+	void latencyNeverReturnsEpochTimestamp() {
+		final long MAX_SANE_LATENCY_MICROS = 1_000_000_000L; // 1000 seconds
+
+		// Case 1: no lifecycle methods called at all
+		var op = new OperationImpl<>(0, OpType.CREATE, new ItemImpl("a"), null, null, null);
+		assertTrue(op.latency() < MAX_SANE_LATENCY_MICROS,
+						"latency must not be epoch-scale when no lifecycle methods called");
+
+		// Case 2: only startRequest
+		op = new OperationImpl<>(0, OpType.CREATE, new ItemImpl("b"), null, null, null);
+		op.startRequest();
+		assertTrue(op.latency() < MAX_SANE_LATENCY_MICROS,
+						"latency must not be epoch-scale after only startRequest");
+
+		// Case 3: startRequest + startResponse (no finishRequest — the actual bug scenario)
+		op = new OperationImpl<>(0, OpType.CREATE, new ItemImpl("c"), null, null, null);
+		op.startRequest();
+		op.startResponse();
+		assertTrue(op.latency() < MAX_SANE_LATENCY_MICROS,
+						"latency must not be epoch-scale when finishRequest was skipped");
+
+		// Case 4: startRequest + finishRequest (no startResponse)
+		op = new OperationImpl<>(0, OpType.CREATE, new ItemImpl("d"), null, null, null);
+		op.startRequest();
+		op.finishRequest();
+		assertTrue(op.latency() < MAX_SANE_LATENCY_MICROS,
+						"latency must not be epoch-scale when startResponse was not called");
+
+		// Case 5: normal full lifecycle
+		op = new OperationImpl<>(0, OpType.CREATE, new ItemImpl("e"), null, null, null);
+		op.startRequest();
+		op.finishRequest();
+		op.startResponse();
+		op.finishResponse();
+		assertTrue(op.latency() < MAX_SANE_LATENCY_MICROS,
+						"latency must not be epoch-scale in normal lifecycle");
+	}
 }

--- a/engine/core/spt-base/src/test/java/com/dell/spt/base/item/op/data/DataOperationImplTest.java
+++ b/engine/core/spt-base/src/test/java/com/dell/spt/base/item/op/data/DataOperationImplTest.java
@@ -138,4 +138,39 @@ class DataOperationImplTest {
 		assertNotNull(result);
 		assertTrue(result.item().name().startsWith("/bucket/"));
 	}
+
+	@Test
+	void dataLatencyReturnsZeroWhenReqTimeDoneNotSet() {
+		final var item = newItem("obj", 1024);
+		final var op = new DataOperationImpl<>(0, OpType.READ, item, "/src", null, null, null, 0);
+		op.startRequest();
+		// Skip finishRequest — simulate the Netty race where the response arrives
+		// before the channel write-complete listener fires
+		assertEquals(0, op.dataLatency(), "dataLatency must be 0 when finishRequest was never called");
+	}
+
+	/**
+	 * Invariant: dataLatency() must never return an epoch-scale timestamp.
+	 * Before the fix, skipping finishRequest() caused dataLatency() to return
+	 * {@code respDataTimeStart - 0}, an absolute wall-clock timestamp (~1.77e15 µs).
+	 */
+	@Test
+	void dataLatencyNeverReturnsEpochTimestamp() {
+		final long MAX_SANE_LATENCY_MICROS = 1_000_000_000L; // 1000 seconds
+
+		// Case 1: no lifecycle methods — both timestamps zero
+		var item = newItem("a", 1024);
+		var op = new DataOperationImpl<>(0, OpType.READ, item, "/src", null, null, null, 0);
+		assertTrue(op.dataLatency() < MAX_SANE_LATENCY_MICROS,
+						"dataLatency must not be epoch-scale when no lifecycle methods called");
+
+		// Case 2: full lifecycle including startDataResponse
+		item = newItem("b", 1024);
+		op = new DataOperationImpl<>(0, OpType.READ, item, "/src", null, null, null, 0);
+		op.startRequest();
+		op.finishRequest();
+		op.startDataResponse();
+		assertTrue(op.dataLatency() < MAX_SANE_LATENCY_MICROS,
+						"dataLatency must not be epoch-scale in normal lifecycle");
+	}
 }

--- a/engine/core/spt-base/src/test/java/com/dell/spt/base/metrics/DistributedLatencyMeanTest.java
+++ b/engine/core/spt-base/src/test/java/com/dell/spt/base/metrics/DistributedLatencyMeanTest.java
@@ -6,7 +6,6 @@ import com.dell.spt.base.concurrent.ServiceTaskExecutor;
 import com.dell.spt.base.item.op.OpType;
 import com.dell.spt.base.metrics.context.DistributedMetricsContextImpl;
 import com.dell.spt.base.metrics.context.MetricsContextImpl;
-import com.dell.spt.base.metrics.snapshot.AllMetricsSnapshot;
 import com.dell.spt.base.metrics.snapshot.DistributedAllMetricsSnapshot;
 import com.github.akurilov.commons.system.SizeInBytes;
 import org.junit.jupiter.api.AfterEach;
@@ -76,8 +75,10 @@ public class DistributedLatencyMeanTest {
 
 	@AfterEach
 	void tearDown() {
-		if (entryCtx != null) entryCtx.close();
-		if (workerCtx != null) workerCtx.close();
+		if (entryCtx != null)
+			entryCtx.close();
+		if (workerCtx != null)
+			workerCtx.close();
 	}
 
 	@Test
@@ -88,8 +89,7 @@ public class DistributedLatencyMeanTest {
 		workerCtx.refreshLastSnapshot();
 		entryCtx.refreshLastSnapshot();
 
-		final DistributedAllMetricsSnapshot snap =
-						(DistributedAllMetricsSnapshot) entryCtx.lastSnapshot();
+		final DistributedAllMetricsSnapshot snap = (DistributedAllMetricsSnapshot) entryCtx.lastSnapshot();
 		assertNotNull(snap, "snapshot should not be null");
 		assertNotNull(snap.latencySnapshot(), "latency snapshot should not be null");
 
@@ -111,8 +111,7 @@ public class DistributedLatencyMeanTest {
 		workerCtx.refreshLastSnapshot();
 		entryCtx.refreshLastSnapshot();
 
-		final DistributedAllMetricsSnapshot snap =
-						(DistributedAllMetricsSnapshot) entryCtx.lastSnapshot();
+		final DistributedAllMetricsSnapshot snap = (DistributedAllMetricsSnapshot) entryCtx.lastSnapshot();
 		assertNotNull(snap, "snapshot should not be null");
 
 		final double latMean = snap.latencySnapshot().mean();
@@ -151,8 +150,7 @@ public class DistributedLatencyMeanTest {
 		workerCtx.refreshLastSnapshot();
 		entryCtx.refreshLastSnapshot();
 
-		final DistributedAllMetricsSnapshot snap =
-						(DistributedAllMetricsSnapshot) entryCtx.lastSnapshot();
+		final DistributedAllMetricsSnapshot snap = (DistributedAllMetricsSnapshot) entryCtx.lastSnapshot();
 		assertNotNull(snap, "snapshot should not be null");
 
 		final double latMean = snap.latencySnapshot().mean();
@@ -179,8 +177,7 @@ public class DistributedLatencyMeanTest {
 		workerCtx.refreshLastSnapshot();
 		entryCtx.refreshLastSnapshot();
 
-		final DistributedAllMetricsSnapshot snap =
-						(DistributedAllMetricsSnapshot) entryCtx.lastSnapshot();
+		final DistributedAllMetricsSnapshot snap = (DistributedAllMetricsSnapshot) entryCtx.lastSnapshot();
 
 		final double durMean = snap.durationSnapshot().mean();
 		final double latMean = snap.latencySnapshot().mean();

--- a/engine/core/spt-base/src/test/java/com/dell/spt/base/metrics/DistributedLatencyMeanTest.java
+++ b/engine/core/spt-base/src/test/java/com/dell/spt/base/metrics/DistributedLatencyMeanTest.java
@@ -1,0 +1,194 @@
+package com.dell.spt.base.metrics;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.dell.spt.base.concurrent.ServiceTaskExecutor;
+import com.dell.spt.base.item.op.OpType;
+import com.dell.spt.base.metrics.context.DistributedMetricsContextImpl;
+import com.dell.spt.base.metrics.context.MetricsContextImpl;
+import com.dell.spt.base.metrics.snapshot.AllMetricsSnapshot;
+import com.dell.spt.base.metrics.snapshot.DistributedAllMetricsSnapshot;
+import com.github.akurilov.commons.system.SizeInBytes;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Reproducer for the latency mean bug: distributed context reports cumulative sum
+ * instead of per-operation average latency.
+ *
+ * The test simulates one worker local context feeding a distributed (entry) context,
+ * records many operations with known latency values, then asserts the distributed
+ * snapshot's latencySnapshot().mean() is close to the expected per-op average.
+ */
+public class DistributedLatencyMeanTest {
+
+	private static final long KNOWN_LATENCY_US = 4000;
+	private static final long KNOWN_DURATION_US = 4500;
+	private static final long ITEM_BYTES = 1024;
+
+	private MetricsContextImpl<?> workerCtx;
+	private DistributedMetricsContextImpl<?> entryCtx;
+
+	@BeforeEach
+	void setUp() {
+		final SizeInBytes size = new SizeInBytes(ITEM_BYTES);
+
+		workerCtx = (MetricsContextImpl<?>) MetricsContextImpl.builder()
+						.loadStepId("lat-test")
+						.opType(OpType.CREATE)
+						.actualConcurrencyGauge(() -> 4)
+						.concurrencyLimit(64)
+						.concurrencyThreshold(0)
+						.itemDataSize(size)
+						.outputPeriodSec(0)
+						.stdOutColorFlag(false)
+						.comment("worker")
+						.runId(1)
+						.build();
+		workerCtx.start();
+
+		entryCtx = (DistributedMetricsContextImpl<?>) DistributedMetricsContextImpl.builder()
+						.loadStepId("lat-test")
+						.opType(OpType.CREATE)
+						.nodeCountSupplier(() -> 1)
+						.concurrencyLimit(64)
+						.concurrencyThreshold(0)
+						.itemDataSize(size)
+						.outputPeriodSec(0)
+						.stdOutColorFlag(false)
+						.avgPersistFlag(false)
+						.sumPersistFlag(false)
+						.timingPersistFlag(false)
+						.snapshotsSupplier(() -> List.of(workerCtx.lastSnapshot()))
+						.quantileValues(Arrays.asList(0.25, 0.5, 0.75))
+						.nodeAddrs(List.of("127.0.0.1:1099"))
+						.comment("entry")
+						.runId(1)
+						.opCountLimit(0L)
+						.timeLimitSec(0L)
+						.build();
+		entryCtx.start();
+	}
+
+	@AfterEach
+	void tearDown() {
+		if (entryCtx != null) entryCtx.close();
+		if (workerCtx != null) workerCtx.close();
+	}
+
+	@Test
+	void latencyMeanCorrectWithSmallOpCount() {
+		for (int i = 0; i < 100; i++) {
+			workerCtx.markSucc(ITEM_BYTES, KNOWN_DURATION_US, KNOWN_LATENCY_US);
+		}
+		workerCtx.refreshLastSnapshot();
+		entryCtx.refreshLastSnapshot();
+
+		final DistributedAllMetricsSnapshot snap =
+						(DistributedAllMetricsSnapshot) entryCtx.lastSnapshot();
+		assertNotNull(snap, "snapshot should not be null");
+		assertNotNull(snap.latencySnapshot(), "latency snapshot should not be null");
+
+		final double latMean = snap.latencySnapshot().mean();
+		System.out.println("Small op count: latency mean = " + latMean + " µs");
+		System.out.println("  latency sum  = " + snap.latencySnapshot().sum());
+		System.out.println("  latency count= " + snap.latencySnapshot().count());
+		assertEquals(KNOWN_LATENCY_US, latMean, 1.0,
+						"Latency mean should equal the known per-op latency");
+	}
+
+	@Test
+	void latencyMeanCorrectWithLargeOpCount() {
+		// Simulate ~1.8M operations (similar to the real test that showed the bug)
+		final int opCount = 1_800_000;
+		for (int i = 0; i < opCount; i++) {
+			workerCtx.markSucc(ITEM_BYTES, KNOWN_DURATION_US, KNOWN_LATENCY_US);
+		}
+		workerCtx.refreshLastSnapshot();
+		entryCtx.refreshLastSnapshot();
+
+		final DistributedAllMetricsSnapshot snap =
+						(DistributedAllMetricsSnapshot) entryCtx.lastSnapshot();
+		assertNotNull(snap, "snapshot should not be null");
+
+		final double latMean = snap.latencySnapshot().mean();
+		final long latSum = snap.latencySnapshot().sum();
+		final long latCount = snap.latencySnapshot().count();
+		System.out.println("Large op count (" + opCount + "):");
+		System.out.println("  latency mean  = " + latMean + " µs");
+		System.out.println("  latency sum   = " + latSum);
+		System.out.println("  latency count = " + latCount);
+		System.out.println("  expected mean = " + KNOWN_LATENCY_US);
+
+		assertEquals(opCount, latCount, "latency count should match op count");
+		assertEquals(KNOWN_LATENCY_US, latMean, 1.0,
+						"Latency mean should equal the known per-op latency, not a cumulative value");
+		assertTrue(latMean < 10_000,
+						"Latency mean (" + latMean + " µs) should be < 10,000 µs, not billions");
+	}
+
+	@Test
+	void latencyMeanCorrectWithConcurrentRefresh() throws Exception {
+		// Simulate concurrent snapshot refreshes (like MetricsManager + snapshot supplier)
+		final int opCount = 500_000;
+		final MetricsManager mgr = new MetricsManagerImpl(ServiceTaskExecutor.VT_EXECUTOR);
+
+		// Register the distributed context with the metrics manager
+		mgr.register(entryCtx);
+
+		// Feed operations while the metrics manager is running
+		for (int i = 0; i < opCount; i++) {
+			workerCtx.markSucc(ITEM_BYTES, KNOWN_DURATION_US, KNOWN_LATENCY_US);
+			if (i % 10000 == 0) {
+				Thread.sleep(1); // allow metrics manager to tick
+			}
+		}
+
+		workerCtx.refreshLastSnapshot();
+		entryCtx.refreshLastSnapshot();
+
+		final DistributedAllMetricsSnapshot snap =
+						(DistributedAllMetricsSnapshot) entryCtx.lastSnapshot();
+		assertNotNull(snap, "snapshot should not be null");
+
+		final double latMean = snap.latencySnapshot().mean();
+		final long latSum = snap.latencySnapshot().sum();
+		final long latCount = snap.latencySnapshot().count();
+		System.out.println("Concurrent refresh (" + opCount + " ops):");
+		System.out.println("  latency mean  = " + latMean + " µs");
+		System.out.println("  latency sum   = " + latSum);
+		System.out.println("  latency count = " + latCount);
+
+		// Allow some slack for concurrency, but mean should be nowhere near billions
+		assertTrue(latMean < 100_000,
+						"Latency mean (" + latMean + " µs) should be reasonable, not " + latMean);
+
+		mgr.close();
+	}
+
+	@Test
+	void durationMeanAlsoCorrect() {
+		final int opCount = 100_000;
+		for (int i = 0; i < opCount; i++) {
+			workerCtx.markSucc(ITEM_BYTES, KNOWN_DURATION_US, KNOWN_LATENCY_US);
+		}
+		workerCtx.refreshLastSnapshot();
+		entryCtx.refreshLastSnapshot();
+
+		final DistributedAllMetricsSnapshot snap =
+						(DistributedAllMetricsSnapshot) entryCtx.lastSnapshot();
+
+		final double durMean = snap.durationSnapshot().mean();
+		final double latMean = snap.latencySnapshot().mean();
+
+		System.out.println("Duration mean = " + durMean + " µs (expected " + KNOWN_DURATION_US + ")");
+		System.out.println("Latency  mean = " + latMean + " µs (expected " + KNOWN_LATENCY_US + ")");
+
+		assertEquals(KNOWN_DURATION_US, durMean, 1.0, "Duration mean should match");
+		assertEquals(KNOWN_LATENCY_US, latMean, 1.0, "Latency mean should match");
+	}
+}

--- a/engine/core/spt-base/src/test/java/com/dell/spt/integration/AppSmokeTest.java
+++ b/engine/core/spt-base/src/test/java/com/dell/spt/integration/AppSmokeTest.java
@@ -66,7 +66,9 @@ public class AppSmokeTest {
 	@BeforeEach
 	public void setUp() {
 		coreResources.install(appHomePath);
-		extClsLoader = Extension.extClassLoader(Paths.get(appHomePath.toString(), DIR_EXT).toFile());
+		final var extDir = Extension.resolveExtDir();
+		final var extDirFile = extDir != null ? extDir : Paths.get(appHomePath.toString(), DIR_EXT).toFile();
+		extClsLoader = Extension.extClassLoader(extDirFile);
 		extensions = Extension.load(extClsLoader);
 		installExtensions(extensions, appHomePath);
 	}

--- a/engine/core/spt-base/src/test/java/com/dell/spt/integration/RunReadinessIntegrationTest.java
+++ b/engine/core/spt-base/src/test/java/com/dell/spt/integration/RunReadinessIntegrationTest.java
@@ -61,7 +61,9 @@ public class RunReadinessIntegrationTest {
 	void setUp() {
 		appHomePath = coreResources.appHomePath();
 		coreResources.install(appHomePath);
-		extClsLoader = Extension.extClassLoader(Paths.get(appHomePath.toString(), DIR_EXT).toFile());
+		final var extDir = Extension.resolveExtDir();
+		final var extDirFile = extDir != null ? extDir : Paths.get(appHomePath.toString(), DIR_EXT).toFile();
+		extClsLoader = Extension.extClassLoader(extDirFile);
 		extensions = Extension.load(extClsLoader);
 	}
 

--- a/engine/core/spt-base/src/test/robot/lib/SptContainer.robot
+++ b/engine/core/spt-base/src/test/robot/lib/SptContainer.robot
@@ -65,7 +65,7 @@ Execute Spt Scenario
     ...  --network host
     ...  ${docker_env_vars}
     ...  --volume ${host_working_dir}/${shared_data_dir}:${SPT_CONTAINER_DATA_DIR}
-    ...  --volume ${host_working_dir}/${LOG_DIR}:/root/.spt/${spt_version}/log
+    ...  --volume ${host_working_dir}/${LOG_DIR}:/opt/spt/log
     ...  ${SPT_IMAGE_NAME}:${image_version}
     ...  ${args}
     ${std_out} =  Run  ${cmd}

--- a/engine/extensions/load-steps/pipeline/ci/docker/Dockerfile
+++ b/engine/extensions/load-steps/pipeline/ci/docker/Dockerfile
@@ -12,5 +12,4 @@ FROM ghcr.io/dell/storage-performance-tool:${BASE_VERSION}
 ARG BASE_VERSION
 ARG VERSION
 COPY --from=0 /build/libs/spt-load-step-pipeline-${VERSION}.jar /tmp/
-RUN mkdir -p $HOME/.spt/${BASE_VERSION}/ext
-RUN mv -f /tmp/spt-load-step-pipeline-*.jar $HOME/.spt/${BASE_VERSION}/ext/
+RUN mv -f /tmp/spt-load-step-pipeline-*.jar /opt/spt/ext/

--- a/engine/extensions/load-steps/weighted/ci/docker/Dockerfile
+++ b/engine/extensions/load-steps/weighted/ci/docker/Dockerfile
@@ -12,5 +12,4 @@ FROM ghcr.io/dell/storage-performance-tool:${BASE_VERSION}
 ARG BASE_VERSION
 ARG VERSION
 COPY --from=0 /build/libs/spt-load-step-weighted-${VERSION}.jar /tmp/
-RUN mkdir -p $HOME/.spt/${BASE_VERSION}/ext
-RUN mv -f /tmp/spt-load-step-weighted-*.jar $HOME/.spt/${BASE_VERSION}/ext/
+RUN mv -f /tmp/spt-load-step-weighted-*.jar /opt/spt/ext/

--- a/engine/extensions/storage-drivers/implementations/atmos/ci/docker/Dockerfile
+++ b/engine/extensions/storage-drivers/implementations/atmos/ci/docker/Dockerfile
@@ -14,12 +14,11 @@ ARG STORAGE_DRIVER_COOP_VERSION
 ARG STORAGE_DRIVER_NETTY_VERSION
 ARG STORAGE_DRIVER_HTTP_VERSION
 ARG VERSION
-RUN mkdir -p $HOME/.spt/${BASE_VERSION}/ext
 COPY --from=0 /build/libs/spt-storage-driver-atmos-${VERSION}.jar /tmp/
 ADD ci/docker/entrypoint_storage_driver_atmos.sh /opt/spt/entrypoint_storage_driver_atmos.sh
-RUN mv -f /tmp/spt-storage-driver-atmos-*.jar $HOME/.spt/${BASE_VERSION}/ext/ \
+RUN mv -f /tmp/spt-storage-driver-atmos-*.jar /opt/spt/ext/ \
     && chmod +x /opt/spt/entrypoint_storage_driver_atmos.sh \
-    && curl http://repo.maven.apache.org/maven2/io/github/dell/spt/spt-storage-driver-coop/${STORAGE_DRIVER_COOP_VERSION}/spt-storage-driver-coop-${STORAGE_DRIVER_COOP_VERSION}.jar -o $HOME/.spt/${BASE_VERSION}/ext/spt-storage-driver-coop.jar \
-    && curl http://repo.maven.apache.org/maven2/io/github/dell/spt/spt-storage-driver-netty/${STORAGE_DRIVER_NETTY_VERSION}/spt-storage-driver-netty-${STORAGE_DRIVER_NETTY_VERSION}.jar -o $HOME/.spt/${BASE_VERSION}/ext/spt-storage-driver-netty.jar \
-    && curl http://repo.maven.apache.org/maven2/io/github/dell/spt/spt-storage-driver-http/${STORAGE_DRIVER_HTTP_VERSION}/spt-storage-driver-http-${STORAGE_DRIVER_HTTP_VERSION}.jar -o $HOME/.spt/${BASE_VERSION}/ext/spt-storage-driver-http.jar
+    && curl http://repo.maven.apache.org/maven2/io/github/dell/spt/spt-storage-driver-coop/${STORAGE_DRIVER_COOP_VERSION}/spt-storage-driver-coop-${STORAGE_DRIVER_COOP_VERSION}.jar -o /opt/spt/ext/spt-storage-driver-coop.jar \
+    && curl http://repo.maven.apache.org/maven2/io/github/dell/spt/spt-storage-driver-netty/${STORAGE_DRIVER_NETTY_VERSION}/spt-storage-driver-netty-${STORAGE_DRIVER_NETTY_VERSION}.jar -o /opt/spt/ext/spt-storage-driver-netty.jar \
+    && curl http://repo.maven.apache.org/maven2/io/github/dell/spt/spt-storage-driver-http/${STORAGE_DRIVER_HTTP_VERSION}/spt-storage-driver-http-${STORAGE_DRIVER_HTTP_VERSION}.jar -o /opt/spt/ext/spt-storage-driver-http.jar
 ENTRYPOINT ["/opt/spt/entrypoint_storage_driver_atmos.sh"]

--- a/engine/extensions/storage-drivers/implementations/s3/README.md
+++ b/engine/extensions/storage-drivers/implementations/s3/README.md
@@ -67,19 +67,19 @@ and put it to your working directory. Note the particular version, which is refe
 
 2. Get the latest `spt-storage-driver-coop` jar from the
 [maven repo](https://repo.maven.apache.org/maven2/io/github/dell/spt/spt-storage-driver-coop/)
-and put it to the `~/.spt/<BASE_VERSION>/ext` directory.
+and put it in the `ext/` directory next to the base jar.
 
 3. Get the latest `spt-storage-driver-netty` jar from the
 [maven repo](https://repo.maven.apache.org/maven2/io/github/dell/spt/spt-storage-driver-netty/)
-and put it to the `~/.spt/<BASE_VERSION>/ext` directory.
+and put it in the `ext/` directory next to the base jar.
 
 4. Get the latest `spt-storage-driver-http` jar from the
 [maven repo](https://repo.maven.apache.org/maven2/io/github/dell/spt/spt-storage-driver-http/)
-and put it to the `~/.spt/<BASE_VERSION>/ext` directory.
+and put it in the `ext/` directory next to the base jar.
 
 5. Get the latest `spt-storage-driver-s3` jar from the
 [maven repo](https://repo.maven.apache.org/maven2/io/github/dell/spt/spt-storage-driver-s3/)
-and put it to the `~/.spt/<BASE_VERSION>/ext` directory.
+and put it in the `ext/` directory next to the base jar.
 
 ```bash
 java -jar spt-base-<BASE_VERSION>.jar \

--- a/engine/extensions/storage-drivers/implementations/s3/ci/docker/Dockerfile
+++ b/engine/extensions/storage-drivers/implementations/s3/ci/docker/Dockerfile
@@ -14,12 +14,11 @@ ARG STORAGE_DRIVER_COOP_VERSION
 ARG STORAGE_DRIVER_NETTY_VERSION
 ARG STORAGE_DRIVER_HTTP_VERSION
 ARG VERSION
-RUN mkdir -p $HOME/.spt/${BASE_VERSION}/ext
 COPY --from=0 /build/libs/spt-storage-driver-s3-${VERSION}.jar /tmp/
 ADD ci/docker/entrypoint_storage_driver_s3.sh /opt/spt/entrypoint_storage_driver_s3.sh
-RUN mv -f /tmp/spt-storage-driver-s3-*.jar $HOME/.spt/${BASE_VERSION}/ext/ \
+RUN mv -f /tmp/spt-storage-driver-s3-*.jar /opt/spt/ext/ \
     && chmod +x /opt/spt/entrypoint_storage_driver_s3.sh \
-    && curl https://repo.maven.apache.org/maven2/io/github/dell/spt/spt-storage-driver-coop/${STORAGE_DRIVER_COOP_VERSION}/spt-storage-driver-coop-${STORAGE_DRIVER_COOP_VERSION}.jar -o $HOME/.spt/${BASE_VERSION}/ext/spt-storage-driver-coop.jar \
-    && curl https://repo.maven.apache.org/maven2/io/github/dell/spt/spt-storage-driver-netty/${STORAGE_DRIVER_NETTY_VERSION}/spt-storage-driver-netty-${STORAGE_DRIVER_NETTY_VERSION}.jar -o $HOME/.spt/${BASE_VERSION}/ext/spt-storage-driver-netty.jar \
-    && curl https://repo.maven.apache.org/maven2/io/github/dell/spt/spt-storage-driver-http/${STORAGE_DRIVER_HTTP_VERSION}/spt-storage-driver-http-${STORAGE_DRIVER_HTTP_VERSION}.jar -o $HOME/.spt/${BASE_VERSION}/ext/spt-storage-driver-http.jar
+    && curl https://repo.maven.apache.org/maven2/io/github/dell/spt/spt-storage-driver-coop/${STORAGE_DRIVER_COOP_VERSION}/spt-storage-driver-coop-${STORAGE_DRIVER_COOP_VERSION}.jar -o /opt/spt/ext/spt-storage-driver-coop.jar \
+    && curl https://repo.maven.apache.org/maven2/io/github/dell/spt/spt-storage-driver-netty/${STORAGE_DRIVER_NETTY_VERSION}/spt-storage-driver-netty-${STORAGE_DRIVER_NETTY_VERSION}.jar -o /opt/spt/ext/spt-storage-driver-netty.jar \
+    && curl https://repo.maven.apache.org/maven2/io/github/dell/spt/spt-storage-driver-http/${STORAGE_DRIVER_HTTP_VERSION}/spt-storage-driver-http-${STORAGE_DRIVER_HTTP_VERSION}.jar -o /opt/spt/ext/spt-storage-driver-http.jar
 ENTRYPOINT ["/opt/spt/entrypoint_storage_driver_s3.sh"]

--- a/engine/extensions/storage-drivers/implementations/s3/src/test/robot/lib/SptContainer.robot
+++ b/engine/extensions/storage-drivers/implementations/s3/src/test/robot/lib/SptContainer.robot
@@ -40,7 +40,7 @@ Execute Spt Scenario
     ...  --network host
     ...  ${docker_env_vars}
     ...  --volume ${host_working_dir}/${shared_data_dir}:${SPT_CONTAINER_DATA_DIR}
-    ...  --volume ${host_working_dir}/${LOG_DIR}:/root/.spt/${base_version}/log
+    ...  --volume ${host_working_dir}/${LOG_DIR}:/opt/spt/log
     ...  ${SPT_IMAGE_NAME}:${image_version}
     ...  ${args}
     ${std_out} =  Run  ${cmd}

--- a/engine/extensions/storage-drivers/implementations/swift/ci/docker/Dockerfile
+++ b/engine/extensions/storage-drivers/implementations/swift/ci/docker/Dockerfile
@@ -14,12 +14,11 @@ ARG STORAGE_DRIVER_COOP_VERSION
 ARG STORAGE_DRIVER_NETTY_VERSION
 ARG STORAGE_DRIVER_HTTP_VERSION
 ARG VERSION
-RUN mkdir -p $HOME/.spt/${BASE_VERSION}/ext
 COPY --from=0 /build/libs/spt-storage-driver-swift-${VERSION}.jar /tmp/
 ADD ci/docker/entrypoint_storage_driver_swift.sh /opt/spt/entrypoint_storage_driver_swift.sh
-RUN mv -f /tmp/spt-storage-driver-swift-*.jar $HOME/.spt/${BASE_VERSION}/ext/ \
+RUN mv -f /tmp/spt-storage-driver-swift-*.jar /opt/spt/ext/ \
     && chmod +x /opt/spt/entrypoint_storage_driver_swift.sh \
-    && curl http://repo.maven.apache.org/maven2/io/github/dell/spt/spt-storage-driver-coop/${STORAGE_DRIVER_COOP_VERSION}/spt-storage-driver-coop-${STORAGE_DRIVER_COOP_VERSION}.jar -o $HOME/.spt/${BASE_VERSION}/ext/spt-storage-driver-coop.jar \
-    && curl http://repo.maven.apache.org/maven2/io/github/dell/spt/spt-storage-driver-netty/${STORAGE_DRIVER_NETTY_VERSION}/spt-storage-driver-netty-${STORAGE_DRIVER_NETTY_VERSION}.jar -o $HOME/.spt/${BASE_VERSION}/ext/spt-storage-driver-netty.jar \
-    && curl http://repo.maven.apache.org/maven2/io/github/dell/spt/spt-storage-driver-http/${STORAGE_DRIVER_HTTP_VERSION}/spt-storage-driver-http-${STORAGE_DRIVER_HTTP_VERSION}.jar -o $HOME/.spt/${BASE_VERSION}/ext/spt-storage-driver-http.jar
+    && curl http://repo.maven.apache.org/maven2/io/github/dell/spt/spt-storage-driver-coop/${STORAGE_DRIVER_COOP_VERSION}/spt-storage-driver-coop-${STORAGE_DRIVER_COOP_VERSION}.jar -o /opt/spt/ext/spt-storage-driver-coop.jar \
+    && curl http://repo.maven.apache.org/maven2/io/github/dell/spt/spt-storage-driver-netty/${STORAGE_DRIVER_NETTY_VERSION}/spt-storage-driver-netty-${STORAGE_DRIVER_NETTY_VERSION}.jar -o /opt/spt/ext/spt-storage-driver-netty.jar \
+    && curl http://repo.maven.apache.org/maven2/io/github/dell/spt/spt-storage-driver-http/${STORAGE_DRIVER_HTTP_VERSION}/spt-storage-driver-http-${STORAGE_DRIVER_HTTP_VERSION}.jar -o /opt/spt/ext/spt-storage-driver-http.jar
 ENTRYPOINT ["/opt/spt/entrypoint_storage_driver_swift.sh"]

--- a/engine/extensions/storage-drivers/implementations/swift/src/test/robot/lib/SptContainer.robot
+++ b/engine/extensions/storage-drivers/implementations/swift/src/test/robot/lib/SptContainer.robot
@@ -40,7 +40,7 @@ Execute Spt Scenario
     ...  --network host
     ...  ${docker_env_vars}
     ...  --volume ${host_working_dir}/${shared_data_dir}:${SPT_CONTAINER_DATA_DIR}
-    ...  --volume ${host_working_dir}/${LOG_DIR}:/root/.spt/${base_version}/log
+    ...  --volume ${host_working_dir}/${LOG_DIR}:/opt/spt/log
     ...  ${SPT_IMAGE_NAME}:${image_version}
     ...  ${args}
     ${std_out} =  Run  ${cmd}

--- a/engine/extensions/storage-drivers/primitives/coop/ci/docker/Dockerfile
+++ b/engine/extensions/storage-drivers/primitives/coop/ci/docker/Dockerfile
@@ -11,9 +11,8 @@ RUN ./gradlew clean jar
 FROM ghcr.io/dell/storage-performance-tool:${BASE_VERSION}
 ARG BASE_VERSION
 ARG VERSION
-RUN mkdir -p $HOME/.spt/${BASE_VERSION}/ext
 COPY --from=0 /build/libs/spt-storage-driver-coop-${VERSION}.jar /tmp/
 ADD ci/docker/entrypoint_storage_driver_coop.sh /opt/spt/entrypoint_storage_driver_coop.sh
-RUN mv -f /tmp/spt-storage-driver-coop-*.jar $HOME/.spt/${BASE_VERSION}/ext/; \
+RUN mv -f /tmp/spt-storage-driver-coop-*.jar /opt/spt/ext/; \
     chmod +x /opt/spt/entrypoint_storage_driver_coop.sh
 ENTRYPOINT ["/opt/spt/entrypoint_storage_driver_coop.sh"]

--- a/engine/extensions/storage-drivers/primitives/netty/ci/docker/Dockerfile
+++ b/engine/extensions/storage-drivers/primitives/netty/ci/docker/Dockerfile
@@ -12,10 +12,9 @@ FROM ghcr.io/dell/storage-performance-tool:${BASE_VERSION}
 ARG BASE_VERSION
 ARG STORAGE_DRIVER_COOP_VERSION
 ARG VERSION
-RUN mkdir -p $HOME/.spt/${BASE_VERSION}/ext
 COPY --from=0 /build/libs/spt-storage-driver-netty-${VERSION}.jar /tmp/
 ADD ci/docker/entrypoint_storage_driver_netty.sh /opt/spt/entrypoint_storage_driver_netty.sh
-RUN mv -f /tmp/spt-storage-driver-netty-*.jar $HOME/.spt/${BASE_VERSION}/ext/ \
+RUN mv -f /tmp/spt-storage-driver-netty-*.jar /opt/spt/ext/ \
     && chmod +x /opt/spt/entrypoint_storage_driver_netty.sh \
-    && curl http://repo.maven.apache.org/maven2/io/github/dell/spt/spt-storage-driver-coop/${STORAGE_DRIVER_COOP_VERSION}/spt-storage-driver-coop-${STORAGE_DRIVER_COOP_VERSION}.jar -o $HOME/.spt/${BASE_VERSION}/ext/spt-storage-driver-coop.jar
+    && curl http://repo.maven.apache.org/maven2/io/github/dell/spt/spt-storage-driver-coop/${STORAGE_DRIVER_COOP_VERSION}/spt-storage-driver-coop-${STORAGE_DRIVER_COOP_VERSION}.jar -o /opt/spt/ext/spt-storage-driver-coop.jar
 ENTRYPOINT ["/opt/spt/entrypoint_storage_driver_netty.sh"]

--- a/engine/extensions/storage-drivers/primitives/nio/ci/docker/Dockerfile
+++ b/engine/extensions/storage-drivers/primitives/nio/ci/docker/Dockerfile
@@ -13,10 +13,9 @@ FROM ghcr.io/dell/storage-performance-tool:${BASE_VERSION}
 ARG BASE_VERSION
 ARG STORAGE_DRIVER_COOP_VERSION
 ARG VERSION
-RUN mkdir -p $HOME/.spt/${BASE_VERSION}/ext
 COPY --from=0 /build/libs/spt-storage-driver-nio-${VERSION}.jar /tmp/
 ADD ci/docker/entrypoint_storage_driver_nio.sh /opt/spt/entrypoint_storage_driver_nio.sh
-RUN mv -f /tmp/spt-storage-driver-nio-*.jar $HOME/.spt/${BASE_VERSION}/ext/ \
+RUN mv -f /tmp/spt-storage-driver-nio-*.jar /opt/spt/ext/ \
     && chmod +x /opt/spt/entrypoint_storage_driver_nio.sh \
-    && curl http://repo.maven.apache.org/maven2/io/github/dell/spt/spt-storage-driver-coop/${STORAGE_DRIVER_COOP_VERSION}/spt-storage-driver-coop-${STORAGE_DRIVER_COOP_VERSION}.jar -o $HOME/.spt/${BASE_VERSION}/ext/spt-storage-driver-coop.jar
+    && curl http://repo.maven.apache.org/maven2/io/github/dell/spt/spt-storage-driver-coop/${STORAGE_DRIVER_COOP_VERSION}/spt-storage-driver-coop-${STORAGE_DRIVER_COOP_VERSION}.jar -o /opt/spt/ext/spt-storage-driver-coop.jar
 ENTRYPOINT ["/opt/spt/entrypoint_storage_driver_nio.sh"]

--- a/engine/extensions/storage-drivers/protocols/fs/README.md
+++ b/engine/extensions/storage-drivers/protocols/fs/README.md
@@ -31,8 +31,8 @@ additional VFS layer. The measured rates may be:
 
 Get the latest pre-built jar file which is available at:
 http://repo.maven.apache.org/maven2/io/github/dell/spt/spt-storage-driver-fs/
-The jar file may be downloaded manually and placed into the `<USER_HOME_DIR>/.spt/<VERSION>/ext`
-directory of Spt to be automatically loaded into the runtime.
+The jar file may be downloaded manually and placed into the `ext/` directory next to `spt.jar`
+to be automatically loaded into the runtime.
 
 ```bash
 java -jar spt-<VERSION>.jar \

--- a/engine/extensions/storage-drivers/protocols/fs/ci/appveyor.yml
+++ b/engine/extensions/storage-drivers/protocols/fs/ci/appveyor.yml
@@ -40,9 +40,9 @@ build_script:
 before_test:
   - cmd: set EXT_DIR=%HOME_DIR%\ext\
   - cmd: mkdir %EXT_DIR%
-  # copy coop, nio drivers to .spt/ext
+  # copy coop, nio drivers to ext dir
   - cmd: for /R %MAVEN_HOME% %%f in (spt-storage-driver-*.jar) do COPY %%f %EXT_DIR%
-  # copy fs driver to .spt/ext
+  # copy fs driver to ext dir
   - cmd: for /R %DRIVER_DIR% %%f in (spt-storage-driver-*.jar) do COPY %%f %EXT_DIR%
   # copy spt-base.jar to home dir
   - cmd: for /R %MAVEN_HOME% %%f in (spt-base-*.jar) do COPY %%f %HOME_DIR%

--- a/engine/extensions/storage-drivers/protocols/fs/ci/appveyor.yml
+++ b/engine/extensions/storage-drivers/protocols/fs/ci/appveyor.yml
@@ -38,7 +38,7 @@ build_script:
   - cmd: gradlew.bat clean jar
 
 before_test:
-  - cmd: set EXT_DIR=C:\Users\appveyor\.spt\%BASE_VERSION%\ext\
+  - cmd: set EXT_DIR=%HOME_DIR%\ext\
   - cmd: mkdir %EXT_DIR%
   # copy coop, nio drivers to .spt/ext
   - cmd: for /R %MAVEN_HOME% %%f in (spt-storage-driver-*.jar) do COPY %%f %EXT_DIR%

--- a/engine/extensions/storage-drivers/protocols/fs/ci/docker/Dockerfile
+++ b/engine/extensions/storage-drivers/protocols/fs/ci/docker/Dockerfile
@@ -13,11 +13,10 @@ ARG BASE_VERSION
 ARG STORAGE_DRIVER_COOP_VERSION
 ARG STORAGE_DRIVER_NIO_VERSION
 ARG VERSION
-RUN mkdir -p $HOME/.spt/${BASE_VERSION}/ext
 COPY --from=0 /build/libs/spt-storage-driver-fs-${VERSION}.jar /tmp/
 ADD ci/docker/entrypoint_storage_driver_fs.sh /opt/spt/entrypoint_storage_driver_fs.sh
-RUN mv -f /tmp/spt-storage-driver-fs-*.jar $HOME/.spt/${BASE_VERSION}/ext/ \
+RUN mv -f /tmp/spt-storage-driver-fs-*.jar /opt/spt/ext/ \
     && chmod +x /opt/spt/entrypoint_storage_driver_fs.sh \
-    && curl https://repo.maven.apache.org/maven2/io/github/dell/spt/spt-storage-driver-coop/${STORAGE_DRIVER_COOP_VERSION}/spt-storage-driver-coop-${STORAGE_DRIVER_COOP_VERSION}.jar -o $HOME/.spt/${BASE_VERSION}/ext/spt-storage-driver-coop.jar \
-    && curl https://repo.maven.apache.org/maven2/io/github/dell/spt/spt-storage-driver-nio/${STORAGE_DRIVER_NIO_VERSION}/spt-storage-driver-nio-${STORAGE_DRIVER_NIO_VERSION}.jar -o $HOME/.spt/${BASE_VERSION}/ext/spt-storage-driver-nio.jar
+    && curl https://repo.maven.apache.org/maven2/io/github/dell/spt/spt-storage-driver-coop/${STORAGE_DRIVER_COOP_VERSION}/spt-storage-driver-coop-${STORAGE_DRIVER_COOP_VERSION}.jar -o /opt/spt/ext/spt-storage-driver-coop.jar \
+    && curl https://repo.maven.apache.org/maven2/io/github/dell/spt/spt-storage-driver-nio/${STORAGE_DRIVER_NIO_VERSION}/spt-storage-driver-nio-${STORAGE_DRIVER_NIO_VERSION}.jar -o /opt/spt/ext/spt-storage-driver-nio.jar
 ENTRYPOINT ["/opt/spt/entrypoint_storage_driver_fs.sh"]

--- a/engine/extensions/storage-drivers/protocols/fs/src/test/robot/api/storage/fs.robot
+++ b/engine/extensions/storage-drivers/protocols/fs/src/test/robot/api/storage/fs.robot
@@ -29,7 +29,7 @@ Windows Get Log Directory
 	${cmd} =  Catenate  ECHO %HomeDrive%%HomePath%
 	${std_out} =  Run   ${cmd}
 	${std_out} =  Strip String  ${std_out}
-	[Return]  ${std_out}\\.spt\\${version}\\log
+	[Return]  ${EXECDIR}\\log
 
 Windows Start Spt
 	[Arguments]  ${base_version}

--- a/engine/extensions/storage-drivers/protocols/fs/src/test/robot/lib/SptContainer.robot
+++ b/engine/extensions/storage-drivers/protocols/fs/src/test/robot/lib/SptContainer.robot
@@ -40,7 +40,7 @@ Execute Spt Scenario
     ...  --network host
     ...  ${docker_env_vars}
     ...  --volume ${host_working_dir}/${shared_data_dir}:${SPT_CONTAINER_DATA_DIR}
-    ...  --volume ${host_working_dir}/${LOG_DIR}:/root/.spt/${spt_version}/log
+    ...  --volume ${host_working_dir}/${LOG_DIR}:/opt/spt/log
     ...  ${SPT_IMAGE_NAME}:${image_version}
     ...  ${args}
     ${std_out} =  Run  ${cmd}

--- a/engine/extensions/storage-drivers/protocols/http/ci/docker/Dockerfile
+++ b/engine/extensions/storage-drivers/protocols/http/ci/docker/Dockerfile
@@ -13,8 +13,7 @@ ARG BASE_VERSION
 ARG STORAGE_DRIVER_COOP_VERSION
 ARG STORAGE_DRIVER_NETTY_VERSION
 ARG VERSION
-RUN mkdir -p $HOME/.spt/${BASE_VERSION}/ext
 COPY --from=0 /build/libs/spt-storage-driver-http-${VERSION}.jar /tmp/
-RUN mv -f /tmp/spt-storage-driver-http-*.jar $HOME/.spt/${BASE_VERSION}/ext/ \
-    && curl http://repo.maven.apache.org/maven2/io/github/dell/spt/spt-storage-driver-coop/${STORAGE_DRIVER_COOP_VERSION}/spt-storage-driver-coop-${STORAGE_DRIVER_COOP_VERSION}.jar -o $HOME/.spt/${BASE_VERSION}/ext/spt-storage-driver-coop.jar \
-    && curl http://repo.maven.apache.org/maven2/io/github/dell/spt/spt-storage-driver-netty/${STORAGE_DRIVER_NETTY_VERSION}/spt-storage-driver-netty-${STORAGE_DRIVER_NETTY_VERSION}.jar -o $HOME/.spt/${BASE_VERSION}/ext/spt-storage-driver-netty.jar \
+RUN mv -f /tmp/spt-storage-driver-http-*.jar /opt/spt/ext/ \
+    && curl http://repo.maven.apache.org/maven2/io/github/dell/spt/spt-storage-driver-coop/${STORAGE_DRIVER_COOP_VERSION}/spt-storage-driver-coop-${STORAGE_DRIVER_COOP_VERSION}.jar -o /opt/spt/ext/spt-storage-driver-coop.jar \
+    && curl http://repo.maven.apache.org/maven2/io/github/dell/spt/spt-storage-driver-netty/${STORAGE_DRIVER_NETTY_VERSION}/spt-storage-driver-netty-${STORAGE_DRIVER_NETTY_VERSION}.jar -o /opt/spt/ext/spt-storage-driver-netty.jar \

--- a/engine/tools/jartest.local.sh
+++ b/engine/tools/jartest.local.sh
@@ -6,6 +6,14 @@ ENGINE_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 GIT_ROOT="$(cd "$ENGINE_ROOT/.." && pwd)"
 RUN_SCRIPT="$ENGINE_ROOT/bundle/build/dist/run.sh"
 
+# Snapshot any variables the caller already exported so that sourcing the
+# .env file (which uses plain assignments) does not clobber them.
+declare -A _caller_env
+for _v in S3_ENDPOINTS S3_ACCESS_KEY S3_SECRET_KEY S3_BUCKET S3_AUTH_VERSION \
+          JARTEST_CONCURRENCY JARTEST_OBJECT_SIZE JARTEST_OP_LIMIT_COUNT; do
+  [[ -n "${!_v+set}" ]] && _caller_env[$_v]="${!_v}"
+done
+
 # Load repo-local environment defaults if present so users can keep
 # credentials and tuning knobs out of the script itself.
 # Check the git repo root first (canonical location), then engine root.
@@ -17,8 +25,13 @@ elif [[ -f "$ENGINE_ROOT/.env" ]]; then
   source "$ENGINE_ROOT/.env"
 fi
 
-# Allow overrides via environment variables. Keep variable names aligned with
-# other helper scripts (e.g., listtest.local.sh) so a single .env works.
+# Restore caller-provided overrides so they take precedence over .env.
+for _v in "${!_caller_env[@]}"; do
+  export "$_v=${_caller_env[$_v]}"
+done
+unset _caller_env _v
+
+# Fall back to built-in defaults for anything still unset.
 : "${S3_ENDPOINTS:=http://127.0.0.1:9000}"
 : "${S3_ACCESS_KEY:=AWS_ACCESS_KEY_ID_EXAMPLE}"
 : "${S3_SECRET_KEY:=AWS_SECRET_ACCESS_KEY_EXAMPLE}"

--- a/engine/tools/jartest.local.sh
+++ b/engine/tools/jartest.local.sh
@@ -2,14 +2,19 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-RUN_SCRIPT="$REPO_ROOT/bundle/build/dist/run.sh"
+ENGINE_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+GIT_ROOT="$(cd "$ENGINE_ROOT/.." && pwd)"
+RUN_SCRIPT="$ENGINE_ROOT/bundle/build/dist/run.sh"
 
 # Load repo-local environment defaults if present so users can keep
 # credentials and tuning knobs out of the script itself.
-if [[ -f "$REPO_ROOT/.env" ]]; then
+# Check the git repo root first (canonical location), then engine root.
+if [[ -f "$GIT_ROOT/.env" ]]; then
   # shellcheck disable=SC1091
-  source "$REPO_ROOT/.env"
+  source "$GIT_ROOT/.env"
+elif [[ -f "$ENGINE_ROOT/.env" ]]; then
+  # shellcheck disable=SC1091
+  source "$ENGINE_ROOT/.env"
 fi
 
 # Allow overrides via environment variables. Keep variable names aligned with
@@ -29,7 +34,7 @@ NODE_ADDRS="${NODE_ADDRS//https:\/\/}"
 
 if [[ ! -x "$RUN_SCRIPT" ]]; then
   echo "Run script not found at $RUN_SCRIPT; building distribution..." >&2
-  (cd "$REPO_ROOT" && ./gradlew -q :bundle:build)
+  (cd "$ENGINE_ROOT" && ./gradlew -q :bundle:build)
 fi
 
 exec "$RUN_SCRIPT" \

--- a/engine/tools/rdmatest.local.sh
+++ b/engine/tools/rdmatest.local.sh
@@ -120,14 +120,6 @@ if [[ ! -f "$SPT_JAR" ]]; then
   (cd "$REPO_ROOT" && ./gradlew -q :bundle:build)
 fi
 
-# Set up extension directory
-USER_EXT_DIR="$HOME/.spt/5.1.1/ext"
-mkdir -p "$USER_EXT_DIR"
-if [[ -d "$EXT_DIR" ]]; then
-  for ext in "$EXT_DIR"/*.jar; do
-    [[ -f "$ext" ]] && ln -sf "$ext" "$USER_EXT_DIR/" 2>/dev/null || true
-  done
-fi
 
 # Build JVM options
 JAVA_OPTS="-XX:MaxDirectMemorySize=4g -Xshare:off"


### PR DESCRIPTION
Remove $HOME/.spt directory pattern

The engine previously required a $HOME/.spt directory tree at startup to stage extensions, defaults, and configuration. This was fragile
(home directory assumptions, Docker USER mismatches, stale state across runs) and unnecessary — everything can be resolved relative to the
JAR itself.

  • Extension.resolveExtDir() now locates ext/ next to the running JAR via ProtectionDomain.getCodeSource(), falling back to ./ext for
  tests
  • CoreResourcesToInstall installs defaults into a temp directory instead of $HOME/.spt
  • Main.java no longer creates or references $HOME/.spt
  • Removed the installSptHomeFiles Gradle task from the bundle build
  • Updated all Dockerfiles, CI configs, Robot Framework tests, docs, and helper scripts to remove ~/.spt references
  • jartest.local.sh updated to source .env from the repo root

Fix latency reporting bug

Under the Netty HTTP driver, finishRequest() is called asynchronously via a ChannelFutureListener. When a response arrives before the
write-completion listener fires, reqTimeDone remains 0 and latency() returns respTimeStart - 0 — an absolute wall-clock timestamp in
microseconds (~1.77e15), which inflates the reported latency mean to millions of milliseconds.

  • OperationImpl.latency() now returns 0 when reqTimeDone or respTimeStart is unset
  • DataOperationImpl.dataLatency() has the same guard
  • These zero values are already filtered by MetricsContextImpl.updateTimings() (if (latencyMicros > 0))
