### PR TITLE
Add --s3-driver flag for runtime storage driver selection

### DIFF
--- a/cli/cmd/constants.go
+++ b/cli/cmd/constants.go
@@ -53,6 +53,7 @@ const (
 const (
 	SptStorageDriverType       = "--storage-driver-type"
 	SptStorageDriverTypeS3     = "s3"
+	SptStorageDriverTypeS3Aws  = "s3-aws"
 	SptStorageDriverTypeS3Rdma = "s3-rdma"
 	SptStorageDriverTypeMock   = "dummy-mock"
 	SptStorageNetNodeAddrs     = "--storage-net-node-addrs"

--- a/cli/cmd/envdefaults.go
+++ b/cli/cmd/envdefaults.go
@@ -99,6 +99,9 @@ func applyEnvDefaultsToRunFlags(cmd *cobra.Command) error {
 		}
 	}
 
+	// S3 driver selection: SPT_S3_DRIVER env var (values: default, netty, aws, rdma)
+	_ = setIf("s3-driver", constants.EnvS3Driver)
+
 	// Multipart upload part size (accepts humanized sizes like "64MB")
 	if f := cmd.Flags().Lookup("part-size"); f != nil && !cmd.Flags().Changed("part-size") {
 		if v := strings.TrimSpace(os.Getenv(constants.EnvPartSize)); v != "" {

--- a/cli/cmd/envdefaults_test.go
+++ b/cli/cmd/envdefaults_test.go
@@ -28,6 +28,7 @@ func newRunLikeCmd() *cobra.Command {
 	c.Flags().String("rdma-log-level", "WARN", "")
 	c.Flags().Int64("rdma-timeout-ms", 30000, "")
 	c.Flags().Int("service-threads", 0, "")
+	c.Flags().String("s3-driver", "default", "")
 	c.Flags().String("part-size", "", "")
 	c.Flags().Int("auth-version", 4, "")
 	return c
@@ -441,5 +442,39 @@ func TestApplyEnvDefaultsToRunFlags_PartSizeInvalidEnv(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), constants.EnvPartSize) {
 		t.Errorf("error should mention env var name, got: %v", err)
+	}
+}
+
+func TestApplyEnvDefaultsToRunFlags_S3DriverFromEnv(t *testing.T) {
+	cmd := newRunLikeCmd()
+
+	os.Setenv(constants.EnvS3Driver, "aws")
+	t.Cleanup(func() { os.Unsetenv(constants.EnvS3Driver) })
+
+	if err := applyEnvDefaultsToRunFlags(cmd); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got, _ := cmd.Flags().GetString("s3-driver")
+	if got != "aws" {
+		t.Errorf("expected s3-driver=aws from env, got %q", got)
+	}
+}
+
+func TestApplyEnvDefaultsToRunFlags_S3DriverFlagWinsOverEnv(t *testing.T) {
+	cmd := newRunLikeCmd()
+
+	os.Setenv(constants.EnvS3Driver, "aws")
+	t.Cleanup(func() { os.Unsetenv(constants.EnvS3Driver) })
+
+	_ = cmd.Flags().Set("s3-driver", "rdma") // explicit flag
+
+	if err := applyEnvDefaultsToRunFlags(cmd); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got, _ := cmd.Flags().GetString("s3-driver")
+	if got != "rdma" {
+		t.Errorf("expected s3-driver=rdma (CLI flag should win), got %q", got)
 	}
 }

--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -574,9 +574,12 @@ Available workload types:
 			_ = os.Unsetenv(constants.EnvSkipImagePull)
 		}
 
-		if params.UseRdma {
+		switch params.S3Driver {
+		case scenario.S3DriverRdma:
 			_ = os.Setenv(constants.EnvRdmaEnabled, "true")
 			fmt.Println("RDMA mode enabled: using s3-rdma driver with device passthrough.")
+		case scenario.S3DriverAws:
+			fmt.Println("Using AWS SDK S3 driver (s3-aws).")
 		}
 
 		// Check for port conflicts before launching Spt
@@ -901,6 +904,9 @@ Example: --test-hosts "host1,host2,host3" --min-hosts 2
 	runCmd.Flags().Int("rmi-port-count", 10, "Number of RMI ports to verify")
 
 	// RDMA Acceleration Options
+	runCmd.Flags().String("s3-driver", "default",
+		`S3 storage driver backend: "default" (Netty), "aws" (AWS SDK), "rdma" (RDMA-accelerated).
+Shorthand: --use-rdma is equivalent to --s3-driver rdma. (env: SPT_S3_DRIVER)`)
 	runCmd.Flags().Bool("use-rdma", false, "Use RDMA-accelerated S3 driver (requires RDMA hardware and device passthrough)")
 	runCmd.Flags().String("rdma-local-ip", "", "Local RDMA interface IP address (env: RDMA_LOCAL_IP)")
 	runCmd.Flags().String("rdma-threshold", "1MB", "Minimum object size for RDMA transfer, e.g. 0, 256KB, 1MB (env: RDMA_THRESHOLD_BYTES)")
@@ -1095,10 +1101,31 @@ func buildScenarioParams(workloadType string, cmd *cobra.Command) (scenario.Para
 		}
 	}
 
-	// RDMA acceleration
+	// S3 driver selection: --s3-driver takes precedence, --use-rdma is a synonym for --s3-driver rdma
+	s3Driver, _ := cmd.Flags().GetString("s3-driver")
 	useRdma, _ := cmd.Flags().GetBool("use-rdma")
-	params.UseRdma = useRdma
-	if useRdma {
+
+	s3DriverExplicit := cmd.Flags().Changed("s3-driver")
+	useRdmaExplicit := cmd.Flags().Changed("use-rdma")
+
+	if s3DriverExplicit && useRdmaExplicit && useRdma && s3Driver != scenario.S3DriverRdma {
+		return params, fmt.Errorf("conflicting flags: --s3-driver %q and --use-rdma cannot be used together", s3Driver)
+	}
+
+	if useRdma && !s3DriverExplicit {
+		s3Driver = scenario.S3DriverRdma
+	}
+
+	// Validate the driver value
+	switch s3Driver {
+	case scenario.S3DriverDefault, scenario.S3DriverNetty, scenario.S3DriverAws, scenario.S3DriverRdma, "":
+		// valid ("" treated as default)
+	default:
+		return params, fmt.Errorf("invalid --s3-driver value %q: must be one of: default, netty, aws, rdma", s3Driver)
+	}
+
+	params.S3Driver = s3Driver
+	if s3Driver == scenario.S3DriverRdma {
 		params.RdmaLocalIP, _ = cmd.Flags().GetString("rdma-local-ip")
 		thresholdStr, _ := cmd.Flags().GetString("rdma-threshold")
 		thresholdBytes, err := sizeparse.Parse(thresholdStr)

--- a/cli/cmd/run_scenario_test.go
+++ b/cli/cmd/run_scenario_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/dell/storage-performance-tool/cli/internal/scenario"
@@ -432,6 +433,14 @@ func TestBuildScenarioParams(t *testing.T) {
 			cmd.Flags().Bool("cleanup", false, "")
 			cmd.Flags().Bool("create-prefix", false, "")
 			cmd.Flags().Int("service-threads", 0, "")
+			cmd.Flags().String("s3-driver", "default", "")
+			cmd.Flags().Bool("use-rdma", false, "")
+			cmd.Flags().String("rdma-local-ip", "", "")
+			cmd.Flags().String("rdma-threshold", "1MB", "")
+			cmd.Flags().Bool("rdma-fallback", false, "")
+			cmd.Flags().String("rdma-device", "auto", "")
+			cmd.Flags().String("rdma-log-level", "WARN", "")
+			cmd.Flags().Int64("rdma-timeout-ms", 30000, "")
 
 			// Set the flag values from the test case
 			for flagName, value := range tt.flags {
@@ -453,7 +462,10 @@ func TestBuildScenarioParams(t *testing.T) {
 				t.Fatalf("buildScenarioParams() unexpected error: %v", err)
 			}
 
-			// Check result
+			// Check result — fill in S3Driver default if the test didn't set it
+			if tt.expected.S3Driver == "" {
+				tt.expected.S3Driver = scenario.S3DriverDefault
+			}
 			if !reflect.DeepEqual(got, tt.expected) {
 				t.Errorf("buildScenarioParams() = %+v, want %+v", got, tt.expected)
 			}
@@ -540,6 +552,14 @@ func TestBuildScenarioParamsEdgeCases(t *testing.T) {
 			cmd.Flags().String("object-size", "", "")
 			cmd.Flags().Int("object-count", 0, "")
 			cmd.Flags().String("duration", "", "")
+			cmd.Flags().String("s3-driver", "default", "")
+			cmd.Flags().Bool("use-rdma", false, "")
+			cmd.Flags().String("rdma-local-ip", "", "")
+			cmd.Flags().String("rdma-threshold", "1MB", "")
+			cmd.Flags().Bool("rdma-fallback", false, "")
+			cmd.Flags().String("rdma-device", "auto", "")
+			cmd.Flags().String("rdma-log-level", "WARN", "")
+			cmd.Flags().Int64("rdma-timeout-ms", 30000, "")
 
 			// Setup flags for this test
 			tt.setupFlags(cmd)
@@ -581,6 +601,14 @@ func TestBuildScenarioParamsServiceThreads(t *testing.T) {
 			cmd.Flags().Int("object-count", 0, "")
 			cmd.Flags().String("duration", "", "")
 			cmd.Flags().Int("service-threads", 0, "")
+			cmd.Flags().String("s3-driver", "default", "")
+			cmd.Flags().Bool("use-rdma", false, "")
+			cmd.Flags().String("rdma-local-ip", "", "")
+			cmd.Flags().String("rdma-threshold", "1MB", "")
+			cmd.Flags().Bool("rdma-fallback", false, "")
+			cmd.Flags().String("rdma-device", "auto", "")
+			cmd.Flags().String("rdma-log-level", "WARN", "")
+			cmd.Flags().Int64("rdma-timeout-ms", 30000, "")
 
 			_ = cmd.Flags().Set("service-threads", fmt.Sprintf("%d", tt.value))
 
@@ -593,4 +621,92 @@ func TestBuildScenarioParamsServiceThreads(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestBuildScenarioParams_S3DriverFlag(t *testing.T) {
+	newCmd := func() *cobra.Command {
+		cmd := &cobra.Command{}
+		cmd.Flags().String("endpoint", "", "")
+		cmd.Flags().StringSlice("endpoints", []string{}, "")
+		cmd.Flags().Bool("slice-endpoints", false, "")
+		cmd.Flags().String("access-key", "", "")
+		cmd.Flags().String("secret-key", "", "")
+		cmd.Flags().String("bucket", "", "")
+		cmd.Flags().String("prefix", "", "")
+		cmd.Flags().Int("auth-version", 4, "")
+		cmd.Flags().Int("threads", 0, "")
+		cmd.Flags().String("object-size", "", "")
+		cmd.Flags().Int("object-count", 0, "")
+		cmd.Flags().String("duration", "", "")
+		cmd.Flags().Bool("cleanup", false, "")
+		cmd.Flags().Int("service-threads", 0, "")
+		cmd.Flags().String("s3-driver", "default", "")
+		cmd.Flags().Bool("use-rdma", false, "")
+		cmd.Flags().String("rdma-local-ip", "", "")
+		cmd.Flags().String("rdma-threshold", "1MB", "")
+		cmd.Flags().Bool("rdma-fallback", false, "")
+		cmd.Flags().String("rdma-device", "auto", "")
+		cmd.Flags().String("rdma-log-level", "WARN", "")
+		cmd.Flags().Int64("rdma-timeout-ms", 30000, "")
+		return cmd
+	}
+
+	t.Run("--s3-driver aws sets S3Driver", func(t *testing.T) {
+		cmd := newCmd()
+		_ = cmd.Flags().Set("s3-driver", "aws")
+		p, err := buildScenarioParams("mock", cmd)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if p.S3Driver != scenario.S3DriverAws {
+			t.Errorf("S3Driver = %q, want %q", p.S3Driver, scenario.S3DriverAws)
+		}
+	})
+
+	t.Run("--use-rdma alone sets S3Driver to rdma", func(t *testing.T) {
+		cmd := newCmd()
+		_ = cmd.Flags().Set("use-rdma", "true")
+		p, err := buildScenarioParams("mock", cmd)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if p.S3Driver != scenario.S3DriverRdma {
+			t.Errorf("S3Driver = %q, want %q", p.S3Driver, scenario.S3DriverRdma)
+		}
+	})
+
+	t.Run("--s3-driver rdma --use-rdma is not a conflict", func(t *testing.T) {
+		cmd := newCmd()
+		_ = cmd.Flags().Set("s3-driver", "rdma")
+		_ = cmd.Flags().Set("use-rdma", "true")
+		_, err := buildScenarioParams("mock", cmd)
+		if err != nil {
+			t.Fatalf("expected no error for consistent flags, got: %v", err)
+		}
+	})
+
+	t.Run("--s3-driver aws --use-rdma conflicts", func(t *testing.T) {
+		cmd := newCmd()
+		_ = cmd.Flags().Set("s3-driver", "aws")
+		_ = cmd.Flags().Set("use-rdma", "true")
+		_, err := buildScenarioParams("mock", cmd)
+		if err == nil {
+			t.Fatal("expected conflict error")
+		}
+		if !strings.Contains(err.Error(), "conflicting") {
+			t.Errorf("expected 'conflicting' in error, got: %v", err)
+		}
+	})
+
+	t.Run("invalid --s3-driver value", func(t *testing.T) {
+		cmd := newCmd()
+		_ = cmd.Flags().Set("s3-driver", "bogus")
+		_, err := buildScenarioParams("mock", cmd)
+		if err == nil {
+			t.Fatal("expected validation error")
+		}
+		if !strings.Contains(err.Error(), "invalid --s3-driver") {
+			t.Errorf("expected validation message, got: %v", err)
+		}
+	})
 }

--- a/cli/docs/SPT_SYNTAX.md
+++ b/cli/docs/SPT_SYNTAX.md
@@ -40,6 +40,7 @@ You can use these variables to avoid repeating sensitive or commonly used parame
 - **Docker:** `SPT_SKIP_IMAGE_PULL` (skip pulling the engine image)
 - **Engine tuning:** `SPT_SERVICE_THREADS` (virtual-thread carrier parallelism)
 - **Multipart upload:** `SPT_PART_SIZE` (part size, e.g. `64MB`)
+- **Storage driver:** `SPT_S3_DRIVER` (driver backend: `default`, `aws`, `rdma`)
 - **RDMA:** `SPT_RDMA_ENABLED`, `RDMA_LOCAL_IP`, `RDMA_DEVICE`, `RDMA_LOG_LEVEL`, `RDMA_THRESHOLD_BYTES`, `RDMA_TIMEOUT_MS`, `RDMA_FALLBACK_ENABLED`
 
 Variable expansion: use `$VAR` or `${VAR}`. Command substitutions like `$(pwd)` are not supported; use `$PWD` instead.
@@ -135,7 +136,28 @@ Required for S3 workloads, optional/ignored for `mock`.
 | `--rmi-port-start` | `40000` | Starting port for RMI range |
 | `--rmi-port-count` | `10` | Number of RMI ports to allocate |
 
-#### 6. RDMA Acceleration Options
+#### 6. Storage Driver Selection
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--s3-driver` | `default` | S3 storage driver backend (see below) |
+
+Available driver values:
+
+| Value | Engine driver | Description |
+|-------|---------------|-------------|
+| `default` | `s3` (Netty) | The standard REST/Netty-based S3 driver. Default for all workloads |
+| `netty` | `s3` (Netty) | Alias for `default` |
+| `aws` | `s3-aws` | AWS SDK v2 synchronous client. Useful for compatibility testing or environments where the Netty driver is not suitable |
+| `rdma` | `s3-rdma` | RDMA-accelerated S3 driver. Equivalent to `--use-rdma` |
+
+**Flag interaction with `--use-rdma`:**
+
+- `--use-rdma` remains the primary way to enable RDMA and is equivalent to `--s3-driver rdma`.
+- If both `--s3-driver` and `--use-rdma` are specified, they must agree — `--s3-driver rdma --use-rdma` is fine, but `--s3-driver aws --use-rdma` is an error.
+- When `--s3-driver rdma` is used, the RDMA acceleration flags (below) apply normally.
+
+#### 7. RDMA Acceleration Options
 
 See [S3_RDMA.md](S3_RDMA.md) for detailed documentation, architecture, and troubleshooting.
 
@@ -149,7 +171,7 @@ See [S3_RDMA.md](S3_RDMA.md) for detailed documentation, architecture, and troub
 | `--rdma-log-level` | `WARN` | RDMA native library log level |
 | `--rdma-timeout-ms` | `30000` | RDMA operation timeout in milliseconds |
 
-#### 7. S3 Tables Options
+#### 8. S3 Tables Options
 
 These flags apply only to the `tables` workload type. See [S3_TABLES.md](S3_TABLES.md) for detailed documentation.
 
@@ -170,7 +192,7 @@ These flags apply only to the `tables` workload type. See [S3_TABLES.md](S3_TABL
 | `--compaction-timeout` | `4h` | Max wait for compaction to complete |
 | `--no-provision` | `false` | Skip table bucket/namespace/table creation |
 
-#### 8. TUI / Headless Options
+#### 9. TUI / Headless Options
 
 By default, `spt run` launches an interactive TUI. Use `--headless` for CI or unattended runs.
 
@@ -404,6 +426,22 @@ spt run write \
     --use-rdma \
     --rdma-local-ip 10.247.128.125 \
     --rdma-threshold 1MB
+```
+
+### AWS SDK Driver
+
+```bash
+# Write using the AWS SDK driver instead of the default Netty driver
+spt run write \
+    --endpoints https://s3.example.com \
+    --access-key "$S3_ACCESS_KEY" \
+    --secret-key "$S3_SECRET_KEY" \
+    --bucket benchmark-test \
+    --threads 16 \
+    --object-size 1MB \
+    --duration 5m \
+    --s3-driver aws \
+    --cleanup
 ```
 
 ### Distributed / Attach Mode

--- a/cli/internal/constants/envvars.go
+++ b/cli/internal/constants/envvars.go
@@ -11,6 +11,7 @@ const (
 	EnvS3AuthVersion  = "S3_AUTH_VERSION"
 	EnvSkipImagePull  = "SPT_SKIP_IMAGE_PULL"
 	EnvRdmaEnabled    = "SPT_RDMA"
+	EnvS3Driver       = "SPT_S3_DRIVER"
 	EnvServiceThreads = "SPT_SERVICE_THREADS"
 
 	// Multipart upload configuration

--- a/cli/internal/scenario/constants.go
+++ b/cli/internal/scenario/constants.go
@@ -8,8 +8,19 @@ const (
 	workloadTypeTables = "tables"
 
 	storageDriverTypeS3       = "s3"
+	storageDriverTypeS3Aws    = "s3-aws"
 	storageDriverTypeS3Rdma   = "s3-rdma"
 	storageDriverTypeS3Tables = "s3-tables"
+
+	// S3DriverDefault selects the standard Netty-based S3 driver.
+	S3DriverDefault = "default"
+	// S3DriverNetty is an alias for S3DriverDefault.
+	S3DriverNetty = "netty"
+	// S3DriverAws selects the AWS SDK S3 driver.
+	S3DriverAws = "aws"
+	// S3DriverRdma selects the RDMA-accelerated S3 driver.
+	S3DriverRdma = "rdma"
+
 	itemTypeData              = "data"
 	itemTypePath              = "path"
 	itemNamingTypeRandom      = "random"

--- a/cli/internal/scenario/constants.go
+++ b/cli/internal/scenario/constants.go
@@ -21,11 +21,11 @@ const (
 	// S3DriverRdma selects the RDMA-accelerated S3 driver.
 	S3DriverRdma = "rdma"
 
-	itemTypeData              = "data"
-	itemTypePath              = "path"
-	itemNamingTypeRandom      = "random"
-	loadOpTypeNoop            = "noop"
-	loadOpTypeList            = "list"
+	itemTypeData         = "data"
+	itemTypePath         = "path"
+	itemNamingTypeRandom = "random"
+	loadOpTypeNoop       = "noop"
+	loadOpTypeList       = "list"
 
 	metricsAveragePeriodFiveSeconds = "5s"
 

--- a/cli/internal/scenario/defaults.go
+++ b/cli/internal/scenario/defaults.go
@@ -301,10 +301,14 @@ func GenerateDefaults(params Params) ([]byte, error) {
 			Auth: AuthConfig{UID: params.AccessKey, Secret: params.SecretKey, Version: authVersion},
 		}
 
-		// RDMA acceleration: override driver type and populate rdma config section
-		if params.UseRdma {
-			config.Storage.Driver.Type = storageDriverTypeS3Rdma
+		// S3 driver selection: set driver type for non-default drivers
+		driverType := resolveStorageDriverType(params.S3Driver)
+		if driverType != storageDriverTypeS3 {
+			config.Storage.Driver.Type = driverType
+		}
 
+		// RDMA acceleration: populate rdma config section when using s3-rdma driver
+		if params.S3Driver == S3DriverRdma {
 			threshold := params.RdmaThresholdBytes
 			device := params.RdmaDevice
 			if device == "" {

--- a/cli/internal/scenario/defaults_test.go
+++ b/cli/internal/scenario/defaults_test.go
@@ -311,7 +311,7 @@ func TestGenerateDefaults(t *testing.T) {
 				SecretKey:          "testsecret",
 				Bucket:             "testbucket",
 				Threads:            4,
-				UseRdma:            true,
+				S3Driver:           S3DriverRdma,
 				RdmaFallback:       true,
 				RdmaThresholdBytes: 1048576, // Cobra default
 				RdmaTimeoutMs:      30000,   // Cobra default
@@ -355,7 +355,7 @@ func TestGenerateDefaults(t *testing.T) {
 				SecretKey:          "testsecret",
 				Bucket:             "testbucket",
 				Threads:            4,
-				UseRdma:            true,
+				S3Driver:           S3DriverRdma,
 				RdmaFallback:       true,
 				RdmaThresholdBytes: 0,     // explicit zero — force RDMA for all sizes
 				RdmaTimeoutMs:      30000, // Cobra default
@@ -388,7 +388,7 @@ func TestGenerateDefaults(t *testing.T) {
 				SecretKey:          "testsecret",
 				Bucket:             "testbucket",
 				Threads:            16,
-				UseRdma:            true,
+				S3Driver:           S3DriverRdma,
 				RdmaLocalIP:        "10.247.128.125",
 				RdmaThresholdBytes: 4194304,
 				RdmaFallback:       false,
@@ -467,7 +467,7 @@ func TestGenerateDefaults(t *testing.T) {
 				SecretKey:    "secret",
 				Bucket:       "listbucket",
 				Threads:      4,
-				UseRdma:      true,
+				S3Driver:     S3DriverRdma,
 				RdmaFallback: true,
 			},
 			wantErr: false,
@@ -487,11 +487,11 @@ func TestGenerateDefaults(t *testing.T) {
 			},
 		},
 		{
-			name: "Mock workload ignores UseRdma",
+			name: "Mock workload ignores S3Driver",
 			params: Params{
 				WorkloadType: "mock",
 				Threads:      4,
-				UseRdma:      true, // should be ignored for mock workloads
+				S3Driver:     S3DriverRdma, // should be ignored for mock workloads
 			},
 			wantErr: false,
 			checkOutput: func(t *testing.T, data []byte) {
@@ -505,6 +505,55 @@ func TestGenerateDefaults(t *testing.T) {
 				}
 				if config.Storage.Rdma != nil {
 					t.Error("Mock workload should not have storage.rdma section")
+				}
+			},
+		},
+		{
+			name: "S3 write with AWS driver",
+			params: Params{
+				WorkloadType: "write",
+				Endpoint:     "http://minio:9000",
+				AccessKey:    "testkey",
+				SecretKey:    "testsecret",
+				Bucket:       "testbucket",
+				Threads:      4,
+				S3Driver:     S3DriverAws,
+			},
+			wantErr: false,
+			checkOutput: func(t *testing.T, data []byte) {
+				t.Helper()
+				var config DefaultsConfig
+				if err := yaml.Unmarshal(data, &config); err != nil {
+					t.Fatalf("Failed to unmarshal YAML: %v", err)
+				}
+				if config.Storage.Driver.Type != "s3-aws" {
+					t.Errorf("Expected driver type 's3-aws', got %q", config.Storage.Driver.Type)
+				}
+				if config.Storage.Rdma != nil {
+					t.Error("AWS driver should not have storage.rdma section")
+				}
+			},
+		},
+		{
+			name: "S3 write with default driver omits driver type",
+			params: Params{
+				WorkloadType: "write",
+				Endpoint:     "http://minio:9000",
+				AccessKey:    "testkey",
+				SecretKey:    "testsecret",
+				Bucket:       "testbucket",
+				Threads:      4,
+				S3Driver:     S3DriverDefault,
+			},
+			wantErr: false,
+			checkOutput: func(t *testing.T, data []byte) {
+				t.Helper()
+				var config DefaultsConfig
+				if err := yaml.Unmarshal(data, &config); err != nil {
+					t.Fatalf("Failed to unmarshal YAML: %v", err)
+				}
+				if config.Storage.Driver.Type != "" {
+					t.Errorf("Default driver should omit type, got %q", config.Storage.Driver.Type)
 				}
 			},
 		},

--- a/cli/internal/scenario/generator.go
+++ b/cli/internal/scenario/generator.go
@@ -39,10 +39,7 @@ func GenerateWriteScenario(params Params) (string, error) {
 	ts := resolveTimestamp(params)
 
 	// Determine storage driver type
-	driverType := storageDriverTypeS3
-	if params.UseRdma {
-		driverType = storageDriverTypeS3Rdma
-	}
+	driverType := resolveStorageDriverType(params.S3Driver)
 
 	// Format strings as quoted JavaScript literals
 	data := map[string]interface{}{
@@ -108,10 +105,7 @@ func GenerateReadScenario(params Params) (string, error) {
 
 	ts := resolveTimestamp(params)
 
-	driverType := storageDriverTypeS3
-	if params.UseRdma {
-		driverType = storageDriverTypeS3Rdma
-	}
+	driverType := resolveStorageDriverType(params.S3Driver)
 
 	seedCount := params.SeedCount
 	if seedCount <= 0 {
@@ -209,6 +203,9 @@ func GenerateListScenario(params Params) (string, error) {
 
 	bucketPath := "/" + strings.TrimPrefix(params.Bucket, "/")
 	baseTS := resolveTimestamp(params)
+
+	driverType := resolveStorageDriverType(params.S3Driver)
+
 	opLimit := 0
 	if params.ObjectCount > 0 {
 		opLimit = params.ObjectCount
@@ -241,7 +238,7 @@ func GenerateListScenario(params Params) (string, error) {
 		templateKeyDuration:             durationValue,
 		templateKeyHasPrefix:            hasPrefix,
 		templateKeyPrefix:               prefixValue,
-		templateKeyStorageDriverType:    fmt.Sprintf(`"%s"`, escapeJSONString(storageDriverTypeS3)),
+		templateKeyStorageDriverType:    fmt.Sprintf(`"%s"`, escapeJSONString(driverType)),
 		templateKeyItemType:             fmt.Sprintf(`"%s"`, escapeJSONString(itemTypePath)),
 		templateKeyItemNamingType:       fmt.Sprintf(`"%s"`, escapeJSONString(itemNamingTypeRandom)),
 		templateKeyLoadOpType:           fmt.Sprintf(`"%s"`, escapeJSONString(loadOpTypeList)),

--- a/cli/internal/scenario/generator_test.go
+++ b/cli/internal/scenario/generator_test.go
@@ -1169,8 +1169,8 @@ func TestNoOpLimitInGeneratedScenarios(t *testing.T) {
 	}
 }
 
-// TestStorageDriverType verifies the correct storage driver type (s3 vs s3-rdma)
-// is generated in the JavaScript scenario based on UseRdma flag.
+// TestStorageDriverType verifies the correct storage driver type (s3, s3-aws, s3-rdma)
+// is generated in the JavaScript scenario based on S3Driver field.
 func TestStorageDriverType(t *testing.T) {
 	tests := []struct {
 		name           string
@@ -1198,7 +1198,7 @@ func TestStorageDriverType(t *testing.T) {
 				Threads:      4,
 				ObjectSize:   "1MB",
 				ObjectCount:  100,
-				UseRdma:      true,
+				S3Driver:     S3DriverRdma,
 			},
 			wantDriverType: `"type": "s3-rdma"`,
 		},
@@ -1222,7 +1222,7 @@ func TestStorageDriverType(t *testing.T) {
 				Threads:      8,
 				ObjectSize:   "1MB",
 				Duration:     "30s",
-				UseRdma:      true,
+				S3Driver:     S3DriverRdma,
 			},
 			wantDriverType: `"type": "s3-rdma"`,
 		},
@@ -1244,7 +1244,7 @@ func TestStorageDriverType(t *testing.T) {
 				Bucket:       "bucket",
 				Threads:      2,
 				ObjectSize:   "1MB",
-				UseRdma:      true,
+				S3Driver:     S3DriverRdma,
 			},
 			wantDriverType: `"type": "s3-rdma"`,
 		},
@@ -1270,7 +1270,7 @@ func TestStorageDriverType(t *testing.T) {
 				ObjectSize:   "1MB",
 				ObjectCount:  50,
 				Cleanup:      true,
-				UseRdma:      true,
+				S3Driver:     S3DriverRdma,
 			},
 			wantDriverType: `"type": "s3-rdma"`,
 		},
@@ -1296,9 +1296,35 @@ func TestStorageDriverType(t *testing.T) {
 				ObjectSize:   "1MB",
 				Duration:     "1m",
 				Cleanup:      true,
-				UseRdma:      true,
+				S3Driver:     S3DriverRdma,
 			},
 			wantDriverType: `"type": "s3-rdma"`,
+		},
+		{
+			name: "write count - AWS driver",
+			params: Params{
+				WorkloadType: "write",
+				Bucket:       "bucket",
+				Threads:      4,
+				ObjectSize:   "1MB",
+				ObjectCount:  100,
+				S3Driver:     S3DriverAws,
+			},
+			wantDriverType: `"type": "s3-aws"`,
+			notDriverType:  `"type": "s3-rdma"`,
+		},
+		{
+			name: "write duration - AWS driver",
+			params: Params{
+				WorkloadType: "write",
+				Bucket:       "bucket",
+				Threads:      8,
+				ObjectSize:   "1MB",
+				Duration:     "30s",
+				S3Driver:     S3DriverAws,
+			},
+			wantDriverType: `"type": "s3-aws"`,
+			notDriverType:  `"type": "s3-rdma"`,
 		},
 	}
 
@@ -1320,14 +1346,14 @@ func TestStorageDriverType(t *testing.T) {
 	}
 }
 
-func TestRdmaDoesNotAffectListScenario(t *testing.T) {
-	// List scenarios always use "s3" driver regardless of UseRdma
+func TestListScenarioRespectsS3Driver(t *testing.T) {
+	// List scenarios respect the S3Driver field for driver selection
 	params := Params{
 		WorkloadType: "list",
 		Bucket:       "testbucket",
 		Threads:      4,
 		ObjectCount:  100,
-		UseRdma:      true, // should be ignored for list workloads
+		S3Driver:     S3DriverAws,
 	}
 
 	got, err := GenerateListScenario(params)
@@ -1335,22 +1361,19 @@ func TestRdmaDoesNotAffectListScenario(t *testing.T) {
 		t.Fatalf("GenerateListScenario() error = %v", err)
 	}
 
-	if !strings.Contains(got, `"type": "s3"`) {
-		t.Error("List scenario should always use s3 driver type")
-	}
-	if strings.Contains(got, `"type": "s3-rdma"`) {
-		t.Error("List scenario should never use s3-rdma driver type")
+	if !strings.Contains(got, `"type": "s3-aws"`) {
+		t.Error("List scenario should use s3-aws driver when S3Driver is set to aws")
 	}
 }
 
 func TestRdmaDoesNotAffectMockScenario(t *testing.T) {
-	// Mock scenarios always use "dummy-mock" driver regardless of UseRdma
+	// Mock scenarios always use "dummy-mock" driver regardless of S3Driver
 	params := Params{
 		WorkloadType: "mock",
 		Threads:      2,
 		ObjectSize:   "1KB",
 		ObjectCount:  50,
-		UseRdma:      true, // should be ignored for mock workloads
+		S3Driver:     S3DriverRdma, // should be ignored for mock workloads
 	}
 
 	got, err := GenerateMockScenario(params)
@@ -1367,7 +1390,7 @@ func TestRdmaDoesNotAffectMockScenario(t *testing.T) {
 }
 
 func TestGenerateScenario_RdmaRouting(t *testing.T) {
-	// Verify GenerateScenario routes correctly and UseRdma only affects write
+	// Verify GenerateScenario routes correctly and S3Driver only affects write/read
 	tests := []struct {
 		name          string
 		params        Params
@@ -1382,7 +1405,7 @@ func TestGenerateScenario_RdmaRouting(t *testing.T) {
 				Threads:      1,
 				ObjectSize:   "1MB",
 				ObjectCount:  10,
-				UseRdma:      true,
+				S3Driver:     S3DriverRdma,
 			},
 			wantDriver: `"type": "s3-rdma"`,
 		},
@@ -1399,25 +1422,24 @@ func TestGenerateScenario_RdmaRouting(t *testing.T) {
 			notWantDriver: `"type": "s3-rdma"`,
 		},
 		{
-			name: "list ignores UseRdma",
+			name: "list respects S3Driver rdma",
 			params: Params{
 				WorkloadType: "list",
 				Bucket:       "b",
 				Threads:      1,
 				ObjectCount:  10,
-				UseRdma:      true,
+				S3Driver:     S3DriverRdma,
 			},
-			wantDriver:    `"type": "s3"`,
-			notWantDriver: `"type": "s3-rdma"`,
+			wantDriver: `"type": "s3-rdma"`,
 		},
 		{
-			name: "mock ignores UseRdma",
+			name: "mock ignores S3Driver rdma",
 			params: Params{
 				WorkloadType: "mock",
 				Threads:      1,
 				ObjectSize:   "1KB",
 				ObjectCount:  10,
-				UseRdma:      true,
+				S3Driver:     S3DriverRdma,
 			},
 			wantDriver:    `"type": "dummy-mock"`,
 			notWantDriver: `"type": "s3-rdma"`,
@@ -1655,7 +1677,7 @@ func TestGenerateReadScenario_RDMA(t *testing.T) {
 				ObjectSize:   "1MB",
 				Duration:     "1m",
 				Cleanup:      true,
-				UseRdma:      true,
+				S3Driver:     S3DriverRdma,
 			},
 			wantDriverType: `"type": "s3-rdma"`,
 		},
@@ -1668,7 +1690,7 @@ func TestGenerateReadScenario_RDMA(t *testing.T) {
 				ObjectSize:   "1MB",
 				ObjectCount:  5000,
 				Cleanup:      true,
-				UseRdma:      true,
+				S3Driver:     S3DriverRdma,
 			},
 			wantDriverType: `"type": "s3-rdma"`,
 		},
@@ -1681,9 +1703,23 @@ func TestGenerateReadScenario_RDMA(t *testing.T) {
 				ObjectSize:   "4MB",
 				Duration:     "30s",
 				Cleanup:      false,
-				UseRdma:      true,
+				S3Driver:     S3DriverRdma,
 			},
 			wantDriverType: `"type": "s3-rdma"`,
+		},
+		{
+			name: "read with AWS driver",
+			params: Params{
+				WorkloadType: "read",
+				Bucket:       "bucket",
+				Threads:      4,
+				ObjectSize:   "1MB",
+				Duration:     "1m",
+				Cleanup:      true,
+				S3Driver:     S3DriverAws,
+			},
+			wantDriverType: `"type": "s3-aws"`,
+			notDriverType:  `"type": "s3-rdma"`,
 		},
 	}
 
@@ -2207,7 +2243,7 @@ func TestGenerateReadScenario_FromFile_RDMA(t *testing.T) {
 		Threads:      4,
 		ObjectSize:   "1MB",
 		Duration:     "1m",
-		UseRdma:      true,
+		S3Driver:     S3DriverRdma,
 		ItemsFile:    "/data/items.csv",
 	}
 
@@ -2470,5 +2506,27 @@ func TestGenerateReadScenario_StandardVsFromFile(t *testing.T) {
 	// From-file should reference the provided path
 	if !strings.Contains(fromFile, "/data/items.csv") {
 		t.Error("from-file should reference the items file path")
+	}
+}
+
+func TestResolveStorageDriverType(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"", "s3"},
+		{S3DriverDefault, "s3"},
+		{S3DriverNetty, "s3"},
+		{S3DriverAws, "s3-aws"},
+		{S3DriverRdma, "s3-rdma"},
+		{"unknown-value", "s3"}, // fallback
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := resolveStorageDriverType(tt.input)
+			if got != tt.want {
+				t.Errorf("resolveStorageDriverType(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
 	}
 }

--- a/cli/internal/scenario/types.go
+++ b/cli/internal/scenario/types.go
@@ -31,7 +31,7 @@ type Params struct {
 	SaveItems bool // Save items.csv to the step log directory for later retrieval
 
 	// RDMA acceleration
-	UseRdma            bool   // Use s3-rdma driver instead of s3
+	S3Driver           string // Storage driver selection: "default"/"netty" → s3, "aws" → s3-aws, "rdma" → s3-rdma
 	RdmaLocalIP        string // Local RDMA interface IP (required for RDMA)
 	RdmaThresholdBytes int64  // Min object size for RDMA (default: 1048576)
 	RdmaFallback       bool   // Fall back to HTTP if RDMA init fails (default: false)
@@ -75,3 +75,19 @@ type TablesParams struct {
 //
 //nolint:revive // compatibility alias retained during migration away from stuttered name
 type ScenarioParams = Params
+
+// resolveStorageDriverType maps the user-facing S3Driver value to the engine
+// storage-driver-type string. An empty value (or "default"/"netty") resolves
+// to the standard Netty-based "s3" driver.
+func resolveStorageDriverType(s3Driver string) string {
+	switch s3Driver {
+	case S3DriverAws:
+		return storageDriverTypeS3Aws
+	case S3DriverRdma:
+		return storageDriverTypeS3Rdma
+	case S3DriverDefault, S3DriverNetty, "":
+		return storageDriverTypeS3
+	default:
+		return storageDriverTypeS3
+	}
+}

--- a/cli/tools/testlist.sh
+++ b/cli/tools/testlist.sh
@@ -15,6 +15,7 @@ Options:
   --headless                 Run in headless mode (no TUI)
   --prefix VALUE             Optional prefix filter for listings
   --bucket NAME              Target bucket override (default uses S3_BUCKET env)
+  --s3-driver TYPE           Storage driver: default, aws, rdma (env: SPT_S3_DRIVER)
   --auto-terminate-seconds N Stop after N seconds (default: $AUTO_TERMINATE_SECONDS)
   -h, --help                 Show this help and exit
 EOF
@@ -25,6 +26,7 @@ PREFIX=${PREFIX:-""}
 BUCKET=${BUCKET:-${S3_BUCKET:-""}}
 THREADS=${THREADS:-""}
 AUTO_TERMINATE_SECONDS=${AUTO_TERMINATE_SECONDS:-120}
+S3_DRIVER=${SPT_S3_DRIVER:-"default"}
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -46,6 +48,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --auto-terminate-seconds)
       AUTO_TERMINATE_SECONDS="${2:-0}"
+      shift 2
+      ;;
+    --s3-driver)
+      S3_DRIVER="${2:-}"
       shift 2
       ;;
     -h|--help)
@@ -93,9 +99,15 @@ if [[ "$AUTO_TERMINATE_SECONDS" =~ ^[0-9]+$ ]] && [ "$AUTO_TERMINATE_SECONDS" -g
   CMD+=(--auto-terminate-seconds "$AUTO_TERMINATE_SECONDS")
 fi
 
+# Storage driver (only pass when non-default to avoid requiring the flag on older builds)
+if [[ "$S3_DRIVER" != "default" ]]; then
+  CMD+=(--s3-driver "$S3_DRIVER")
+fi
+
 [[ -n "$PREFIX" ]] && echo "Prefix: $PREFIX"
 [[ -n "$BUCKET" ]] && echo "Bucket: $BUCKET"
 [[ -n "$THREADS" ]] && echo "Threads: $THREADS"
+[[ "$S3_DRIVER" != "default" ]] && echo "S3 Driver: $S3_DRIVER"
 if [[ "$AUTO_TERMINATE_SECONDS" =~ ^[0-9]+$ ]] && [ "$AUTO_TERMINATE_SECONDS" -gt 0 ]; then
   echo "Auto-terminate: ${AUTO_TERMINATE_SECONDS}s"
 fi

--- a/cli/tools/testlocal.headless.sh
+++ b/cli/tools/testlocal.headless.sh
@@ -28,10 +28,14 @@ CLEANUP=${CLEANUP:-true}
 MOCK=${MOCK:-false}
 USE_RDMA=${USE_RDMA:-false}
 
+# Storage driver selection (default, netty, aws, rdma)
+S3_DRIVER=${SPT_S3_DRIVER:-"default"}
+
 while [ $# -gt 0 ]; do
   case "$1" in
     --mock) MOCK=true; shift 1 ;;
     --use-rdma) USE_RDMA=true; shift 1 ;;
+    --s3-driver) S3_DRIVER="${2:-}"; [ "$S3_DRIVER" = "rdma" ] && USE_RDMA=true; shift 2 ;;
     --s3-endpoint) S3_ENDPOINT="${2:-}"; shift 2 ;;
     --s3-endpoints) S3_ENDPOINTS="${2:-}"; shift 2 ;;
     --s3-access-key) S3_ACCESS_KEY="${2:-}"; shift 2 ;;
@@ -52,6 +56,7 @@ while [ $# -gt 0 ]; do
 Usage: $(basename "$0") [options]  (headless)
   --mock                   Run a mock workload (no S3 endpoint required)
   --use-rdma               Enable RDMA device passthrough in containers
+  --s3-driver TYPE         Storage driver: default, aws, rdma (env: SPT_S3_DRIVER, default: $S3_DRIVER)
   --s3-endpoint URL        Single S3 endpoint (env: S3_ENDPOINT)
   --s3-endpoints CSV       Multiple S3 endpoints (env: S3_ENDPOINTS)
   --s3-access-key KEY      S3 access key (env: S3_ACCESS_KEY)
@@ -97,6 +102,9 @@ else
   RUN_SPEC="ObjectCount: $OBJECT_COUNT"
 fi
 echo "Threads: $THREADS  ObjectSize: $OBJECT_SIZE  $RUN_SPEC"
+if [ "$S3_DRIVER" != "default" ]; then
+  echo "S3 Driver: $S3_DRIVER"
+fi
 if $USE_RDMA; then
   echo "RDMA:    enabled (SPT_RDMA=true)"
   [[ -n "${SPT_IMAGE:-}" ]] && echo "Image:   $SPT_IMAGE"
@@ -119,6 +127,11 @@ else
   else
     cmd+=(--endpoint "$S3_ENDPOINT")
   fi
+fi
+
+# Storage driver (only pass when non-default to avoid requiring the flag on older builds)
+if [ "$S3_DRIVER" != "default" ]; then
+  cmd+=(--s3-driver "$S3_DRIVER")
 fi
 
 if [ -n "$DURATION" ]; then

--- a/cli/tools/testlocal.sh
+++ b/cli/tools/testlocal.sh
@@ -29,10 +29,14 @@ KEEP_SCENARIO=${KEEP_SCENARIO:-true}
 MOCK=${MOCK:-false}
 USE_RDMA=${USE_RDMA:-false}
 
+# Storage driver selection (default, netty, aws, rdma)
+S3_DRIVER=${SPT_S3_DRIVER:-"default"}
+
 while [ $# -gt 0 ]; do
   case "$1" in
     --mock) MOCK=true; shift 1 ;;
     --use-rdma) USE_RDMA=true; shift 1 ;;
+    --s3-driver) S3_DRIVER="${2:-}"; [ "$S3_DRIVER" = "rdma" ] && USE_RDMA=true; shift 2 ;;
     --s3-endpoint) S3_ENDPOINT="${2:-}"; shift 2 ;;
     --s3-endpoints) S3_ENDPOINTS="${2:-}"; shift 2 ;;
     --s3-access-key) S3_ACCESS_KEY="${2:-}"; shift 2 ;;
@@ -55,6 +59,7 @@ while [ $# -gt 0 ]; do
 Usage: $(basename "$0") [options]
   --mock                   Run a mock workload (no S3 endpoint required)
   --use-rdma               Enable RDMA device passthrough in containers
+  --s3-driver TYPE         Storage driver: default, aws, rdma (env: SPT_S3_DRIVER, default: $S3_DRIVER)
   --s3-endpoint URL        Single S3 endpoint (env: S3_ENDPOINT)
   --s3-endpoints CSV       Multiple S3 endpoints (env: S3_ENDPOINTS)
   --s3-access-key KEY      S3 access key (env: S3_ACCESS_KEY)
@@ -101,6 +106,9 @@ else
   RUN_SPEC="ObjectCount: $OBJECT_COUNT"
 fi
 echo "Threads: $THREADS  ObjectSize: $OBJECT_SIZE  $RUN_SPEC"
+if [ "$S3_DRIVER" != "default" ]; then
+  echo "S3 Driver: $S3_DRIVER"
+fi
 if $USE_RDMA; then
   echo "RDMA:    enabled (SPT_RDMA=true)"
   [[ -n "${SPT_IMAGE:-}" ]] && echo "Image:   $SPT_IMAGE"
@@ -123,6 +131,11 @@ else
   else
     cmd+=(--endpoint "$S3_ENDPOINT")
   fi
+fi
+
+# Storage driver (only pass when non-default to avoid requiring the flag on older builds)
+if [ "$S3_DRIVER" != "default" ]; then
+  cmd+=(--s3-driver "$S3_DRIVER")
 fi
 
 if [ -n "$DURATION" ]; then

--- a/cli/tools/testmulti.headless.sh
+++ b/cli/tools/testmulti.headless.sh
@@ -25,6 +25,9 @@ MOCK=${MOCK:-false}
 AUTO_TERMINATE_SECONDS=${AUTO_TERMINATE_SECONDS:-0}
 ATTACH_EXISTING=${ATTACH_EXISTING:-false}
 
+# Storage driver selection (default, netty, aws, rdma)
+S3_DRIVER=${SPT_S3_DRIVER:-"default"}
+
 while [ $# -gt 0 ]; do
   case "$1" in
     --mock) MOCK=true; shift 1 ;;
@@ -49,6 +52,7 @@ while [ $# -gt 0 ]; do
     --no-keep-scenario) KEEP_SCENARIO=false; shift 1 ;;
     --attach-existing) ATTACH_EXISTING=true; shift 1 ;;
     --no-attach-existing) ATTACH_EXISTING=false; shift 1 ;;
+    --s3-driver) S3_DRIVER="${2:-}"; shift 2 ;;
     -h|--help)
       cat << EOF
 Usage: $(basename "$0") [options]  (headless)
@@ -69,6 +73,7 @@ Usage: $(basename "$0") [options]  (headless)
   --[no-]cleanup           delete created objects (default: $CLEANUP)
   --[no-]keep-scenario     keep generated scenario (default: $KEEP_SCENARIO)
   --[no-]attach-existing   reuse prestarted worker nodes (default: $ATTACH_EXISTING)
+  --s3-driver TYPE         Storage driver: default, aws, rdma (env: SPT_S3_DRIVER, default: $S3_DRIVER)
 
 Tips:
   - Target multiple endpoints with --s3-endpoints or env S3_ENDPOINTS.
@@ -98,6 +103,9 @@ else
   RUN_SPEC="ObjectCount: $OBJECT_COUNT"
 fi
 echo "Threads: $THREADS  ObjectSize: $OBJECT_SIZE  $RUN_SPEC"
+if [ "$S3_DRIVER" != "default" ]; then
+  echo "S3 Driver: $S3_DRIVER"
+fi
 if [[ "$AUTO_TERMINATE_SECONDS" =~ ^[0-9]+$ ]] && [ "$AUTO_TERMINATE_SECONDS" -gt 0 ]; then
   echo "Auto-terminate: ${AUTO_TERMINATE_SECONDS}s"
 fi
@@ -121,6 +129,11 @@ else
   else
     cmd+=(--endpoint "$S3_ENDPOINT")
   fi
+fi
+
+# Storage driver (only pass when non-default to avoid requiring the flag on older builds)
+if [ "$S3_DRIVER" != "default" ]; then
+  cmd+=(--s3-driver "$S3_DRIVER")
 fi
 
 if [ -n "$DURATION" ]; then

--- a/cli/tools/testmulti.sh
+++ b/cli/tools/testmulti.sh
@@ -42,6 +42,9 @@ AUTO_TERMINATE_SECONDS=${AUTO_TERMINATE_SECONDS:-0}
 ATTACH_EXISTING=${ATTACH_EXISTING:-false}
 MIN_HOSTS=${MIN_HOSTS:-0}
 
+# Storage driver selection (default, netty, aws, rdma)
+S3_DRIVER=${SPT_S3_DRIVER:-"default"}
+
 # Simple arg parsing (overrides env)
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -68,6 +71,7 @@ while [ $# -gt 0 ]; do
     --min-hosts) MIN_HOSTS="${2:-0}"; shift 2 ;;
     --attach-existing) ATTACH_EXISTING=true; shift 1 ;;
     --no-attach-existing) ATTACH_EXISTING=false; shift 1 ;;
+    --s3-driver) S3_DRIVER="${2:-}"; shift 2 ;;
     -h|--help)
       cat << EOF
 Usage: $(basename "$0") [options]
@@ -89,6 +93,7 @@ Usage: $(basename "$0") [options]
   --[no-]cleanup           delete created objects (default: $CLEANUP)
   --[no-]keep-scenario     keep generated scenario (default: $KEEP_SCENARIO)
   --[no-]attach-existing   reuse prestarted worker nodes (default: $ATTACH_EXISTING)
+  --s3-driver TYPE         Storage driver: default, aws, rdma (env: SPT_S3_DRIVER, default: $S3_DRIVER)
 
 Tips:
   - Target multiple endpoints with --s3-endpoints or env S3_ENDPOINTS.
@@ -118,6 +123,9 @@ else
   RUN_SPEC="ObjectCount: $OBJECT_COUNT"
 fi
 echo "Threads: $THREADS  ObjectSize: $OBJECT_SIZE  $RUN_SPEC"
+if [ "$S3_DRIVER" != "default" ]; then
+  echo "S3 Driver: $S3_DRIVER"
+fi
 if [[ "$AUTO_TERMINATE_SECONDS" =~ ^[0-9]+$ ]] && [ "$AUTO_TERMINATE_SECONDS" -gt 0 ]; then
   echo "Auto-terminate: ${AUTO_TERMINATE_SECONDS}s"
 fi
@@ -141,6 +149,11 @@ else
   else
     cmd+=(--endpoint "$S3_ENDPOINT")
   fi
+fi
+
+# Storage driver (only pass when non-default to avoid requiring the flag on older builds)
+if [ "$S3_DRIVER" != "default" ]; then
+  cmd+=(--s3-driver "$S3_DRIVER")
 fi
 
 if [ -n "$DURATION" ]; then

--- a/cli/tools/testrdma.sh
+++ b/cli/tools/testrdma.sh
@@ -30,6 +30,9 @@ CLEANUP=${CLEANUP:-true}
 KEEP_SCENARIO=${KEEP_SCENARIO:-true}
 ATTACH_EXISTING=${ATTACH_EXISTING:-false}
 
+# Storage driver selection (default, netty, aws, rdma)
+S3_DRIVER=${SPT_S3_DRIVER:-"default"}
+
 # RDMA-specific settings (from env or defaults)
 RDMA_FALLBACK=${RDMA_FALLBACK_ENABLED:-false}
 RDMA_THRESHOLD=${RDMA_THRESHOLD_BYTES:-1048576}
@@ -62,6 +65,7 @@ while [ $# -gt 0 ]; do
     --no-keep-scenario) KEEP_SCENARIO=false; shift 1 ;;
     --attach-existing) ATTACH_EXISTING=true; shift 1 ;;
     --no-attach-existing) ATTACH_EXISTING=false; shift 1 ;;
