### PR TITLE
Classify s3-aws failures and log exceptions

### DIFF
--- a/engine/extensions/storage-drivers/implementations/s3-aws/src/main/java/com/dell/spt/storage/driver/coop/aws/s3/S3AwsStorageDriver.java
+++ b/engine/extensions/storage-drivers/implementations/s3-aws/src/main/java/com/dell/spt/storage/driver/coop/aws/s3/S3AwsStorageDriver.java
@@ -25,9 +25,13 @@ import java.nio.file.Path;
 
 import java.io.IOException;
 import java.nio.channels.Channels;
+import java.util.concurrent.TimeoutException;
+import software.amazon.awssdk.core.exception.ApiCallAttemptTimeoutException;
+import software.amazon.awssdk.core.exception.ApiCallTimeoutException;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.*;
-import software.amazon.awssdk.core.sync.RequestBody;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -70,6 +74,7 @@ public class S3AwsStorageDriver<I extends Item, O extends Operation<I>> extends 
 	 * 4. System username + "test" (fallback)
 	 */
 	static String resolveBucketName(final Config config) {
+		final Logger log = LoggerFactory.getLogger(S3AwsStorageDriver.class);
 		String resolved = null;
 
 		try {
@@ -81,7 +86,9 @@ public class S3AwsStorageDriver<I extends Item, O extends Operation<I>> extends 
 					resolved = nodeAddrs;
 				}
 			}
-		} catch (Exception ignored) {}
+		} catch (Exception e) {
+			log.debug("Could not read storage-net-node-addrs from config: {}", e.toString());
+		}
 
 		if (resolved == null) {
 			try {
@@ -96,10 +103,14 @@ public class S3AwsStorageDriver<I extends Item, O extends Operation<I>> extends 
 							if (inputPath != null && inputPath.startsWith("/") && inputPath.length() > 1) {
 								resolved = inputPath.substring(1);
 							}
-						} catch (Exception ignored) {}
+						} catch (Exception e) {
+							log.debug("Could not read item.input-path from config: {}", e.toString());
+						}
 					}
 				}
-			} catch (Exception ignored) {}
+			} catch (Exception e) {
+				log.debug("Could not read item config: {}", e.toString());
+			}
 		}
 
 		if (resolved == null || resolved.isEmpty()) {
@@ -126,16 +137,40 @@ public class S3AwsStorageDriver<I extends Item, O extends Operation<I>> extends 
 			finishOperation(op);
 
 		} catch (Exception e) {
-			// For failed operations, still need to properly complete timing.
-			// finishOperation must NOT run here — it would mark the op as SUCC.
-			op.status(Status.FAIL_UNKNOWN);
+			op.status(classifyFailure(e));
+			LOG.debug("{} {} failed: {}", op.type(), op.item().name(), e.toString());
+			LOG.trace("{} {} stack trace", op.type(), op.item().name(), e);
 			try {
 				op.startResponse();
 				op.finishResponse();
-			} catch (Exception ignored) {
-				// Ignore timing errors on failed operations
+			} catch (Exception ignored) {}
+		}
+	}
+
+	/**
+	 * Map an exception to the most specific Operation.Status failure code.
+	 */
+	static Status classifyFailure(final Exception e) {
+		if (e instanceof S3Exception) {
+			final int statusCode = ((S3Exception) e).statusCode();
+			if (statusCode == 401 || statusCode == 403) {
+				return Status.RESP_FAIL_AUTH;
+			} else if (statusCode == 404) {
+				return Status.RESP_FAIL_NOT_FOUND;
+			} else if (statusCode >= 400 && statusCode < 500) {
+				return Status.RESP_FAIL_CLIENT;
+			} else if (statusCode >= 500) {
+				return Status.RESP_FAIL_SVC;
 			}
 		}
+		if (e instanceof ApiCallTimeoutException || e instanceof ApiCallAttemptTimeoutException
+						|| e instanceof TimeoutException) {
+			return Status.FAIL_TIMEOUT;
+		}
+		if (e instanceof IOException || (e instanceof SdkClientException && e.getCause() instanceof IOException)) {
+			return Status.FAIL_IO;
+		}
+		return Status.FAIL_UNKNOWN;
 	}
 
 	@Override

--- a/engine/extensions/storage-drivers/implementations/s3-aws/src/test/java/com/dell/spt/storage/driver/coop/aws/s3/S3AwsStorageDriverTest.java
+++ b/engine/extensions/storage-drivers/implementations/s3-aws/src/test/java/com/dell/spt/storage/driver/coop/aws/s3/S3AwsStorageDriverTest.java
@@ -1394,4 +1394,106 @@ public class S3AwsStorageDriverTest {
 			assertEquals("inputbucket", S3AwsStorageDriver.resolveBucketName(config));
 		}
 	}
