### PR TITLE
fix testRunLoadStepClient 10-minute hang from remote node retries

### DIFF
--- a/engine/core/spt-base/src/test/java/com/dell/spt/base/load/step/client/LoadStepClientBaseTest.java
+++ b/engine/core/spt-base/src/test/java/com/dell/spt/base/load/step/client/LoadStepClientBaseTest.java
@@ -13,7 +13,6 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.rmi.RemoteException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -815,18 +814,14 @@ class LoadStepClientBaseTest {
 
 		@Test
 		void testRunLoadStepClient() throws IOException, IllegalStateException, InterruptedException {
-			// Suppress expected connection-refused retries to nonexistent FileManager during this config smoke
-			Configurator.setLevel("com.dell.spt.base.logging.Errors", Level.OFF);
+			// Local-only config: no remote node addrs to avoid 10-minute retry hang
+			// against a nonexistent FileManager (exponential backoff up to 120s per retry)
 			Config complexConfig = TestConfigBuilder.config();
 			complexConfig.val("load-step-id", "complex-integration-test");
 			complexConfig.val("load-op-type", "create");
 			complexConfig.val("storage-driver-limit-concurrency", 75);
 			complexConfig.val("load-batch-size", 250);
 			complexConfig.val("storage-driver-type", "s3");
-			complexConfig.val("load-step-node-port", 1099);
-
-			final List<String> nodeList = Arrays.asList("127.0.0.1:1099");
-			complexConfig.val("load-step-node-addrs", nodeList);
 
 			TestLoadStepExtension newExt = new TestLoadStepExtension();
 
@@ -844,8 +839,6 @@ class LoadStepClientBaseTest {
 			assertDoesNotThrow(() -> linearClient.doShutdown());
 			assertDoesNotThrow(() -> linearClient.doClose());
 			assertDoesNotThrow(() -> linearClient.doStop());
-			// Restore error logging for other tests
-			Configurator.setLevel("com.dell.spt.base.logging.Errors", Level.ERROR);
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- Remove `load-step-node-addrs` and `load-step-node-port` config from `testRunLoadStepClient()` in `LoadStepClientBaseTest`
- The test configured a remote FileManager at `127.0.0.1:1099` that doesn't exist, triggering exponential backoff retries (up to 120s each) that inflated the test from ~1s to ~10 minutes
- Remove the `Configurator.setLevel` workaround that was suppressing the resulting error logs

#### Test plan
- [x] `testRunLoadStepClient()` passes in ~1s (was ~10min)
- [x] Full `LoadStepClientBaseTest` class passes in ~10s