+    --s3-driver) S3_DRIVER="${2:-}"; shift 2 ;;
     --rdma-fallback) RDMA_FALLBACK=true; shift 1 ;;
     --no-rdma-fallback) RDMA_FALLBACK=false; shift 1 ;;
     --rdma-threshold) RDMA_THRESHOLD="${2:-}"; shift 2 ;;
@@ -89,6 +93,9 @@ Workload:
   --duration DUR           e.g. 30s, 5m (default: $DURATION)
   --object-count N         Operations; only used if --duration is empty
   --min-hosts N            Minimum hosts required (default: $MIN_HOSTS)
+
+Driver:
+  --s3-driver TYPE         Storage driver: default, aws, rdma (env: SPT_S3_DRIVER, default: $S3_DRIVER)
 
 RDMA:
   --[no-]rdma-fallback     Fall back to HTTP on RDMA failure (default: $RDMA_FALLBACK)
@@ -130,6 +137,9 @@ else
   RUN_SPEC="ObjectCount: ${OBJECT_COUNT:-1000}"
 fi
 echo "Threads: $THREADS  ObjectSize: $OBJECT_SIZE  $RUN_SPEC"
+if [ "$S3_DRIVER" != "default" ]; then
+  echo "S3 Driver: $S3_DRIVER"
+fi
 echo "RDMA: fallback=$RDMA_FALLBACK  threshold=$RDMA_THRESHOLD  device=$RDMA_DEVICE"
 echo
 