+
+	@Nested
+	class ClassifyFailureTest {
+
+		@Test
+		void s3Exception_401_returnsRespFailAuth() {
+			S3Exception e = (S3Exception) S3Exception.builder()
+							.statusCode(401)
+							.message("Unauthorized")
+							.build();
+			assertEquals(Operation.Status.RESP_FAIL_AUTH, S3AwsStorageDriver.classifyFailure(e));
+		}
+
+		@Test
+		void s3Exception_403_returnsRespFailAuth() {
+			S3Exception e = (S3Exception) S3Exception.builder()
+							.statusCode(403)
+							.message("Forbidden")
+							.build();
+			assertEquals(Operation.Status.RESP_FAIL_AUTH, S3AwsStorageDriver.classifyFailure(e));
+		}
+
+		@Test
+		void s3Exception_404_returnsRespFailNotFound() {
+			S3Exception e = (S3Exception) S3Exception.builder()
+							.statusCode(404)
+							.message("Not Found")
+							.build();
+			assertEquals(Operation.Status.RESP_FAIL_NOT_FOUND, S3AwsStorageDriver.classifyFailure(e));
+		}
+
+		@Test
+		void s3Exception_400_returnsRespFailClient() {
+			S3Exception e = (S3Exception) S3Exception.builder()
+							.statusCode(400)
+							.message("Bad Request")
+							.build();
+			assertEquals(Operation.Status.RESP_FAIL_CLIENT, S3AwsStorageDriver.classifyFailure(e));
+		}
+
+		@Test
+		void s3Exception_500_returnsRespFailSvc() {
+			S3Exception e = (S3Exception) S3Exception.builder()
+							.statusCode(500)
+							.message("Internal Server Error")
+							.build();
+			assertEquals(Operation.Status.RESP_FAIL_SVC, S3AwsStorageDriver.classifyFailure(e));
+		}
+
+		@Test
+		void s3Exception_503_returnsRespFailSvc() {
+			S3Exception e = (S3Exception) S3Exception.builder()
+							.statusCode(503)
+							.message("Service Unavailable")
+							.build();
+			assertEquals(Operation.Status.RESP_FAIL_SVC, S3AwsStorageDriver.classifyFailure(e));
+		}
+
+		@Test
+		void ioException_returnsFailIo() {
+			assertEquals(Operation.Status.FAIL_IO, S3AwsStorageDriver.classifyFailure(new IOException("connection reset")));
+		}
+
+		@Test
+		void sdkClientException_wrappingIo_returnsFailIo() {
+			var e = software.amazon.awssdk.core.exception.SdkClientException.builder()
+							.cause(new IOException("connection refused"))
+							.build();
+			assertEquals(Operation.Status.FAIL_IO, S3AwsStorageDriver.classifyFailure(e));
+		}
+
+		@Test
+		void apiCallTimeoutException_returnsFailTimeout() {
+			var e = software.amazon.awssdk.core.exception.ApiCallTimeoutException.builder()
+							.message("timed out")
+							.build();
+			assertEquals(Operation.Status.FAIL_TIMEOUT, S3AwsStorageDriver.classifyFailure(e));
+		}
+
+		@Test
+		void apiCallAttemptTimeoutException_returnsFailTimeout() {
+			var e = software.amazon.awssdk.core.exception.ApiCallAttemptTimeoutException.builder()
+							.message("attempt timed out")
+							.build();
+			assertEquals(Operation.Status.FAIL_TIMEOUT, S3AwsStorageDriver.classifyFailure(e));
+		}
+
+		@Test
+		void genericException_returnsFailUnknown() {
+			assertEquals(
+							Operation.Status.FAIL_UNKNOWN,
+							S3AwsStorageDriver.classifyFailure(new RuntimeException("unexpected")));
+		}
+
+		@Test
+		void sdkClientException_nonIoCause_returnsFailUnknown() {
+			var e = software.amazon.awssdk.core.exception.SdkClientException.builder()
+							.cause(new IllegalStateException("bad state"))
+							.build();
+			assertEquals(Operation.Status.FAIL_UNKNOWN, S3AwsStorageDriver.classifyFailure(e));
+		}
+	}
 }


### PR DESCRIPTION
## Summary

The s3-aws driver was silently swallowing all exceptions, setting every failure to `FAIL_UNKNOWN` with no log output. This made diagnosing issues (like the AWS SDK version incompatibility) extremely difficult.

### Changes

- **Exception classification**: New `classifyFailure()` method maps AWS SDK exceptions to specific `Operation.Status` codes:
  - `S3Exception` 401/403 → `RESP_FAIL_AUTH`
  - `S3Exception` 404 → `RESP_FAIL_NOT_FOUND`
  - `S3Exception` 4xx → `RESP_FAIL_CLIENT`
  - `S3Exception` 5xx → `RESP_FAIL_SVC`
  - `ApiCallTimeoutException` / `ApiCallAttemptTimeoutException` → `FAIL_TIMEOUT`
  - `IOException` (or `SdkClientException` wrapping `IOException`) → `FAIL_IO`
  - Everything else → `FAIL_UNKNOWN`

- **Exception logging**: Failed operations are now logged at DEBUG (exception message) and TRACE (full stack trace) instead of being silently swallowed.

- **Config resolution logging**: The `resolveBucketName` method now logs config lookup failures at DEBUG instead of silently ignoring them.

### Test plan

- [x] 12 new unit tests covering all failure classification paths
- [x] All engine tests pass (`./gradlew test`)