### PR TITLE
Upgrade AWS SDK version for s3-aws plugin

### DIFF
--- a/engine/core/spt-base/src/main/java/com/dell/spt/base/item/io/DataItemInputStream.java
+++ b/engine/core/spt-base/src/main/java/com/dell/spt/base/item/io/DataItemInputStream.java
@@ -13,6 +13,7 @@ public final class DataItemInputStream extends InputStream {
 
 	private long doneSize = 0;
 	private long markPos = 0;
+	private long markDoneSize = 0;
 	private ByteBuffer buffWrapper = null;
 	private byte[] buff = null;
 
@@ -61,11 +62,13 @@ public final class DataItemInputStream extends InputStream {
 	@Override
 	public final void mark(final int readLimit) {
 		this.markPos = dataItem.position();
+		this.markDoneSize = doneSize;
 	}
 
 	@Override
 	public final void reset() throws IOException {
 		dataItem.position(markPos);
+		this.doneSize = markDoneSize;
 	}
 
 	@Override

--- a/engine/extensions/storage-drivers/implementations/s3-aws/build.gradle
+++ b/engine/extensions/storage-drivers/implementations/s3-aws/build.gradle
@@ -9,44 +9,26 @@ ext {
 	rootPkg = "com.dell.spt.storage.driver.coop.aws.s3"
 }
 
+configurations.implementation {
+	// The s3-aws driver uses the Apache HTTP client, not the Netty NIO client.
+	// Exclude netty-nio-client and all io.netty transitive deps globally so that
+	// no AWS SDK module (s3, sts, etc.) can pull them in.
+	exclude group: 'software.amazon.awssdk', module: 'netty-nio-client'
+	exclude group: 'io.netty'
+}
+
 dependencies {
 	// AWS SDK – extension-private, safe to bundle.
-	// Exclude Netty and SLF4J globally: the s3-aws driver uses the Apache HTTP
-	// client, not the Netty NIO client, and the AWS SDK BOM pulls in an older
-	// Netty (4.1.x) that conflicts with the engine's own Netty (4.2.x).
-	implementation(libs.aws.s3) {
-		exclude group: 'org.slf4j', module: 'slf4j-api'
-		exclude group: 'io.netty'
-		exclude group: 'software.amazon.awssdk', module: 'netty-nio-client'
-	}
-	implementation(libs.aws.auth) {
-		exclude group: 'org.slf4j', module: 'slf4j-api'
-	}
-	implementation(libs.aws.regions) {
-		exclude group: 'org.slf4j', module: 'slf4j-api'
-	}
-	implementation(libs.aws.core) {
-		exclude group: 'org.slf4j', module: 'slf4j-api'
-	}
-	implementation(libs.aws.sts) {
-		exclude group: 'org.slf4j', module: 'slf4j-api'
-	}
-	implementation(libs.aws.http.client.spi) {
-		exclude group: 'org.slf4j', module: 'slf4j-api'
-	}
-	implementation(libs.aws.apache.client) {
-		exclude group: 'org.slf4j', module: 'slf4j-api'
-		exclude group: 'io.netty'
-	}
-	implementation(libs.aws.sdk.core) {
-		exclude group: 'org.slf4j', module: 'slf4j-api'
-	}
-	implementation(libs.aws.utils) {
-		exclude group: 'org.slf4j', module: 'slf4j-api'
-	}
-	implementation(libs.aws.profiles) {
-		exclude group: 'org.slf4j', module: 'slf4j-api'
-	}
+	implementation libs.aws.s3
+	implementation libs.aws.auth
+	implementation libs.aws.regions
+	implementation libs.aws.core
+	implementation libs.aws.sts
+	implementation libs.aws.http.client.spi
+	implementation libs.aws.apache.client
+	implementation libs.aws.sdk.core
+	implementation libs.aws.utils
+	implementation libs.aws.profiles
 
 	// SPT framework APIs – provided by parent classloader
 	compileOnly project(':core:spt-base')

--- a/engine/extensions/storage-drivers/implementations/s3-aws/src/main/java/com/dell/spt/storage/driver/coop/aws/s3/S3AwsStorageDriver.java
+++ b/engine/extensions/storage-drivers/implementations/s3-aws/src/main/java/com/dell/spt/storage/driver/coop/aws/s3/S3AwsStorageDriver.java
@@ -20,11 +20,10 @@ import com.github.akurilov.confuse.Config;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.nio.file.Files;
 import java.nio.file.Path;
 
 import java.io.IOException;
-import java.nio.channels.Channels;
+import com.dell.spt.base.item.io.DataItemInputStream;
 import java.util.concurrent.TimeoutException;
 import software.amazon.awssdk.core.exception.ApiCallAttemptTimeoutException;
 import software.amazon.awssdk.core.exception.ApiCallTimeoutException;
@@ -318,22 +317,22 @@ public class S3AwsStorageDriver<I extends Item, O extends Operation<I>> extends 
 
 		if (op.item() instanceof DataItem) {
 			DataItem dataItem = (DataItem) op.item();
+			dataItem.position(0);
 			s3Client.putObject(
 							PutObjectRequest.builder()
 											.bucket(bk[0])
 											.key(bk[1])
 											.build(),
-							RequestBody.fromInputStream(Channels.newInputStream(dataItem), dataItem.size()));
+							RequestBody.fromInputStream(new DataItemInputStream(dataItem), dataItem.size()));
 		} else if (op.item() instanceof PathItem) {
 			PathItem pathItem = (PathItem) op.item();
 			Path path = Path.of(pathItem.name());
-			long size = Files.size(path);
 			s3Client.putObject(
 							PutObjectRequest.builder()
 											.bucket(bk[0])
 											.key(bk[1])
 											.build(),
-							RequestBody.fromInputStream(Files.newInputStream(path), size));
+							RequestBody.fromFile(path));
 		} else {
 			throw new UnsupportedOperationException("s3-aws PUT requires DataItem or PathItem");
 		}

--- a/engine/gradle/libs.versions.toml
+++ b/engine/gradle/libs.versions.toml
@@ -44,7 +44,7 @@ avro = "1.11.4"
 hadoop = "3.3.6"
 
 # AWS SDK
-awsSdk = "2.21.29"
+awsSdk = "2.42.28"
 
 # Build tools
 dockerJava = "3.1.5"


### PR DESCRIPTION
- Fix DataItemInputStream mark/reset to preserve doneSize counter,
  required by the newer SDK's retry mechanism which re-reads the stream
- Use DataItemInputStream (supports mark/reset) instead of
  Channels.newInputStream for DataItem uploads
- Use RequestBody.fromFile() for PathItem uploads
- Simplify build.gradle: use configuration-level exclusions for Netty
  instead of per-dependency excludes