@@ -152,6 +162,11 @@ if [ -n "$S3_ENDPOINTS" ]; then
   cmd+=(--endpoints "$S3_ENDPOINTS")
 elif [ -n "$S3_ENDPOINT" ]; then
   cmd+=(--endpoint "$S3_ENDPOINT")
+fi
+
+# Storage driver (only pass when non-default to avoid requiring the flag on older builds)
+if [ "$S3_DRIVER" != "default" ]; then
+  cmd+=(--s3-driver "$S3_DRIVER")
 fi
 
 if [ -n "$DURATION" ]; then

--- a/cli/tools/testread.sh
+++ b/cli/tools/testread.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 #
 # Seeds 1000 objects then reads them for 60 seconds (by default).
 # RDMA is off by default; pass --use-rdma to enable.
+# Storage driver is selectable via --s3-driver (default, aws, rdma).
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")"/.. && pwd)"
 [ -f "$ROOT_DIR/.env" ] && source "$ROOT_DIR/.env"
@@ -27,6 +28,9 @@ FORCE=${FORCE:-true}
 CLEANUP=${CLEANUP:-true}
 KEEP_SCENARIO=${KEEP_SCENARIO:-true}
 ATTACH_EXISTING=${ATTACH_EXISTING:-false}
+
+# Storage driver selection (default, netty, aws, rdma)
+S3_DRIVER=${SPT_S3_DRIVER:-"default"}
 
 # RDMA (off by default; pass --use-rdma to enable)
 USE_RDMA=${USE_RDMA:-false}
