### PR TITLE
Fix Item input list parsing issue

### DIFF
--- a/engine/extensions/storage-drivers/implementations/s3-aws/build.gradle
+++ b/engine/extensions/storage-drivers/implementations/s3-aws/build.gradle
@@ -58,6 +58,7 @@ dependencies {
 
 	// Shared logging API – do not bundle
 	compileOnly 'org.slf4j:slf4j-api:1.7.36'
+	compileOnly libs.log4j.api
 
 	// Tests
 	testImplementation 'junit:junit:4.13.2'

--- a/engine/extensions/storage-drivers/implementations/s3-aws/src/main/java/com/dell/spt/storage/driver/coop/aws/s3/S3AwsStorageDriver.java
+++ b/engine/extensions/storage-drivers/implementations/s3-aws/src/main/java/com/dell/spt/storage/driver/coop/aws/s3/S3AwsStorageDriver.java
@@ -147,8 +147,7 @@ public class S3AwsStorageDriver<I extends Item, O extends Operation<I>> extends 
 			try {
 				op.startResponse();
 				op.finishResponse();
-			} catch (Exception ignored) {
-			}
+			} catch (Exception ignored) {}
 		}
 	}
 
@@ -211,9 +210,11 @@ public class S3AwsStorageDriver<I extends Item, O extends Operation<I>> extends 
 			final var slashPos = rel.indexOf('/');
 			if (slashPos > 0) {
 				// Nested dstPath like "/bucket/prefix" — prepend prefix to key
-				return new String[]{rel.substring(0, slashPos), rel.substring(slashPos + 1) + "/" + key};
+				return new String[]{rel.substring(0, slashPos), rel.substring(slashPos + 1) + "/" + key
+				};
 			}
-			return new String[]{rel, key};
+			return new String[]{rel, key
+			};
 		}
 
 		// No dstPath — parse full path from item name
@@ -232,11 +233,13 @@ public class S3AwsStorageDriver<I extends Item, O extends Operation<I>> extends 
 		final var relPath = itemName.startsWith("/") ? itemName.substring(1) : itemName;
 		final var slashPos = relPath.indexOf('/');
 		if (slashPos > 0) {
-			return new String[]{relPath.substring(0, slashPos), relPath.substring(slashPos + 1)};
+			return new String[]{relPath.substring(0, slashPos), relPath.substring(slashPos + 1)
+			};
 		}
 		// No slash — entire relPath is the bucket, key is empty (shouldn't happen
 		// in normal operation but handle gracefully)
-		return new String[]{relPath, ""};
+		return new String[]{relPath, ""
+		};
 	}
 
 	private void putObject(final O op) throws Exception {

--- a/engine/extensions/storage-drivers/implementations/s3-aws/src/main/java/com/dell/spt/storage/driver/coop/aws/s3/S3AwsStorageDriver.java
+++ b/engine/extensions/storage-drivers/implementations/s3-aws/src/main/java/com/dell/spt/storage/driver/coop/aws/s3/S3AwsStorageDriver.java
@@ -13,6 +13,7 @@ import com.dell.spt.base.item.op.Operation.Status; // Added import for Operation
 import com.dell.spt.base.storage.Credential;
 import com.dell.spt.base.storage.driver.ListDiscoveryProbe;
 import com.dell.spt.base.storage.driver.ListOptions;
+import com.dell.spt.base.logging.Loggers;
 import com.dell.spt.storage.driver.coop.nio.NioStorageDriverBase;
 import com.github.akurilov.confuse.Config;
 
@@ -141,13 +142,12 @@ public class S3AwsStorageDriver<I extends Item, O extends Operation<I>> extends 
 			finishOperation(op);
 
 		} catch (Exception e) {
-			// For failed operations, still need to properly complete timing
+			Loggers.ERR.warn("{} {}: {}", op.type(), op.item().name(), e.getMessage(), e);
 			op.status(Status.FAIL_UNKNOWN);
 			try {
 				op.startResponse();
 				op.finishResponse();
 			} catch (Exception ignored) {
-				// Ignore timing errors on failed operations
 			}
 		}
 	}
@@ -188,32 +188,77 @@ public class S3AwsStorageDriver<I extends Item, O extends Operation<I>> extends 
 		}
 	}
 
