### PR TITLE
fix docker-publish verify-ci to check all CI checks before publishing

### DIFF
--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -47,7 +47,7 @@ jobs:
           script: |
             const sha = context.sha;
             const ciCheckNames = ['Engine Build & Tests', 'Go Quality Suite'];
-            const maxAttempts = 30;
+            const maxAttempts = 60;
             const intervalMs = 30000;
 
             console.log(`Checking CI status for commit ${sha}`);
@@ -60,21 +60,30 @@ jobs:
                 ref: sha,
               });
 
-              const ciCheck = checkRuns.check_runs.find(
-                run => ciCheckNames.includes(run.name)
-              );
-
-              if (!ciCheck) {
-                console.log(`Attempt ${attempt}/${maxAttempts}: CI check not found yet. Available: ${checkRuns.check_runs.map(r => r.name).join(', ') || '(none)'}`);
-              } else if (ciCheck.conclusion === 'success') {
-                console.log(`CI check "${ciCheck.name}" passed.`);
-                return;
-              } else if (ciCheck.conclusion) {
-                core.setFailed(`CI check "${ciCheck.name}" failed (conclusion: ${ciCheck.conclusion}). Cannot publish image.`);
-                return;
-              } else {
-                console.log(`Attempt ${attempt}/${maxAttempts}: CI check "${ciCheck.name}" still in progress...`);
+              const passed = new Set();
+              const pending = [];
+              for (const name of ciCheckNames) {
+                const run = checkRuns.check_runs.find(r => r.name === name);
+                if (!run) {
+                  pending.push(name);
+                  console.log(`Attempt ${attempt}/${maxAttempts}: "${name}" not found yet.`);
+                } else if (run.conclusion === 'success') {
+                  passed.add(name);
+                } else if (run.conclusion) {
+                  core.setFailed(`CI check "${name}" failed (conclusion: ${run.conclusion}). Cannot publish image.`);
+                  return;
+                } else {
+                  pending.push(name);
+                  console.log(`Attempt ${attempt}/${maxAttempts}: "${name}" still in progress...`);
+                }
               }
+
+              if (passed.size === ciCheckNames.length) {
+                console.log(`All CI checks passed: ${[...passed].join(', ')}`);
+                return;
+              }
+
+              console.log(`Attempt ${attempt}/${maxAttempts}: ${passed.size}/${ciCheckNames.length} passed, waiting on: ${pending.join(', ')}`);
 
               if (attempt < maxAttempts) {
                 await new Promise(r => setTimeout(r, intervalMs));


### PR DESCRIPTION
The verify-ci gate used .find() which returned whichever CI check
appeared first in the API response. This meant only one of the two
required checks (Engine Build & Tests, Go Quality Suite) was ever
tracked per poll. In the v5.5.0 release, it grabbed the slower
Engine Build check (~14min) and timed out at 900s, 1m45s before
it completed — while Go Quality Suite had passed in under 3 minutes.

Fix: iterate all entries in ciCheckNames, track each independently,
and only succeed when all have passed. Also bump maxAttempts from
30 to 40 (900s → 1200s) for headroom.