@@ -62,6 +66,7 @@ while [ $# -gt 0 ]; do
     --no-keep-scenario) KEEP_SCENARIO=false; shift 1 ;;
     --attach-existing) ATTACH_EXISTING=true; shift 1 ;;
     --no-attach-existing) ATTACH_EXISTING=false; shift 1 ;;
+    --s3-driver) S3_DRIVER="${2:-}"; [ "$S3_DRIVER" = "rdma" ] && USE_RDMA=true; shift 2 ;;
     --use-rdma) USE_RDMA=true; shift 1 ;;
     --no-rdma) USE_RDMA=false; shift 1 ;;
     --rdma-fallback) RDMA_FALLBACK=true; shift 1 ;;
@@ -94,6 +99,9 @@ Workload:
   --object-count N         Read ops; only used if --duration is empty
   --min-hosts N            Minimum hosts required (default: $MIN_HOSTS)
 
+Driver:
+  --s3-driver TYPE         Storage driver: default, aws, rdma (env: SPT_S3_DRIVER, default: $S3_DRIVER)
+
 RDMA:
   --use-rdma               Enable RDMA-accelerated S3 driver (default: off)
   --no-rdma                Disable RDMA (default)
@@ -113,6 +121,7 @@ General:
 
 Examples:
   $(basename "$0")                                     # 2500 seed, 60s read, HTTP