-	private void putObject(final O op) throws Exception {
-		// Use item name as the S3 key - remove leading slash if present
-		String s3Key = op.item().name();
-		if (s3Key.startsWith("/")) {
-			s3Key = s3Key.substring(1);
+	/**
+	 * Resolve bucket name and object key from the operation context.
+	 *
+	 * The framework splits CSV item paths (e.g., "/large/mkk0lurmliru") into:
+	 *   op.dstPath() = "/large"  (bucket/prefix)
+	 *   op.item().name() = "mkk0lurmliru"  (key)
+	 *
+	 * When dstPath is available, bucket comes from dstPath and key from item name.
+	 * When dstPath is null/empty (e.g., items with full paths in their name),
+	 * falls back to parsing the full path from item.name().
+	 *
+	 * @return a two-element array: [0] = bucket, [1] = key
+	 */
+	private String[] resolveBucketAndKey(final O op) {
+		final var dstPath = op.dstPath();
+		final var itemName = op.item().name();
+
+		if (dstPath != null && !dstPath.isEmpty()) {
+			final var rel = dstPath.startsWith("/") ? dstPath.substring(1) : dstPath;
+			var key = itemName.startsWith("/") ? itemName.substring(1) : itemName;
+			final var slashPos = rel.indexOf('/');
+			if (slashPos > 0) {
+				// Nested dstPath like "/bucket/prefix" — prepend prefix to key
+				return new String[]{rel.substring(0, slashPos), rel.substring(slashPos + 1) + "/" + key};
+			}
+			return new String[]{rel, key};
 		}
 
+		// No dstPath — parse full path from item name
+		return parseBucketAndKey(itemName);
+	}
+
+	/**
+	 * Extract bucket name and object key from a full item name path.
+	 * Item names follow the pattern "/{bucket}/{key}" — the first path segment
+	 * is the bucket and the remainder is the object key. Used as a fallback
+	 * when op.dstPath() is not available.
+	 *
+	 * @return a two-element array: [0] = bucket, [1] = key
+	 */
+	static String[] parseBucketAndKey(final String itemName) {
+		final var relPath = itemName.startsWith("/") ? itemName.substring(1) : itemName;
+		final var slashPos = relPath.indexOf('/');
+		if (slashPos > 0) {
+			return new String[]{relPath.substring(0, slashPos), relPath.substring(slashPos + 1)};
+		}
+		// No slash — entire relPath is the bucket, key is empty (shouldn't happen
+		// in normal operation but handle gracefully)
+		return new String[]{relPath, ""};
+	}
+
+	private void putObject(final O op) throws Exception {
+		final var bk = resolveBucketAndKey(op);
+
 		if (op.item() instanceof DataItem) {
-			// Handle in-memory data (DataItem) - always use streaming
 			DataItem dataItem = (DataItem) op.item();
 			s3Client.putObject(
 							PutObjectRequest.builder()
-											.bucket(bucketName)
-											.key(s3Key)
+											.bucket(bk[0])
+											.key(bk[1])
 											.build(),
 							RequestBody.fromInputStream(Channels.newInputStream(dataItem), dataItem.size()));
 		} else if (op.item() instanceof PathItem) {
-			// Handle file-based data (PathItem) - always use streaming
 			PathItem pathItem = (PathItem) op.item();
 			Path path = Path.of(pathItem.name());
 
 			long size = Files.size(path);
 			s3Client.putObject(
 							PutObjectRequest.builder()
-											.bucket(bucketName)
-											.key(s3Key)
+											.bucket(bk[0])
+											.key(bk[1])
 											.build(),
 							RequestBody.fromInputStream(Files.newInputStream(path), size));
 		} else {
@@ -223,25 +268,20 @@ public class S3AwsStorageDriver<I extends Item, O extends Operation<I>> extends 
 	}
 
 	private void readObject(final O op) throws Exception {
-		// Use item name as the S3 key - remove leading slash if present
-		String s3Key = op.item().name();
-		if (s3Key.startsWith("/")) {
-			s3Key = s3Key.substring(1);
-		}
+		final var bk = resolveBucketAndKey(op);
 
 		try (var response = s3Client.getObject(
 						GetObjectRequest.builder()
-										.bucket(bucketName)
-										.key(s3Key)
+										.bucket(bk[0])
+										.key(bk[1])
 										.build())) {
 
 			// Read and consume the stream to properly transfer data
-			var inputStream = response;
-			byte[] buffer = new byte[8192]; // 8KB buffer for reading
+			byte[] buffer = new byte[8192];
 			long bytesRead = 0;
 			int n;
 
-			while ((n = inputStream.read(buffer)) != -1) {
+			while ((n = response.read(buffer)) != -1) {
 				bytesRead += n;
 			}
 
@@ -253,16 +293,12 @@ public class S3AwsStorageDriver<I extends Item, O extends Operation<I>> extends 
 	}
 
 	private void deleteObject(final O op) {
-		// Use item name as the S3 key - remove leading slash if present
-		String s3Key = op.item().name();
-		if (s3Key.startsWith("/")) {
-			s3Key = s3Key.substring(1);
-		}
+		final var bk = resolveBucketAndKey(op);
 
 		s3Client.deleteObject(
 						DeleteObjectRequest.builder()
-										.bucket(bucketName)
-										.key(s3Key)
+										.bucket(bk[0])
+										.key(bk[1])
 										.build());
 	}
 

--- a/engine/extensions/storage-drivers/implementations/s3-aws/src/test/java/com/dell/spt/storage/driver/coop/aws/s3/S3StorageDriverTest.java
+++ b/engine/extensions/storage-drivers/implementations/s3-aws/src/test/java/com/dell/spt/storage/driver/coop/aws/s3/S3StorageDriverTest.java
@@ -1,6 +1,5 @@
 package com.dell.spt.storage.driver.coop.aws.s3;
 
-import com.dell.spt.base.item.DataItem;
 import com.dell.spt.base.item.Item;
 import com.dell.spt.base.item.ItemFactory;
 import com.dell.spt.base.item.op.OpType;

--- a/engine/extensions/storage-drivers/implementations/s3-aws/src/test/java/com/dell/spt/storage/driver/coop/aws/s3/S3StorageDriverTest.java
+++ b/engine/extensions/storage-drivers/implementations/s3-aws/src/test/java/com/dell/spt/storage/driver/coop/aws/s3/S3StorageDriverTest.java
@@ -1,8 +1,11 @@
 package com.dell.spt.storage.driver.coop.aws.s3;
 
+import com.dell.spt.base.item.DataItem;
 import com.dell.spt.base.item.Item;
 import com.dell.spt.base.item.ItemFactory;
+import com.dell.spt.base.item.op.OpType;
 import com.dell.spt.base.item.op.Operation;
+import com.dell.spt.base.storage.driver.ListDiscoveryProbe;
 import com.dell.spt.base.storage.driver.ListOptions;
 
 import org.junit.jupiter.api.Test;
@@ -13,6 +16,7 @@ import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.*;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collections;
@@ -166,7 +170,7 @@ public class S3StorageDriverTest {
 						.thenReturn(mockResponse);
 
 		// Execute
-		List<String> result = drv.probeCommonPrefixes(bucketPath, prefix, delimiter, 100);
+		ListDiscoveryProbe.DiscoverResult result = drv.probeCommonPrefixes(bucketPath, prefix, delimiter, 100);
 
 		// Verify using ArgumentCaptor
 		ArgumentCaptor<ListObjectsV2Request> requestCaptor = ArgumentCaptor.forClass(ListObjectsV2Request.class);
@@ -176,9 +180,9 @@ public class S3StorageDriverTest {
 		assertEquals("test-bucket", capturedRequest.bucket());
 		assertEquals(prefix, capturedRequest.prefix());
 		assertEquals(delimiter, capturedRequest.delimiter());
-		assertEquals(2, result.size());
-		assertTrue(result.contains("test/dir1/"));
-		assertTrue(result.contains("test/dir2/"));
+		assertEquals(2, result.commonPrefixes().size());
+		assertTrue(result.commonPrefixes().contains("test/dir1/"));
+		assertTrue(result.commonPrefixes().contains("test/dir2/"));
 	}
 
 	@Test
@@ -335,5 +339,262 @@ public class S3StorageDriverTest {
 		assertNotNull(result);
 		// Don't assert the size - it might depend on implementation details
 		verify(mockS3Client).listObjectsV2(any(ListObjectsV2Request.class));
+	}
+
+	// ---- Bucket/key resolution tests ----
+	// The driver resolves bucket and key from the Operation at request time:
+	//   1. Primary: op.dstPath() provides the bucket (set by the framework when
+	//      it splits CSV item paths like "/large/mkk0lurmliru" into
+	//      dstPath="/large" and item.name()="mkk0lurmliru").
+	//   2. Fallback: when dstPath is null, the full path is parsed from
+	//      item.name() (e.g., "/spttest/fgagy5kost30" → bucket="spttest").
+
+	/**
+	 * Helper: invoke the private deleteObject(Operation) method via reflection.
+	 */
+	private void invokeDeleteObject(S3AwsStorageDriver<Item, Operation<Item>> drv, Operation<Item> op) throws Exception {
+		Method m = S3AwsStorageDriver.class.getDeclaredMethod("deleteObject", Operation.class);
+		m.setAccessible(true);
+		m.invoke(drv, op);
+	}
+
+	/**
+	 * Helper: invoke the private readObject(Operation) method via reflection.
+	 */
+	private void invokeReadObject(S3AwsStorageDriver<Item, Operation<Item>> drv, Operation<Item> op) throws Exception {
+		Method m = S3AwsStorageDriver.class.getDeclaredMethod("readObject", Operation.class);
+		m.setAccessible(true);
+		m.invoke(drv, op);
+	}
+
+	/**
+	 * Helper: create a mock Operation with separate dstPath and item name.
+	 * This simulates how the framework splits CSV paths.
+	 */
+	@SuppressWarnings("unchecked")
+	private Operation<Item> mockOpWithPaths(String itemName, String dstPath, OpType type) {
+		Item mockItem = mock(Item.class);
+		when(mockItem.name()).thenReturn(itemName);
+		Operation<Item> op = mock(Operation.class);
+		when(op.item()).thenReturn(mockItem);
+		when(op.type()).thenReturn(type);
+		when(op.dstPath()).thenReturn(dstPath);
+		return op;
+	}
+
+	/**
+	 * Helper: create a mock Operation with no dstPath (fallback to item name parsing).
+	 */
+	private Operation<Item> mockOpWithItemName(String itemName, OpType type) {
+		return mockOpWithPaths(itemName, null, type);
+	}
+
+	// ---- Tests for framework path-splitting (primary path) ----
+	// The framework splits CSV item paths: dstPath="/large", item.name()="mkk0lurmliru"
+
+	/**
+	 * When the framework provides dstPath="/large", the bucket must be "large"
+	 * and the key must be the item name.
+	 */
+	@Test
+	void deleteObject_shouldUseBucketFromDstPath() throws Exception {
+		var drv = newDriverMock();
+		var mockS3 = mock(S3Client.class);
+		setS3Client(drv, mockS3);
+		setBucketName(drv, "wrongbucket");
+
+		when(mockS3.deleteObject(any(DeleteObjectRequest.class)))
+						.thenReturn(DeleteObjectResponse.builder().build());
+
+		invokeDeleteObject(drv, mockOpWithPaths("mkk0lurmliru", "/large", OpType.DELETE));
+
+		var captor = ArgumentCaptor.forClass(DeleteObjectRequest.class);
+		verify(mockS3).deleteObject(captor.capture());
+
+		assertEquals("large", captor.getValue().bucket(),
+						"Bucket should come from dstPath, not from item name or constructor field");
+		assertEquals("mkk0lurmliru", captor.getValue().key(),
+						"Key should be the item name");
+	}
+
+	/**
+	 * readObject with framework-split paths: dstPath="/large", item.name()="mkk0lurmliru".
+	 */
+	@Test
+	void readObject_shouldUseBucketFromDstPath() throws Exception {
+		var drv = newDriverMock();
+		var mockS3 = mock(S3Client.class);
+		setS3Client(drv, mockS3);
+		setBucketName(drv, "wrongbucket");
+
+		var getResponse = GetObjectResponse.builder().build();
+		var realResponse = new software.amazon.awssdk.core.ResponseInputStream<>(
+						getResponse, new java.io.ByteArrayInputStream(new byte[0]));
+		when(mockS3.getObject(any(GetObjectRequest.class))).thenReturn(realResponse);
+
+		invokeReadObject(drv, mockOpWithPaths("mkk0lurmliru", "/large", OpType.READ));
+
+		var captor = ArgumentCaptor.forClass(GetObjectRequest.class);
+		verify(mockS3).getObject(captor.capture());
+
+		assertEquals("large", captor.getValue().bucket(),
+						"Bucket should come from dstPath");
+		assertEquals("mkk0lurmliru", captor.getValue().key(),
+						"Key should be the item name");
+	}
+
+	/**
+	 * Nested dstPath: "/mybucket/prefix" with item.name()="object"
+	 * → bucket="mybucket", key="prefix/object".
+	 */
+	@Test
+	void deleteObject_shouldHandleNestedDstPath() throws Exception {
+		var drv = newDriverMock();
+		var mockS3 = mock(S3Client.class);
+		setS3Client(drv, mockS3);
+		setBucketName(drv, "wrongbucket");
+
+		when(mockS3.deleteObject(any(DeleteObjectRequest.class)))
+						.thenReturn(DeleteObjectResponse.builder().build());
+
+		invokeDeleteObject(drv, mockOpWithPaths("object", "/mybucket/prefix", OpType.DELETE));
+
+		var captor = ArgumentCaptor.forClass(DeleteObjectRequest.class);
+		verify(mockS3).deleteObject(captor.capture());
+
+		assertEquals("mybucket", captor.getValue().bucket(),
+						"Bucket should be first segment of dstPath");
+		assertEquals("prefix/object", captor.getValue().key(),
+						"Key should include dstPath prefix and item name");
+	}
+
+	// ---- Tests for fallback (no dstPath, full path in item name) ----
+
+	/**
+	 * When dstPath is null, bucket must be extracted from the item name.
+	 * Item "/spttest/fgagy5kost30" → bucket="spttest".
+	 */
+	@Test
+	void deleteObject_shouldUseBucketFromItemName() throws Exception {
+		var drv = newDriverMock();
+		var mockS3 = mock(S3Client.class);
+		setS3Client(drv, mockS3);
+		setBucketName(drv, "wrongbucket");
+
+		when(mockS3.deleteObject(any(DeleteObjectRequest.class)))
+						.thenReturn(DeleteObjectResponse.builder().build());
+
+		invokeDeleteObject(drv, mockOpWithItemName("/spttest/fgagy5kost30", OpType.DELETE));
+
+		var captor = ArgumentCaptor.forClass(DeleteObjectRequest.class);
+		verify(mockS3).deleteObject(captor.capture());
+
+		assertEquals("spttest", captor.getValue().bucket(),
+						"Bucket should be extracted from item name when dstPath is null");
+	}
+
+	/**
+	 * When dstPath is null, key must be extracted from the item name.
+	 * Item "/spttest/fgagy5kost30" → key="fgagy5kost30".
+	 */
+	@Test
+	void deleteObject_shouldUseKeyWithoutBucketPrefix() throws Exception {
+		var drv = newDriverMock();
+		var mockS3 = mock(S3Client.class);
+		setS3Client(drv, mockS3);
+		setBucketName(drv, "wrongbucket");
+
+		when(mockS3.deleteObject(any(DeleteObjectRequest.class)))
+						.thenReturn(DeleteObjectResponse.builder().build());
+
+		invokeDeleteObject(drv, mockOpWithItemName("/spttest/fgagy5kost30", OpType.DELETE));
+
+		var captor = ArgumentCaptor.forClass(DeleteObjectRequest.class);
+		verify(mockS3).deleteObject(captor.capture());
+
+		assertEquals("fgagy5kost30", captor.getValue().key(),
+						"Key should not contain the bucket prefix");
+	}
+
+	/**
+	 * Fallback read: dstPath is null, item "/spttest/fgagy5kost30"
+	 * → bucket="spttest", key="fgagy5kost30".
+	 */
+	@Test
+	void readObject_shouldUseBucketFromItemName() throws Exception {
+		var drv = newDriverMock();
+		var mockS3 = mock(S3Client.class);
+		setS3Client(drv, mockS3);
+		setBucketName(drv, "wrongbucket");
+
+		var getResponse = GetObjectResponse.builder().build();
+		var realResponse = new software.amazon.awssdk.core.ResponseInputStream<>(
+						getResponse, new java.io.ByteArrayInputStream(new byte[0]));
+		when(mockS3.getObject(any(GetObjectRequest.class))).thenReturn(realResponse);
+
+		invokeReadObject(drv, mockOpWithItemName("/spttest/fgagy5kost30", OpType.READ));
+
+		var captor = ArgumentCaptor.forClass(GetObjectRequest.class);
+		verify(mockS3).getObject(captor.capture());
+
+		assertEquals("spttest", captor.getValue().bucket(),
+						"Bucket should be extracted from item name when dstPath is null");
+		assertEquals("fgagy5kost30", captor.getValue().key(),
+						"Key should not contain the bucket prefix");
+	}
+
+	/**
+	 * Fallback with nested paths: dstPath is null,
+	 * item "/mybucket/path/to/object" → bucket="mybucket", key="path/to/object".
+	 */
+	@Test
+	void deleteObject_shouldHandleNestedKeyPaths() throws Exception {
+		var drv = newDriverMock();
+		var mockS3 = mock(S3Client.class);
+		setS3Client(drv, mockS3);
+		setBucketName(drv, "wrongbucket");
+
+		when(mockS3.deleteObject(any(DeleteObjectRequest.class)))
+						.thenReturn(DeleteObjectResponse.builder().build());
+
+		invokeDeleteObject(drv, mockOpWithItemName("/mybucket/path/to/object", OpType.DELETE));
+
+		var captor = ArgumentCaptor.forClass(DeleteObjectRequest.class);
+		verify(mockS3).deleteObject(captor.capture());
+
+		assertEquals("mybucket", captor.getValue().bucket(),
+						"Bucket should be the first path segment");
+		assertEquals("path/to/object", captor.getValue().key(),
+						"Key should be everything after the first path segment");
+	}
+
+	// ---- parseBucketAndKey unit tests ----
+
+	@Test
+	void parseBucketAndKey_standardItemName() {
+		var bk = S3AwsStorageDriver.parseBucketAndKey("/spttest/fgagy5kost30");
+		assertEquals("spttest", bk[0], "bucket");
+		assertEquals("fgagy5kost30", bk[1], "key");
+	}
+
+	@Test
+	void parseBucketAndKey_noLeadingSlash() {
+		var bk = S3AwsStorageDriver.parseBucketAndKey("spttest/fgagy5kost30");
+		assertEquals("spttest", bk[0], "bucket");
+		assertEquals("fgagy5kost30", bk[1], "key");
+	}
+
+	@Test
+	void parseBucketAndKey_nestedKey() {
+		var bk = S3AwsStorageDriver.parseBucketAndKey("/mybucket/path/to/object");
+		assertEquals("mybucket", bk[0], "bucket");
+		assertEquals("path/to/object", bk[1], "key");
+	}
+
+	@Test
+	void parseBucketAndKey_bucketOnly() {
+		var bk = S3AwsStorageDriver.parseBucketAndKey("/mybucket");
+		assertEquals("mybucket", bk[0], "bucket");
+		assertEquals("", bk[1], "key should be empty when no key segment");
 	}
 }


### PR DESCRIPTION
Fixes bucket/key resolution in the s3-aws driver when reading items from a CSV file.

Bug: When using --item-input-file=items.csv, the framework's prepare() splits each item path into op.dstPath() (parent/bucket) and op.item().name() (key). For an item /
large/mkk0lurmliru, this becomes dstPath="/large" and name="mkk0lurmliru". The driver was calling parseBucketAndKey(op.item().name()), which received just "mkk0lurmliru"
— no slash — producing bucket="mkk0lurmliru", key="". Every read failed with Key cannot be empty.

Fix: Added resolveBucketAndKey(O op) which extracts the bucket from op.dstPath() (matching the standard S3 driver's behavior) and falls back to parsing the full path from
item.name() when dstPath is null. Also handles nested destination paths (e.g., /bucket/prefix).

Also:

  • Added error logging in invokeNio() catch block (was silently swallowing exceptions)
  • Added log4j.api compile dependency for Loggers import

Test plan

  • [x] ./gradlew :extensions:storage-drivers:implementations:s3-aws:test — 13/17 pass (4 pre-existing failures in list/probe tests unchanged)
  • [x] Live read test: 500 x 100MB reads from items.csv — 500 successful, 0 failed, ~1.19 GB/s
