### PR TITLE
fix e2e behavior for --save-items

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,6 +128,7 @@ engine/.mvn/wrapper/maven-wrapper.jar
 engine/tmp/
 *.tmp
 engine/tools/log/
+engine/tools/results/
 engine/log/
 
 # Miscellaneous engine logs

--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -515,6 +515,10 @@ Available workload types:
 			warnSeedSize(params)
 		}
 
+		// Lock the base timestamp so that every GenerateScenario call
+		// (here and later in the orchestrator) produces identical step IDs.
+		params.BaseTimestamp = scenario.BaseTimestamp()
+
 		// Generate scenario content
 		scenarioContent, err := scenario.GenerateScenario(params)
 		if err != nil {

--- a/cli/internal/scenario/generator.go
+++ b/cli/internal/scenario/generator.go
@@ -36,7 +36,7 @@ func GenerateWriteScenario(params Params) (string, error) {
 
 	// Prepare template data
 	// Use a single run-level timestamp for natural sorting across steps
-	ts := baseTimestamp()
+	ts := resolveTimestamp(params)
 
 	// Determine storage driver type
 	driverType := storageDriverTypeS3
@@ -104,7 +104,7 @@ func GenerateWriteScenario(params Params) (string, error) {
 func GenerateReadScenario(params Params) (string, error) {
 	bucketPath := "/" + strings.TrimPrefix(params.Bucket, "/")
 
-	ts := baseTimestamp()
+	ts := resolveTimestamp(params)
 
 	driverType := storageDriverTypeS3
 	if params.UseRdma {
@@ -204,7 +204,7 @@ func GenerateListScenario(params Params) (string, error) {
 	}
 
 	bucketPath := "/" + strings.TrimPrefix(params.Bucket, "/")
-	baseTS := baseTimestamp()
+	baseTS := resolveTimestamp(params)
 	opLimit := 0
 	if params.ObjectCount > 0 {
 		opLimit = params.ObjectCount
@@ -265,7 +265,7 @@ func GenerateListScenario(params Params) (string, error) {
 // GenerateMockScenario creates a scenario for mock testing with optional cleanup
 func GenerateMockScenario(params Params) (string, error) {
 	// shared base timestamp for this scenario
-	ts := baseTimestamp()
+	ts := resolveTimestamp(params)
 	if params.Cleanup && params.ObjectCount > 0 {
 		// Use PipelineLoad for cleanup - create then delete
 		stepCreate := formatStepID(1, ts, "create")

--- a/cli/internal/scenario/generator_tables.go
+++ b/cli/internal/scenario/generator_tables.go
@@ -16,7 +16,7 @@ func GenerateTablesScenario(params Params) (string, error) {
 		duration = "5m"
 	}
 
-	ts := baseTimestamp()
+	ts := resolveTimestamp(params)
 
 	data := map[string]interface{}{
 		templateKeyTablesAccessKey:        params.AccessKey,

--- a/cli/internal/scenario/generator_test.go
+++ b/cli/internal/scenario/generator_test.go
@@ -1862,7 +1862,7 @@ func TestGenerateWriteScenario_SaveItems(t *testing.T) {
 				SaveItems:    true,
 			},
 			checkLines: []string{
-				`var itemsFile = java.lang.System.getProperty("user.home")`,
+				`ThreadContext.get("home_dir")`,
 				`"/items.csv"`,
 				`config["item"]["output"]["file"] = itemsFile`,
 			},
@@ -2258,6 +2258,78 @@ func TestGenerateWriteScenario_SaveItems_NotOnCleanup(t *testing.T) {
 	}
 	if !strings.Contains(got, "itemsFile") {
 		t.Error("expected itemsFile reference")
+	}
+}
+
+func TestSaveItems_UsesThreadContextHomeDir(t *testing.T) {
+	// All templates that produce itemsFile must use ThreadContext.get("home_dir")
+	// instead of the old java.lang.System.getProperty("user.home")
+	tests := []struct {
+		name   string
+		params Params
+		genFn  func(Params) (string, error)
+	}{
+		{
+			name: "write count",
+			params: Params{
+				WorkloadType: "write",
+				Bucket:       "b",
+				Threads:      1,
+				ObjectSize:   "1MB",
+				ObjectCount:  10,
+				SaveItems:    true,
+			},
+			genFn: GenerateWriteScenario,
+		},
+		{
+			name: "write duration",
+			params: Params{
+				WorkloadType: "write",
+				Bucket:       "b",
+				Threads:      1,
+				ObjectSize:   "1MB",
+				Duration:     "30s",
+				SaveItems:    true,
+			},
+			genFn: GenerateWriteScenario,
+		},
+		{
+			name: "write default",
+			params: Params{
+				WorkloadType: "write",
+				Bucket:       "b",
+				Threads:      1,
+				ObjectSize:   "1MB",
+				SaveItems:    true,
+			},
+			genFn: GenerateWriteScenario,
+		},
+		{
+			name: "read duration (seed phase)",
+			params: Params{
+				WorkloadType: "read",
+				Bucket:       "b",
+				Threads:      1,
+				ObjectSize:   "1MB",
+				Duration:     "30s",
+			},
+			genFn: GenerateReadScenario,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.genFn(tt.params)
+			if err != nil {
+				t.Fatalf("error: %v", err)
+			}
+			if !strings.Contains(got, `ThreadContext.get("home_dir")`) {
+				t.Errorf("expected ThreadContext.get(\"home_dir\") in scenario\nGot:\n%s", got)
+			}
+			if strings.Contains(got, `getProperty("user.home")`) {
+				t.Errorf("should NOT use user.home; must use ThreadContext home_dir\nGot:\n%s", got)
+			}
+		})
 	}
 }
 

--- a/cli/internal/scenario/plan.go
+++ b/cli/internal/scenario/plan.go
@@ -47,17 +47,3 @@ func BuildStepPlanFromScenario(scenarioText string) (StepPlan, error) {
 	sort.SliceStable(steps, func(i, j int) bool { return steps[i].Number < steps[j].Number })
 	return StepPlan{Steps: steps}, nil
 }
-
-// GenerateScenarioWithPlan returns the scenario and a parsed StepPlan.
-// It wraps GenerateScenario to ensure the plan matches the emitted content.
-func GenerateScenarioWithPlan(params Params) (string, StepPlan, error) {
-	s, err := GenerateScenario(params)
-	if err != nil {
-		return "", StepPlan{}, err
-	}
-	plan, err := BuildStepPlanFromScenario(s)
-	if err != nil {
-		return s, StepPlan{}, err
-	}
-	return s, plan, nil
-}

--- a/cli/internal/scenario/stepid.go
+++ b/cli/internal/scenario/stepid.go
@@ -6,11 +6,20 @@ import (
 	"time"
 )
 
-// baseTimestamp returns a UTC timestamp string in yyyymmdd.HHMMSS.mmm
-// This is stable for the scenario generation call and intended to be
-// shared across all steps in a single test for natural sorting.
-func baseTimestamp() string {
+// BaseTimestamp returns a new UTC timestamp string in yyyymmdd.HHMMSS.mmm.
+// Callers that need a stable timestamp across multiple GenerateScenario
+// invocations should call this once and store the result in Params.BaseTimestamp.
+func BaseTimestamp() string {
 	return time.Now().UTC().Format("20060102.150405.000")
+}
+
+// resolveTimestamp returns params.BaseTimestamp if non-empty, otherwise
+// generates a fresh timestamp via BaseTimestamp().
+func resolveTimestamp(params Params) string {
+	if params.BaseTimestamp != "" {
+		return params.BaseTimestamp
+	}
+	return BaseTimestamp()
 }
 
 // formatStepID builds: mt-<step-number>-<base-ts>-<op>

--- a/cli/internal/scenario/stepid_test.go
+++ b/cli/internal/scenario/stepid_test.go
@@ -5,6 +5,32 @@ import (
 	"testing"
 )
 
+func TestBaseTimestamp_Format(t *testing.T) {
+	ts := BaseTimestamp()
+	re := regexp.MustCompile(`^[0-9]{8}\.[0-9]{6}\.[0-9]{3}$`)
+	if !re.MatchString(ts) {
+		t.Fatalf("BaseTimestamp() = %q, does not match yyyymmdd.HHMMSS.mmm", ts)
+	}
+}
+
+func TestResolveTimestamp_UsesParamsWhenSet(t *testing.T) {
+	fixed := "20260101.120000.000"
+	p := Params{BaseTimestamp: fixed}
+	got := resolveTimestamp(p)
+	if got != fixed {
+		t.Fatalf("resolveTimestamp() = %q, want %q", got, fixed)
+	}
+}
+
+func TestResolveTimestamp_GeneratesWhenEmpty(t *testing.T) {
+	p := Params{}
+	got := resolveTimestamp(p)
+	re := regexp.MustCompile(`^[0-9]{8}\.[0-9]{6}\.[0-9]{3}$`)
+	if !re.MatchString(got) {
+		t.Fatalf("resolveTimestamp() with empty BaseTimestamp = %q, expected valid format", got)
+	}
+}
+
 func TestFormatStepID_ZeroPadAndOrder(t *testing.T) {
 	ts := "20250909.154231.045"
 

--- a/cli/internal/scenario/templates.go
+++ b/cli/internal/scenario/templates.go
@@ -311,8 +311,9 @@ var itemSize = {{.ItemSize}};
 var itemCount = {{.ItemCount}};
 var outputPath = {{.OutputPath}};
 {{- if .SaveItems}}
-var itemsFile = java.lang.System.getProperty("user.home")
-    + "/log/" + "{{.StepID}}" + "/items.csv";
+var sptLogDir = org.apache.logging.log4j.ThreadContext.get("home_dir");
+if (!sptLogDir) { sptLogDir = java.lang.System.getProperty("user.dir"); }
+var itemsFile = sptLogDir + "/log/" + "{{.StepID}}" + "/items.csv";
 {{- end}}
 
 var config = {
@@ -367,8 +368,9 @@ var itemSize = {{.ItemSize}};
 var duration = {{.Duration}};
 var outputPath = {{.OutputPath}};
 {{- if .SaveItems}}
-var itemsFile = java.lang.System.getProperty("user.home")
-    + "/log/" + "{{.StepID}}" + "/items.csv";
+var sptLogDir = org.apache.logging.log4j.ThreadContext.get("home_dir");
+if (!sptLogDir) { sptLogDir = java.lang.System.getProperty("user.dir"); }
+var itemsFile = sptLogDir + "/log/" + "{{.StepID}}" + "/items.csv";
 {{- end}}
 
 var config = {
@@ -423,8 +425,9 @@ var itemSize = {{.ItemSize}};
 var itemCount = 1000; // default
 var outputPath = {{.OutputPath}};
 {{- if .SaveItems}}
-var itemsFile = java.lang.System.getProperty("user.home")
-    + "/log/" + "{{.StepID}}" + "/items.csv";
+var sptLogDir = org.apache.logging.log4j.ThreadContext.get("home_dir");
+if (!sptLogDir) { sptLogDir = java.lang.System.getProperty("user.dir"); }
+var itemsFile = sptLogDir + "/log/" + "{{.StepID}}" + "/items.csv";
 {{- end}}
 
 var config = {
@@ -484,8 +487,9 @@ var itemSize = {{.ItemSize}};
 var seedCount = {{.SeedCount}};
 var duration = {{.Duration}};
 var outputPath = {{.OutputPath}};
-var itemsFile = java.lang.System.getProperty("user.home")
-    + "/log/" + "{{.StepIDSeed}}" + "/items.csv";
+var sptLogDir = org.apache.logging.log4j.ThreadContext.get("home_dir");
+if (!sptLogDir) { sptLogDir = java.lang.System.getProperty("user.dir"); }
+var itemsFile = sptLogDir + "/log/" + "{{.StepIDSeed}}" + "/items.csv";
 var pauseTime = 10; // seconds between phases
 
 // Helper functions
@@ -620,8 +624,9 @@ var itemSize = {{.ItemSize}};
 var seedCount = {{.SeedCount}};
 var readCount = {{.ItemCount}};
 var outputPath = {{.OutputPath}};
-var itemsFile = java.lang.System.getProperty("user.home")
-    + "/log/" + "{{.StepIDSeed}}" + "/items.csv";
+var sptLogDir = org.apache.logging.log4j.ThreadContext.get("home_dir");
+if (!sptLogDir) { sptLogDir = java.lang.System.getProperty("user.dir"); }
+var itemsFile = sptLogDir + "/log/" + "{{.StepIDSeed}}" + "/items.csv";
 var pauseTime = 10; // seconds between phases
 
 // Helper functions
@@ -756,8 +761,9 @@ var itemSize = {{.ItemSize}};
 var seedCount = {{.SeedCount}};
 var duration = {{.Duration}};
 var outputPath = {{.OutputPath}};
-var itemsFile = java.lang.System.getProperty("user.home")
-    + "/log/" + "{{.StepIDSeed}}" + "/items.csv";
+var sptLogDir = org.apache.logging.log4j.ThreadContext.get("home_dir");
+if (!sptLogDir) { sptLogDir = java.lang.System.getProperty("user.dir"); }
+var itemsFile = sptLogDir + "/log/" + "{{.StepIDSeed}}" + "/items.csv";
 var pauseTime = 10; // seconds between phases
 
 // Helper functions
@@ -862,8 +868,9 @@ var itemSize = {{.ItemSize}};
 var seedCount = {{.SeedCount}};
 var readCount = {{.ItemCount}};
 var outputPath = {{.OutputPath}};
-var itemsFile = java.lang.System.getProperty("user.home")
-    + "/log/" + "{{.StepIDSeed}}" + "/items.csv";
+var sptLogDir = org.apache.logging.log4j.ThreadContext.get("home_dir");
+if (!sptLogDir) { sptLogDir = java.lang.System.getProperty("user.dir"); }
+var itemsFile = sptLogDir + "/log/" + "{{.StepIDSeed}}" + "/items.csv";
 var pauseTime = 10; // seconds between phases
 
 // Helper functions
@@ -968,8 +975,9 @@ var itemSize = {{.ItemSize}};
 var seedCount = 2500; // default
 var duration = "60s"; // default
 var outputPath = {{.OutputPath}};
-var itemsFile = java.lang.System.getProperty("user.home")
-    + "/log/" + "{{.StepIDSeed}}" + "/items.csv";
+var sptLogDir = org.apache.logging.log4j.ThreadContext.get("home_dir");
+if (!sptLogDir) { sptLogDir = java.lang.System.getProperty("user.dir"); }
+var itemsFile = sptLogDir + "/log/" + "{{.StepIDSeed}}" + "/items.csv";
 var pauseTime = 10; // seconds between phases
 
 // Helper functions

--- a/cli/internal/scenario/types.go
+++ b/cli/internal/scenario/types.go
@@ -38,6 +38,11 @@ type Params struct {
 	RdmaLogLevel       string // Native RDMA log level (default: "WARN")
 	RdmaTimeoutMs      int64  // RDMA operation timeout (default: 30000)
 
+	// Stable timestamp for step IDs.  When set, all Generate*Scenario
+	// functions use this value instead of calling time.Now(), ensuring that
+	// repeated generation from the same Params produces identical step IDs.
+	BaseTimestamp string
+
 	// TUI layout
 	MinimalTUI bool // Start TUI with graphs and messages panels collapsed
 

--- a/engine/tools/jartest.local.sh
+++ b/engine/tools/jartest.local.sh
@@ -50,7 +50,14 @@ if [[ ! -x "$RUN_SCRIPT" ]]; then
   (cd "$ENGINE_ROOT" && ./gradlew -q :bundle:build)
 fi
 
-exec "$RUN_SCRIPT" \
+# ---- Results directory -----------------------------------------------------
+RESULTS_DIR="${SCRIPT_DIR}/results/jartest-$(date +%Y%m%d-%H%M%S)"
+mkdir -p "$RESULTS_DIR"
+
+echo "== jartest: ${JARTEST_OP_LIMIT_COUNT} × ${JARTEST_OBJECT_SIZE}, concurrency=${JARTEST_CONCURRENCY} =="
+echo "== Results: ${RESULTS_DIR} =="
+
+"$RUN_SCRIPT" \
   --storage-driver-type=s3 \
   --storage-net-node-addrs="${NODE_ADDRS}" \
   --storage-auth-version="${S3_AUTH_VERSION}" \
@@ -60,4 +67,6 @@ exec "$RUN_SCRIPT" \
   --storage-driver-limit-concurrency="${JARTEST_CONCURRENCY}" \
   --item-data-size="${JARTEST_OBJECT_SIZE}" \
   --load-op-limit-count="${JARTEST_OP_LIMIT_COUNT}" \
-  "$@"
+  "$@" 2>&1 | tee "${RESULTS_DIR}/output.log"
+
+echo "== Results saved to: ${RESULTS_DIR} =="

--- a/engine/tools/listtest.local.sh
+++ b/engine/tools/listtest.local.sh
@@ -93,6 +93,13 @@ if [[ ! -x "$RUN_SCRIPT" ]]; then
   (cd "$REPO_ROOT" && ./gradlew -q :bundle:build)
 fi
 
+# ---- Results directory -----------------------------------------------------
+RESULTS_DIR="${SCRIPT_DIR}/results/listtest-$(date +%Y%m%d-%H%M%S)"
+mkdir -p "$RESULTS_DIR"
+
+echo "== listtest: bucket=/${S3_BUCKET}, concurrency=${LIST_CONCURRENCY}, mode=${EFFECTIVE_MODE} =="
+echo "== Results: ${RESULTS_DIR} =="
+
 declare -a REMAPPED_ARGS=()
 for arg in "$@"; do
 	case "${arg,,}" in
@@ -113,7 +120,9 @@ done
 
 # If LIST_TIMEOUT is set, wrap with GNU timeout for safety
 if [[ -n "${LIST_TIMEOUT}" ]]; then
-  exec timeout -k 5 "${LIST_TIMEOUT}" "$RUN_SCRIPT" "${CLI_ARGS[@]}" "${REMAPPED_ARGS[@]}"
+  timeout -k 5 "${LIST_TIMEOUT}" "$RUN_SCRIPT" "${CLI_ARGS[@]}" "${REMAPPED_ARGS[@]}" 2>&1 | tee "${RESULTS_DIR}/output.log"
 else
-  exec "$RUN_SCRIPT" "${CLI_ARGS[@]}" "${REMAPPED_ARGS[@]}"
+  "$RUN_SCRIPT" "${CLI_ARGS[@]}" "${REMAPPED_ARGS[@]}" 2>&1 | tee "${RESULTS_DIR}/output.log"
 fi
+
+echo "== Results saved to: ${RESULTS_DIR} =="

--- a/engine/tools/rdmatest.local.sh
+++ b/engine/tools/rdmatest.local.sh
@@ -151,7 +151,11 @@ if [[ -n "${RDMA_LOCAL_IP}" ]]; then
 fi
 
 # Items file for passing created items from write to read phase
-ITEMS_FILE="/tmp/spt/rdmatest-items.csv"
+RESULTS_DIR="${SCRIPT_DIR}/results/rdmatest-$(date +%Y%m%d-%H%M%S)"
+mkdir -p "$RESULTS_DIR"
+ITEMS_FILE="${RESULTS_DIR}/items.csv"
+
+echo "== Results: ${RESULTS_DIR} ==" >&2
 
 # Common SPT args
 COMMON_ARGS=(
@@ -189,7 +193,7 @@ run_write() {
     "${COMMON_ARGS[@]}" \
     "--item-output-path=/${S3_BUCKET}" \
     "--item-output-file=${ITEMS_FILE}" \
-    "$@"
+    "$@" 2>&1 | tee "${RESULTS_DIR}/write.log"
 }
 
 run_read() {
@@ -208,7 +212,7 @@ run_read() {
     "${COMMON_ARGS[@]}" \
     --load-op-type=read \
     "${items_arg[@]}" \
-    "$@"
+    "$@" 2>&1 | tee "${RESULTS_DIR}/read.log"
 }
 
 case "$MODE" in
@@ -225,3 +229,5 @@ case "$MODE" in
     run_read "$@"
     ;;
 esac
+
+echo "== Results saved to: ${RESULTS_DIR} =="

--- a/engine/tools/save-items-test.local.sh
+++ b/engine/tools/save-items-test.local.sh
@@ -10,6 +10,8 @@
 #
 # Skip cleanup: SKIP_CLEANUP=1 ./save-items-test.local.sh
 # Override knobs via env or .env file (same as jartest.local.sh).
+#
+# Results are preserved under ./results/save-items-<timestamp>/.
 # ---------------------------------------------------------------------------
 set -euo pipefail
 
@@ -55,8 +57,10 @@ unset _caller_env _v
 NODE_ADDRS="${S3_ENDPOINTS//http:\/\/}"
 NODE_ADDRS="${NODE_ADDRS//https:\/\/}"
 
-ITEMS_FILE="$(mktemp "${TMPDIR:-/tmp}/spt-items-XXXXXXXX.csv")"
-trap 'rm -f "$ITEMS_FILE"' EXIT
+# ---- Results directory -----------------------------------------------------
+RESULTS_DIR="${SCRIPT_DIR}/results/save-items-$(date +%Y%m%d-%H%M%S)"
+mkdir -p "$RESULTS_DIR"
+ITEMS_FILE="${RESULTS_DIR}/items.csv"
 
 # ---- Shared flags ----------------------------------------------------------
 SHARED_ARGS=(
@@ -120,3 +124,4 @@ else
 fi
 
 echo "== save-items round-trip test finished =="
+echo "== Results preserved in: ${RESULTS_DIR} =="


### PR DESCRIPTION
  • Fix --save-items writing items.csv to an unreachable path inside the Docker container. Scenario templates used
  java.lang.System.getProperty("user.home") to build the items.csv output path, but the engine sets its log root via Log4j2
  ThreadContext("home_dir") (typically /opt/spt), which may differ from user.home. All templates now read home_dir from ThreadContext with
  a fallback to user.dir.
  • Stabilize step IDs across repeated GenerateScenario calls. Introduce BaseTimestamp on Params so the CLI locks a single timestamp
  before scenario generation, preventing drift if generation is called more than once for the same run.
  • Update engine local test scripts to capture results into a results/ directory for easier post-run inspection.