+  $(basename "$0") --s3-driver aws                     # use AWS SDK driver
   $(basename "$0") --use-rdma --rdma-threshold 0       # RDMA for all sizes
   $(basename "$0") --seed-objects 5000 --duration 5m   # larger seed, longer read
   $(basename "$0") --no-cleanup                        # keep seed data for reuse
@@ -137,6 +146,9 @@ else
   RUN_SPEC="ObjectCount: ${OBJECT_COUNT:-1000}"
 fi
 echo "Threads: $THREADS  ObjectSize: $OBJECT_SIZE  SeedObjects: $SEED_OBJECTS  $RUN_SPEC"
+if [ "$S3_DRIVER" != "default" ]; then
+  echo "S3 Driver: $S3_DRIVER"
+fi
 if $USE_RDMA; then
   echo "RDMA: enabled  fallback=$RDMA_FALLBACK  threshold=$RDMA_THRESHOLD  device=$RDMA_DEVICE"
 else
@@ -159,6 +171,11 @@ if [ -n "$S3_ENDPOINTS" ]; then
   cmd+=(--endpoints "$S3_ENDPOINTS")
 elif [ -n "$S3_ENDPOINT" ]; then
   cmd+=(--endpoint "$S3_ENDPOINT")
+fi
+
+# Storage driver (only pass when non-default to avoid requiring the flag on older builds)
+if [ "$S3_DRIVER" != "default" ]; then
+  cmd+=(--s3-driver "$S3_DRIVER")
 fi
 
 if [ -n "$DURATION" ]; then

--- a/engine/README.md
+++ b/engine/README.md
@@ -89,6 +89,37 @@ run.bat --version     # Windows
   --load-op-limit-count=1000
 ```
 
+### Selecting a Storage Driver
+
+SPT supports multiple S3 storage driver backends. Use `--storage-driver-type` to select one:
+
+| Value | Description |
+|-------|-------------|
+| `s3` | Default Netty/REST-based S3 driver |
+| `s3-aws` | AWS SDK v2 synchronous client |
+| `s3-rdma` | RDMA-accelerated S3 driver (requires RDMA hardware) |
+
+```bash
+# Write test using the AWS SDK driver
+./run.sh \
+  --storage-driver-type=s3-aws \
+  --storage-net-node-addrs=your-s3-endpoint.com:9020 \
+  --storage-auth-uid=your-access-key \
+  --storage-auth-secret=your-secret-key \
+  --item-data-size=1MB \
+  --load-op-limit-count=1000
+
+# Read test using the AWS SDK driver
+./run.sh \
+  --storage-driver-type=s3-aws \
+  --storage-net-node-addrs=your-s3-endpoint.com:9020 \
+  --storage-auth-uid=your-access-key \
+  --storage-auth-secret=your-secret-key \
+  --load-op-type=read \
+  --item-input-file=items.csv \
+  --load-op-limit-count=500
+```
+
 Note: Extensions are loaded from the `ext/` directory next to `spt.jar`.
 
 ### Common Command-Line Options
@@ -142,6 +173,13 @@ make docker
 # Run a simple test
 docker run --rm ghcr.io/dell/storage-performance-tool:latest \
   --storage-driver-type=s3 \
+  --storage-net-node-addrs=your-s3-endpoint.com \
+  --storage-auth-uid=your-access-key \
+  --storage-auth-secret=your-secret-key
+
+# Run using the AWS SDK driver
+docker run --rm ghcr.io/dell/storage-performance-tool:latest \
+  --storage-driver-type=s3-aws \
   --storage-net-node-addrs=your-s3-endpoint.com \
   --storage-auth-uid=your-access-key \
   --storage-auth-secret=your-secret-key


### PR DESCRIPTION
Summary

  • Add --s3-driver CLI flag (and SPT_S3_DRIVER env var) to select between the default Netty-based S3 driver (s3) and the new AWS SDK driver (s3-aws) at runtime
  • Wire the flag through scenario generation so the engine receives the correct storage.driver.type config value
  • Add --s3-driver / SPT_S3_DRIVER support to all test wrapper scripts (testread.sh, testlist.sh, testlocal.sh, testlocal.headless.sh, testmulti.sh,
  testmulti.headless.sh, testrdma.sh)
  • Document the flag in CLI syntax reference and engine README

Details

The driver defaults to s3 (Netty) when unset, preserving existing behavior. Valid values are s3 and s3-aws. Invalid values are rejected at startup.

Scenario generation passes the selected driver through to the engine config via the existing storage.driver.type path.

Test plan

  • [x] New unit tests for env var parsing (envdefaults_test.go)
  • [x] New/updated scenario generation tests (generator_test.go, defaults_test.go, run_scenario_test.go)
