### PR TITLE
Optimize read throughput: fast-recycle dispatch + VT quiesce

### DIFF
--- a/engine/bundle/build.gradle
+++ b/engine/bundle/build.gradle
@@ -141,8 +141,10 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 # - UseNUMA: NUMA-aware allocation for multi-socket servers
 # - Xshare:off: disable CDS to prevent SIGBUS when JDK/JAR resides on NFS
 # - UseAVX=2: avoid AVX-512 EVEX glibc code paths with known SIGBUS crashes
+# - DoJVMTIVirtualThreadTransitions: skip JVMTI mount/unmount notifications on every
+#   VirtualThread context switch; reduces per-op overhead when no debugging agent is attached
 # Override: SPT_JAVA_OPTS="-Xmx8g" ./run.sh ...
-SPT_JAVA_OPTS="${SPT_JAVA_OPTS:--XX:+UseZGC -Xms1g -Xmx4g -XX:MaxDirectMemorySize=64g -XX:+AlwaysPreTouch -XX:+UseNUMA -Xshare:off -XX:UseAVX=2}"
+SPT_JAVA_OPTS="${SPT_JAVA_OPTS:--XX:+UseZGC -Xms1g -Xmx4g -XX:MaxDirectMemorySize=64g -XX:+AlwaysPreTouch -XX:+UseNUMA -Xshare:off -XX:UseAVX=2 -XX:+UnlockExperimentalVMOptions -XX:-DoJVMTIVirtualThreadTransitions}"
 
 # Run Spt with all arguments passed to this script
 java $SPT_JAVA_OPTS -jar "$SCRIPT_DIR/spt.jar" "$@"
@@ -158,7 +160,7 @@ rem Get the directory where this script is located
 set SCRIPT_DIR=%~dp0
 
 rem Default JVM options for Spt (JDK 21+)
-if not defined SPT_JAVA_OPTS set SPT_JAVA_OPTS=-XX:+UseZGC -Xms1g -Xmx4g -XX:MaxDirectMemorySize=64g -XX:+AlwaysPreTouch -Xshare:off -XX:UseAVX=2
+if not defined SPT_JAVA_OPTS set SPT_JAVA_OPTS=-XX:+UseZGC -Xms1g -Xmx4g -XX:MaxDirectMemorySize=64g -XX:+AlwaysPreTouch -Xshare:off -XX:UseAVX=2 -XX:+UnlockExperimentalVMOptions -XX:-DoJVMTIVirtualThreadTransitions
 
 rem Run Spt with all arguments passed to this script
 java %SPT_JAVA_OPTS% -jar "%SCRIPT_DIR%spt.jar" %*

--- a/engine/bundle/docker/entrypoint.sh
+++ b/engine/bundle/docker/entrypoint.sh
@@ -25,7 +25,9 @@ if [ -z "$JAVA_OPTS" ]; then
     # - UseNUMA: NUMA-aware allocation for multi-socket servers
     # - Xshare:off: disable CDS to prevent SIGBUS when JDK/JAR resides on NFS
     # - UseAVX=2: avoid AVX-512 EVEX glibc code paths with known SIGBUS crashes
-    export JAVA_OPTS="-XX:+UseZGC -Xms1g -Xmx4g -XX:MaxDirectMemorySize=64g -XX:+AlwaysPreTouch -XX:+UseNUMA -Xshare:off -XX:UseAVX=2"
+    # - DoJVMTIVirtualThreadTransitions: skip JVMTI mount/unmount notifications on every
+    #   VirtualThread context switch; reduces per-op overhead when no debugging agent is attached
+    export JAVA_OPTS="-XX:+UseZGC -Xms1g -Xmx4g -XX:MaxDirectMemorySize=64g -XX:+AlwaysPreTouch -XX:+UseNUMA -Xshare:off -XX:UseAVX=2 -XX:+UnlockExperimentalVMOptions -XX:-DoJVMTIVirtualThreadTransitions"
 fi
 
 # Additional Java options that can be set via environment variables

--- a/engine/core/spt-base/src/main/java/com/dell/spt/base/item/op/Operation.java
+++ b/engine/core/spt-base/src/main/java/com/dell/spt/base/item/op/Operation.java
@@ -101,4 +101,14 @@ public interface Operation<I extends Item> {
 	Operation<I> result();
 
 	void reset();
+
+	/**
+	 * Returns {@code true} if the storage driver has already recycled this operation
+	 * via the fast-recycle path (re-submitted directly without going through the
+	 * LoadGenerator recycle queue).  When set, {@code LoadStepContextImpl} must
+	 * skip calling {@code generator.recycle()} to avoid double-recycling.
+	 */
+	boolean driverRecycled();
+
+	void driverRecycled(boolean flag);
 }

--- a/engine/core/spt-base/src/main/java/com/dell/spt/base/item/op/OperationImpl.java
+++ b/engine/core/spt-base/src/main/java/com/dell/spt/base/item/op/OperationImpl.java
@@ -21,6 +21,7 @@ public class OperationImpl<I extends Item> implements Operation<I> {
 	protected volatile long reqTimeDone;
 	protected volatile long respTimeStart;
 	protected volatile long respTimeDone;
+	protected volatile boolean driverRecycled;
 
 	public OperationImpl() {}
 
@@ -76,6 +77,7 @@ public class OperationImpl<I extends Item> implements Operation<I> {
 		this.reqTimeDone = other.reqTimeDone;
 		this.respTimeStart = other.respTimeStart;
 		this.respTimeDone = other.respTimeDone;
+		this.driverRecycled = other.driverRecycled;
 	}
 
 	@Override
@@ -90,6 +92,17 @@ public class OperationImpl<I extends Item> implements Operation<I> {
 		nodeAddr = null;
 		status = Status.PENDING;
 		reqTimeStart = reqTimeDone = respTimeStart = respTimeDone = 0;
+		driverRecycled = false;
+	}
+
+	@Override
+	public final boolean driverRecycled() {
+		return driverRecycled;
+	}
+
+	@Override
+	public final void driverRecycled(final boolean flag) {
+		this.driverRecycled = flag;
 	}
 
 	@Override

--- a/engine/core/spt-base/src/main/java/com/dell/spt/base/load/generator/LoadGenerator.java
+++ b/engine/core/spt-base/src/main/java/com/dell/spt/base/load/generator/LoadGenerator.java
@@ -22,4 +22,13 @@ public interface LoadGenerator<I extends Item, O extends Operation<I>> extends T
 
 	/** Returns true when the recycle queue is currently empty. */
 	boolean isNothingToRecycle();
+
+	/**
+	 * Enable idle-VT quiescing for fast-recycle workloads.  When enabled, the
+	 * generator parks its VT (instead of spin-waiting/yielding) when the recycle
+	 * queue is empty, because the driver is handling recycling inline.  The
+	 * {@link #recycle} method will unpark the VT immediately if an op falls back
+	 * to the normal path.
+	 */
+	default void enableFastRecycleQuiesce() {}
 }

--- a/engine/core/spt-base/src/main/java/com/dell/spt/base/load/generator/LoadGeneratorImpl.java
+++ b/engine/core/spt-base/src/main/java/com/dell/spt/base/load/generator/LoadGeneratorImpl.java
@@ -60,6 +60,8 @@ public class LoadGeneratorImpl<I extends Item, O extends Operation<I>> extends T
 	private final boolean shuffleFlag;
 	private final Random rnd;
 	private final String name;
+	private volatile boolean fastRecycleQuiesce = false;
+	private volatile Thread generatorThread;
 	private final ThreadLocal<CircularBuffer<O>> threadLocalOpBuff;
 	private final LongAdder builtTasksCounter = new LongAdder();
 	private final LongAdder recycledOpCounter = new LongAdder();
@@ -103,6 +105,7 @@ public class LoadGeneratorImpl<I extends Item, O extends Operation<I>> extends T
 	@Override
 	protected void doInit() {
 		ThreadContext.put(KEY_CLASS_NAME, CLS_NAME);
+		generatorThread = Thread.currentThread();
 	}
 
 	@Override
@@ -145,12 +148,21 @@ public class LoadGeneratorImpl<I extends Item, O extends Operation<I>> extends T
 							pendingOpCount += n;
 							recycledOpCounter.add(n);
 						} else {
-							// Yield the virtual thread back to the ForkJoinPool so
-							// in-flight ops can complete. Thread.yield() is purely
-							// userspace on VTs — no futex/context-switch overhead
-							// unlike LockSupport.parkNanos() which triggers a full
-							// kernel round-trip even for parkNanos(1).
-							yieldThread();
+							// No recycled ops available right now.
+							if (fastRecycleQuiesce) {
+								// Fast-recycle is handling ops inline in the driver;
+								// park this VT until recycle() unparks us or the
+								// timeout expires.  10ms keeps the VT off the carrier
+								// while still bounding wake-up latency for fallback ops.
+								LockSupport.parkNanos(10_000_000);
+							} else {
+								// Yield the virtual thread back to the ForkJoinPool so
+								// in-flight ops can complete. Thread.yield() is purely
+								// userspace on VTs — no futex/context-switch overhead
+								// unlike LockSupport.parkNanos() which triggers a full
+								// kernel round-trip even for parkNanos(1).
+								yieldThread();
+							}
 						}
 					}
 				} else {
@@ -353,11 +365,21 @@ public class LoadGeneratorImpl<I extends Item, O extends Operation<I>> extends T
 			recycleQueueFullState = true;
 			Loggers.ERR.warn("{}: recycle queue exceeded configured capacity ({})", name, recycleQueueCapacity);
 		}
+		// Wake the generator VT if it's parked in the quiesce state
+		if (fastRecycleQuiesce) {
+			LockSupport.unpark(generatorThread);
+		}
 	}
 
 	@Override
 	public final boolean isNothingToRecycle() {
 		return recycleQueue.isEmpty();
+	}
+
+	@Override
+	public void enableFastRecycleQuiesce() {
+		fastRecycleQuiesce = true;
+		Loggers.MSG.info("{}: fast-recycle quiesce enabled (generator VT will park when idle)", name);
 	}
 
 	private boolean isFinished() {

--- a/engine/core/spt-base/src/main/java/com/dell/spt/base/load/generator/LoadGeneratorImpl.java
+++ b/engine/core/spt-base/src/main/java/com/dell/spt/base/load/generator/LoadGeneratorImpl.java
@@ -61,6 +61,7 @@ public class LoadGeneratorImpl<I extends Item, O extends Operation<I>> extends T
 	private final Random rnd;
 	private final String name;
 	private volatile boolean fastRecycleQuiesce = false;
+	private volatile boolean generatorParked = false;
 	private volatile Thread generatorThread;
 	private final ThreadLocal<CircularBuffer<O>> threadLocalOpBuff;
 	private final LongAdder builtTasksCounter = new LongAdder();
@@ -154,7 +155,9 @@ public class LoadGeneratorImpl<I extends Item, O extends Operation<I>> extends T
 								// park this VT until recycle() unparks us or the
 								// timeout expires.  10ms keeps the VT off the carrier
 								// while still bounding wake-up latency for fallback ops.
+								generatorParked = true;
 								LockSupport.parkNanos(10_000_000);
+								generatorParked = false;
 							} else {
 								// Yield the virtual thread back to the ForkJoinPool so
 								// in-flight ops can complete. Thread.yield() is purely
@@ -365,8 +368,11 @@ public class LoadGeneratorImpl<I extends Item, O extends Operation<I>> extends T
 			recycleQueueFullState = true;
 			Loggers.ERR.warn("{}: recycle queue exceeded configured capacity ({})", name, recycleQueueCapacity);
 		}
-		// Wake the generator VT if it's parked in the quiesce state
-		if (fastRecycleQuiesce) {
+		// Wake the generator VT if it's actually parked in the quiesce state.
+		// Checking generatorParked avoids spurious unpark() calls when the
+		// generator is running (e.g. at higher concurrency where fast-recycle
+		// doesn't handle all ops).
+		if (fastRecycleQuiesce && generatorParked) {
 			LockSupport.unpark(generatorThread);
 		}
 	}

--- a/engine/core/spt-base/src/main/java/com/dell/spt/base/load/step/local/context/LoadStepContextImpl.java
+++ b/engine/core/spt-base/src/main/java/com/dell/spt/base/load/step/local/context/LoadStepContextImpl.java
@@ -164,7 +164,15 @@ public class LoadStepContextImpl<I extends Item, O extends Operation<I>> extends
 			final int driverConcurrency = this.driver.concurrencyLimit();
 			final int threshold = driverConcurrency > 0 ? Math.min(driverConcurrency, 8) : 8;
 			this.driver.enableFastRecycle(threshold);
-			this.generator.enableFastRecycleQuiesce();
+			// Only quiesce when the configured concurrency is low enough that
+			// fast-recycle handles most operations inline.  At higher concurrency
+			// (T8+), fast-recycle rarely fires and the generator/dispatch VTs
+			// need to stay responsive — yield is faster than park+unpark when
+			// ops flow through the recycleQueue continuously.
+			if (driverConcurrency > 0 && driverConcurrency <= 4) {
+				this.generator.enableFastRecycleQuiesce();
+				this.driver.enableFastRecycleQuiesce();
+			}
 		}
 	}
 

--- a/engine/core/spt-base/src/main/java/com/dell/spt/base/load/step/local/context/LoadStepContextImpl.java
+++ b/engine/core/spt-base/src/main/java/com/dell/spt/base/load/step/local/context/LoadStepContextImpl.java
@@ -155,6 +155,16 @@ public class LoadStepContextImpl<I extends Item, O extends Operation<I>> extends
 							com.dell.spt.base.metrics.MetricsConstants.METADATA_LIST_SHARD_METRICS,
 							this.listShardMetricsRecorder);
 		}
+		// Enable fast-recycle on the driver when recycling simple data ops
+		// without content updates.  The threshold is the configured concurrency
+		// limit (or a cap of 8 for unlimited).  updateContents is excluded
+		// because the driver re-submits the original op directly and cannot
+		// safely mutate the shared DataItem offset concurrently with metrics.
+		if (this.recycleFlag && !this.updateContents && !this.listPathWorkload) {
+			final int driverConcurrency = this.driver.concurrencyLimit();
+			final int threshold = driverConcurrency > 0 ? Math.min(driverConcurrency, 8) : 8;
+			this.driver.enableFastRecycle(threshold);
+		}
 	}
 
 	@Override
@@ -373,7 +383,12 @@ public class LoadStepContextImpl<I extends Item, O extends Operation<I>> extends
 						// TODO: possible change: remove dataItem.offset() to improve perf and increase variability
 						dataItem.offset(dataItem.offset() + rand.get().nextLong());
 					}
-					generator.recycle(opResult);
+					// Skip generator.recycle() when the driver already re-submitted the
+					// original op via the fast-recycle path — calling recycle here would
+					// create a duplicate in-flight operation.
+					if (!opResult.driverRecycled()) {
+						generator.recycle(opResult);
+					}
 				}
 
 				// each recycled op's lat and dur should be written to file each time
@@ -494,7 +509,9 @@ public class LoadStepContextImpl<I extends Item, O extends Operation<I>> extends
 								listShardMetricsRecorder.onRequeue(shardRef);
 							}
 						}
-						generator.recycle(opResult);
+						if (!opResult.driverRecycled()) {
+							generator.recycle(opResult);
+						}
 					}
 
 					// each recycled op's lat and dur should be written to file each time

--- a/engine/core/spt-base/src/main/java/com/dell/spt/base/load/step/local/context/LoadStepContextImpl.java
+++ b/engine/core/spt-base/src/main/java/com/dell/spt/base/load/step/local/context/LoadStepContextImpl.java
@@ -164,6 +164,7 @@ public class LoadStepContextImpl<I extends Item, O extends Operation<I>> extends
 			final int driverConcurrency = this.driver.concurrencyLimit();
 			final int threshold = driverConcurrency > 0 ? Math.min(driverConcurrency, 8) : 8;
 			this.driver.enableFastRecycle(threshold);
+			this.generator.enableFastRecycleQuiesce();
 		}
 	}
 

--- a/engine/core/spt-base/src/main/java/com/dell/spt/base/storage/driver/StorageDriver.java
+++ b/engine/core/spt-base/src/main/java/com/dell/spt/base/storage/driver/StorageDriver.java
@@ -87,6 +87,18 @@ public interface StorageDriver<I extends Item, O extends Operation<I>>
 	 */
 	default void enableFastRecycle(final int concurrencyThreshold) {}
 
+	/**
+	 * Signal that the fast-recycle path is expected to handle most operations
+	 * and the dispatch/generator VTs may quiesce (park on long waits).  Only
+	 * called when the configured concurrency is low enough that fast-recycle
+	 * dominates; at higher concurrency the normal pipeline needs to stay
+	 * responsive.
+	 * <p>
+	 * Default is a no-op; cooperative drivers override to inform their
+	 * dispatch task.
+	 */
+	default void enableFastRecycleQuiesce() {}
+
 	@Override
 	AsyncRunnable stop();
 

--- a/engine/core/spt-base/src/main/java/com/dell/spt/base/storage/driver/StorageDriver.java
+++ b/engine/core/spt-base/src/main/java/com/dell/spt/base/storage/driver/StorageDriver.java
@@ -73,6 +73,20 @@ public interface StorageDriver<I extends Item, O extends Operation<I>>
 
 	void adjustIoBuffers(final long avgTransferSize, final OpType opType);
 
+	/**
+	 * Enable the fast-recycle dispatch path.  When active and the current
+	 * active-op count is at or below {@code concurrencyThreshold}, the driver
+	 * will re-submit a successfully completed simple operation directly on the
+	 * I/O thread instead of returning it through the LoadGenerator recycle queue.
+	 * <p>
+	 * The default implementation is a no-op; subclasses that support the
+	 * optimisation (e.g. Netty-based drivers) override this.
+	 *
+	 * @param concurrencyThreshold maximum active-op count at which the
+	 *                             fast-recycle path is used (0 = disabled)
+	 */
+	default void enableFastRecycle(final int concurrencyThreshold) {}
+
 	@Override
 	AsyncRunnable stop();
 

--- a/engine/core/spt-base/src/test/java/com/dell/spt/base/item/op/OperationImplTest.java
+++ b/engine/core/spt-base/src/test/java/com/dell/spt/base/item/op/OperationImplTest.java
@@ -141,4 +141,37 @@ class OperationImplTest {
 		assertTrue(op.latency() < MAX_SANE_LATENCY_MICROS,
 						"latency must not be epoch-scale in normal lifecycle");
 	}
+
+	// ---------- driverRecycled flag tests ----------
+
+	@Test
+	void driverRecycled_defaultIsFalse() {
+		final var op = new OperationImpl<>(0, OpType.READ, new ItemImpl("item"), null, null, null);
+		assertFalse(op.driverRecycled(), "driverRecycled should default to false");
+	}
+
+	@Test
+	void driverRecycled_setAndGet() {
+		final var op = new OperationImpl<>(0, OpType.READ, new ItemImpl("item"), null, null, null);
+		op.driverRecycled(true);
+		assertTrue(op.driverRecycled(), "driverRecycled should be true after setting");
+		op.driverRecycled(false);
+		assertFalse(op.driverRecycled(), "driverRecycled should be false after clearing");
+	}
+
+	@Test
+	void driverRecycled_copiedByResult() {
+		final var op = new OperationImpl<>(0, OpType.READ, new ItemImpl("item"), null, "/path", null);
+		op.driverRecycled(true);
+		final var copy = op.result();
+		assertTrue(copy.driverRecycled(), "driverRecycled should be preserved in result copy");
+	}
+
+	@Test
+	void driverRecycled_clearedByReset() {
+		final var op = new OperationImpl<>(0, OpType.READ, new ItemImpl("item"), null, "/path", null);
+		op.driverRecycled(true);
+		op.reset();
+		assertFalse(op.driverRecycled(), "driverRecycled should be cleared by reset()");
+	}
 }

--- a/engine/core/spt-base/src/test/java/com/dell/spt/base/load/generator/LoadGeneratorImplRecycleTest.java
+++ b/engine/core/spt-base/src/test/java/com/dell/spt/base/load/generator/LoadGeneratorImplRecycleTest.java
@@ -296,6 +296,35 @@ class LoadGeneratorImplRecycleTest {
 		assertTrue(elapsedMs < 5, "doWork took " + elapsedMs + "ms; yield should be sub-millisecond");
 	}
 
+	/**
+	 * Verify the generatorParked flag guards against spurious unpark calls.
+	 * When quiesce is enabled but the generator is NOT parked (e.g. actively
+	 * processing ops), recycle() should still enqueue ops and they should be
+	 * picked up via the normal polling path in doWork().
+	 */
+	@Test
+	void recycleWithQuiesceEnabledButGeneratorNotParked() throws Exception {
+		// Enable quiesce, but we'll call doWork() manually so the generator
+		// VT is never actually parked (doWork returns after one spin).
+		generator.enableFastRecycleQuiesce();
+		generator.doWork(); // exhaust item input
+
+		// generatorParked should be false since we're not in the park path
+		final var parkedField = LoadGeneratorImpl.class.getDeclaredField("generatorParked");
+		parkedField.setAccessible(true);
+		assertFalse(parkedField.getBoolean(generator),
+						"generatorParked should be false when not in park path");
+
+		// Recycle an op while the generator is not parked
+		final DataOperation<DataItem> op = newOp("not-parked-1");
+		generator.recycle(op);
+
+		// doWork should still pick up the op via polling
+		generator.doWork();
+		assertEquals(1, output.received.size());
+		assertSame(op, output.received.get(0));
+	}
+
 	// --- helpers ---
 
 	private DataOperation<DataItem> newOp(final String name) {

--- a/engine/core/spt-base/src/test/java/com/dell/spt/base/load/generator/LoadGeneratorImplRecycleTest.java
+++ b/engine/core/spt-base/src/test/java/com/dell/spt/base/load/generator/LoadGeneratorImplRecycleTest.java
@@ -144,20 +144,18 @@ class LoadGeneratorImplRecycleTest {
 	@Test
 	void concurrentRecycleDuringRunningGenerator() throws Exception {
 		final int opCount = 20;
-		final ConcurrentCollectingOutput<DataOperation<DataItem>> concurrentOutput =
-						new ConcurrentCollectingOutput<>(opCount);
+		final ConcurrentCollectingOutput<DataOperation<DataItem>> concurrentOutput = new ConcurrentCollectingOutput<>(opCount);
 
-		final LoadGeneratorImpl<DataItem, DataOperation<DataItem>> runningGen =
-						new LoadGeneratorImpl<>(
-										itemInput,
-										opsBuilder,
-										List.of(),
-										concurrentOutput,
-										BATCH_SIZE,
-										0,
-										1000,
-										true,
-										false);
+		final LoadGeneratorImpl<DataItem, DataOperation<DataItem>> runningGen = new LoadGeneratorImpl<>(
+						itemInput,
+						opsBuilder,
+						List.of(),
+						concurrentOutput,
+						BATCH_SIZE,
+						0,
+						1000,
+						true,
+						false);
 
 		try {
 			runningGen.start();
@@ -238,20 +236,18 @@ class LoadGeneratorImplRecycleTest {
 	@Test
 	void recycleUnparksQuiescedGenerator() throws Exception {
 		final int opCount = 10;
-		final ConcurrentCollectingOutput<DataOperation<DataItem>> concurrentOutput =
-						new ConcurrentCollectingOutput<>(opCount);
+		final ConcurrentCollectingOutput<DataOperation<DataItem>> concurrentOutput = new ConcurrentCollectingOutput<>(opCount);
 
-		final LoadGeneratorImpl<DataItem, DataOperation<DataItem>> quiescedGen =
-						new LoadGeneratorImpl<>(
-										itemInput,
-										opsBuilder,
-										List.of(),
-										concurrentOutput,
-										BATCH_SIZE,
-										0,
-										1000,
-										true,
-										false);
+		final LoadGeneratorImpl<DataItem, DataOperation<DataItem>> quiescedGen = new LoadGeneratorImpl<>(
+						itemInput,
+						opsBuilder,
+						List.of(),
+						concurrentOutput,
+						BATCH_SIZE,
+						0,
+						1000,
+						true,
+						false);
 		quiescedGen.enableFastRecycleQuiesce();
 
 		try {

--- a/engine/core/spt-base/src/test/java/com/dell/spt/base/load/generator/LoadGeneratorImplRecycleTest.java
+++ b/engine/core/spt-base/src/test/java/com/dell/spt/base/load/generator/LoadGeneratorImplRecycleTest.java
@@ -24,8 +24,7 @@ import org.junit.jupiter.api.Test;
  * Characterization tests for the recycle-poll path in {@link LoadGeneratorImpl#doWork()}.
  * <p>
  * These tests document the current behavior of the spin-wait, yield, and output
- * logic in the recycle branch as a safety net before modifying this code path
- * for idle-VT quiescing (Phase 2 of fast-recycle dispatch).
+ * logic in the recycle branch, plus the fast-recycle quiesce behavior (park/unpark).
  */
 @SuppressWarnings("unchecked")
 class LoadGeneratorImplRecycleTest {
@@ -207,6 +206,98 @@ class LoadGeneratorImplRecycleTest {
 		assertTrue(generator.isNothingToRecycle());
 		assertEquals(3, generator.generatedOpCount());
 		assertEquals(3, output.received.size());
+	}
+
+	// --- fast-recycle quiesce tests ---
+
+	/**
+	 * With quiesce enabled and empty recycle queue, doWork() parks for up to 10ms
+	 * instead of yielding.  Verify it returns within a bounded time.
+	 */
+	@Test
+	void quiesceParksOnEmptyRecycleQueue() throws Exception {
+		generator.enableFastRecycleQuiesce();
+		// Exhaust item input
+		generator.doWork();
+		assertTrue(generator.isItemInputFinished());
+
+		// doWork with quiesce + empty queue parks for up to 10ms
+		final long start = System.nanoTime();
+		generator.doWork();
+		final long elapsedMs = (System.nanoTime() - start) / 1_000_000;
+
+		// Should park for ~10ms (timeout), bounded well under 100ms
+		assertTrue(elapsedMs < 100, "doWork took " + elapsedMs + "ms; expected < 100ms");
+		assertEquals(0, output.received.size());
+	}
+
+	/**
+	 * With quiesce enabled, recycle() unparks the generator VT so it picks
+	 * up the op quickly rather than waiting the full 10ms timeout.
+	 */
+	@Test
+	void recycleUnparksQuiescedGenerator() throws Exception {
+		final int opCount = 10;
+		final ConcurrentCollectingOutput<DataOperation<DataItem>> concurrentOutput =
+						new ConcurrentCollectingOutput<>(opCount);
+
+		final LoadGeneratorImpl<DataItem, DataOperation<DataItem>> quiescedGen =
+						new LoadGeneratorImpl<>(
+										itemInput,
+										opsBuilder,
+										List.of(),
+										concurrentOutput,
+										BATCH_SIZE,
+										0,
+										1000,
+										true,
+										false);
+		quiescedGen.enableFastRecycleQuiesce();
+
+		try {
+			quiescedGen.start();
+			assertEventually(quiescedGen::isItemInputFinished, 2000);
+
+			// Recycle ops with slight spacing to exercise the unpark path
+			final long t0 = System.nanoTime();
+			for (int i = 0; i < opCount; i++) {
+				quiescedGen.recycle(newOp("quiesce-" + i));
+				Thread.sleep(1);
+			}
+
+			// All ops should arrive well under 10ms * opCount since unpark wakes
+			// the generator immediately for each one
+			assertTrue(
+							concurrentOutput.latch.await(5, TimeUnit.SECONDS),
+							"Expected " + opCount + " ops but got " + concurrentOutput.received.size());
+			final long elapsedMs = (System.nanoTime() - t0) / 1_000_000;
+			assertTrue(
+							elapsedMs < 2000,
+							"Took " + elapsedMs + "ms for " + opCount + " ops; unpark may not be working");
+			assertEquals(opCount, concurrentOutput.received.size());
+		} finally {
+			quiescedGen.stop();
+			quiescedGen.await(5, TimeUnit.SECONDS);
+			quiescedGen.close();
+		}
+	}
+
+	/**
+	 * Without quiesce, the existing yield path is used (characterization of
+	 * the non-quiesce path when fast-recycle is not enabled).
+	 */
+	@Test
+	void nonQuiesceUsesYieldPath() throws Exception {
+		// quiesce NOT enabled — default
+		generator.doWork(); // exhaust item input
+
+		// doWork with empty queue should return very quickly (yield, not 10ms park)
+		final long start = System.nanoTime();
+		generator.doWork();
+		final long elapsedMs = (System.nanoTime() - start) / 1_000_000;
+
+		// Yield returns in microseconds, not milliseconds
+		assertTrue(elapsedMs < 5, "doWork took " + elapsedMs + "ms; yield should be sub-millisecond");
 	}
 
 	// --- helpers ---

--- a/engine/core/spt-base/src/test/java/com/dell/spt/base/load/generator/LoadGeneratorImplRecycleTest.java
+++ b/engine/core/spt-base/src/test/java/com/dell/spt/base/load/generator/LoadGeneratorImplRecycleTest.java
@@ -1,0 +1,306 @@
+package com.dell.spt.base.load.generator;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import com.dell.spt.base.item.DataItem;
+import com.dell.spt.base.item.DataItemImpl;
+import com.dell.spt.base.item.op.OpType;
+import com.dell.spt.base.item.op.OperationsBuilder;
+import com.dell.spt.base.item.op.data.DataOperation;
+import com.dell.spt.base.item.op.data.DataOperationImpl;
+import com.github.akurilov.commons.io.Input;
+import com.github.akurilov.commons.io.Output;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Characterization tests for the recycle-poll path in {@link LoadGeneratorImpl#doWork()}.
+ * <p>
+ * These tests document the current behavior of the spin-wait, yield, and output
+ * logic in the recycle branch as a safety net before modifying this code path
+ * for idle-VT quiescing (Phase 2 of fast-recycle dispatch).
+ */
+@SuppressWarnings("unchecked")
+class LoadGeneratorImplRecycleTest {
+
+	private static final int BATCH_SIZE = 4;
+
+	private Input<DataItem> itemInput;
+	private OperationsBuilder<DataItem, DataOperation<DataItem>> opsBuilder;
+	private CollectingOutput<DataOperation<DataItem>> output;
+	private LoadGeneratorImpl<DataItem, DataOperation<DataItem>> generator;
+
+	@BeforeEach
+	void setUp() throws Exception {
+		// Default mock: get(List,int) returns 0 and doesn't populate the list,
+		// so items stays empty and itemInputFinishFlag is set on first doWork().
+		itemInput = mock(Input.class);
+		when(itemInput.toString()).thenReturn("EmptyInput");
+
+		opsBuilder = mock(OperationsBuilder.class);
+		when(opsBuilder.opType()).thenReturn(OpType.READ);
+		when(opsBuilder.originIndex()).thenReturn(0);
+
+		output = new CollectingOutput<>();
+
+		generator = new LoadGeneratorImpl<>(
+						itemInput,
+						opsBuilder,
+						List.of(),
+						output,
+						BATCH_SIZE,
+						0, // countLimit -> Long.MAX_VALUE
+						1000, // recycleQueueCapacity
+						true, // recycleFlag
+						false); // shuffleFlag
+	}
+
+	@AfterEach
+	void tearDown() {
+		generator.close();
+	}
+
+	/**
+	 * Exhaust item input, then recycle one op, then call doWork() again.
+	 * The recycled op should appear in the output via the single-op path.
+	 */
+	@Test
+	void recycleEnqueueThenDoWorkOutputsOp() throws Exception {
+		// First doWork: exhausts item input, sets itemInputFinishFlag
+		generator.doWork();
+		assertTrue(generator.isItemInputFinished());
+		assertEquals(0, output.received.size());
+
+		// Recycle one op
+		final DataOperation<DataItem> op = newOp("item-1");
+		generator.recycle(op);
+		assertFalse(generator.isNothingToRecycle());
+
+		// Second doWork: enters recycle branch, picks up op, outputs it
+		generator.doWork();
+		assertEquals(1, output.received.size());
+		assertSame(op, output.received.get(0));
+		assertTrue(generator.isNothingToRecycle());
+		assertEquals(1, generator.generatedOpCount());
+	}
+
+	/**
+	 * With empty recycle queue, doWork() should return promptly via the
+	 * spin-wait + yield path. This verifies the yield doesn't block
+	 * indefinitely.
+	 */
+	@Test
+	void emptyRecycleQueueDoWorkReturnsPromptly() throws Exception {
+		// Exhaust item input
+		generator.doWork();
+		assertTrue(generator.isItemInputFinished());
+
+		// doWork with empty recycle queue -- should return quickly
+		final long start = System.nanoTime();
+		generator.doWork();
+		final long elapsedMs = (System.nanoTime() - start) / 1_000_000;
+
+		// Spin-wait (128x ~10ns) + yield is well under 100ms
+		assertTrue(elapsedMs < 100, "doWork took " + elapsedMs + "ms; expected < 100ms");
+		assertEquals(0, output.received.size());
+	}
+
+	/**
+	 * Recycle multiple ops and verify a single doWork() picks up all of them
+	 * (up to batchSize) and outputs them as a batch.
+	 */
+	@Test
+	void batchRecycleOutputsAllOps() throws Exception {
+		// Exhaust item input
+		generator.doWork();
+
+		// Recycle BATCH_SIZE ops
+		final List<DataOperation<DataItem>> ops = new ArrayList<>();
+		for (int i = 0; i < BATCH_SIZE; i++) {
+			final DataOperation<DataItem> op = newOp("item-" + i);
+			ops.add(op);
+			generator.recycle(op);
+		}
+
+		// Single doWork should pick up and output all of them
+		generator.doWork();
+		assertEquals(BATCH_SIZE, output.received.size());
+		for (int i = 0; i < BATCH_SIZE; i++) {
+			assertSame(ops.get(i), output.received.get(i));
+		}
+		assertEquals(BATCH_SIZE, generator.generatedOpCount());
+	}
+
+	/**
+	 * Start the generator VT loop, recycle ops from the test thread,
+	 * and verify all ops eventually reach the output.
+	 */
+	@Test
+	void concurrentRecycleDuringRunningGenerator() throws Exception {
+		final int opCount = 20;
+		final ConcurrentCollectingOutput<DataOperation<DataItem>> concurrentOutput =
+						new ConcurrentCollectingOutput<>(opCount);
+
+		final LoadGeneratorImpl<DataItem, DataOperation<DataItem>> runningGen =
+						new LoadGeneratorImpl<>(
+										itemInput,
+										opsBuilder,
+										List.of(),
+										concurrentOutput,
+										BATCH_SIZE,
+										0,
+										1000,
+										true,
+										false);
+
+		try {
+			runningGen.start();
+
+			// Wait for item input to be exhausted
+			assertEventually(runningGen::isItemInputFinished, 2000);
+
+			// Recycle ops from test thread
+			for (int i = 0; i < opCount; i++) {
+				runningGen.recycle(newOp("concurrent-" + i));
+			}
+
+			// Wait for all ops to be output
+			assertTrue(
+							concurrentOutput.latch.await(5, TimeUnit.SECONDS),
+							"Expected " + opCount + " ops but got " + concurrentOutput.received.size());
+			assertEquals(opCount, concurrentOutput.received.size());
+		} finally {
+			runningGen.stop();
+			runningGen.await(5, TimeUnit.SECONDS);
+			runningGen.close();
+		}
+	}
+
+	/**
+	 * Verify isNothingToRecycle() and generatedOpCount() track queue state
+	 * correctly across recycle() and doWork() calls.
+	 */
+	@Test
+	void recycleQueueStateTracking() throws Exception {
+		// Initially empty
+		assertTrue(generator.isNothingToRecycle());
+		assertEquals(0, generator.generatedOpCount());
+
+		// Exhaust item input
+		generator.doWork();
+
+		// Recycle 3 ops
+		for (int i = 0; i < 3; i++) {
+			generator.recycle(newOp("track-" + i));
+		}
+		assertFalse(generator.isNothingToRecycle());
+
+		// doWork drains the queue and outputs all ops
+		generator.doWork();
+		assertTrue(generator.isNothingToRecycle());
+		assertEquals(3, generator.generatedOpCount());
+		assertEquals(3, output.received.size());
+	}
+
+	// --- helpers ---
+
+	private DataOperation<DataItem> newOp(final String name) {
+		final DataItem item = new DataItemImpl(name, 0, 1024);
+		return new DataOperationImpl<>(0, OpType.READ, item, "/bucket", null, null, List.of(), 0);
+	}
+
+	private void assertEventually(
+					final java.util.function.BooleanSupplier condition,
+					final long timeoutMs)
+					throws InterruptedException {
+		final long deadline = System.currentTimeMillis() + timeoutMs;
+		while (!condition.getAsBoolean()) {
+			if (System.currentTimeMillis() > deadline) {
+				fail("Condition not met within " + timeoutMs + "ms");
+			}
+			Thread.sleep(10);
+		}
+	}
+
+	/** Simple collecting output for single-threaded doWork() tests. */
+	private static class CollectingOutput<O> implements Output<O> {
+		final List<O> received = new ArrayList<>();
+
+		@Override
+		public boolean put(final O item) {
+			if (item != null) {
+				received.add(item);
+			}
+			return true;
+		}
+
+		@Override
+		public int put(final List<O> buffer, final int from, final int to) {
+			for (int i = from; i < to; i++) {
+				received.add(buffer.get(i));
+			}
+			return to - from;
+		}
+
+		@Override
+		public int put(final List<O> buffer) {
+			return put(buffer, 0, buffer.size());
+		}
+
+		@Override
+		public Input<O> getInput() {
+			return null;
+		}
+
+		@Override
+		public void close() {}
+	}
+
+	/** Thread-safe collecting output with a latch for concurrent tests. */
+	private static class ConcurrentCollectingOutput<O> implements Output<O> {
+		final List<O> received = new CopyOnWriteArrayList<>();
+		final CountDownLatch latch;
+
+		ConcurrentCollectingOutput(final int expectedCount) {
+			latch = new CountDownLatch(expectedCount);
+		}
+
+		@Override
+		public boolean put(final O item) {
+			if (item != null) {
+				received.add(item);
+				latch.countDown();
+			}
+			return true;
+		}
+
+		@Override
+		public int put(final List<O> buffer, final int from, final int to) {
+			for (int i = from; i < to; i++) {
+				received.add(buffer.get(i));
+				latch.countDown();
+			}
+			return to - from;
+		}
+
+		@Override
+		public int put(final List<O> buffer) {
+			return put(buffer, 0, buffer.size());
+		}
+
+		@Override
+		public Input<O> getInput() {
+			return null;
+		}
+
+		@Override
+		public void close() {}
+	}
+}

--- a/engine/extensions/storage-drivers/primitives/coop/src/main/java/com/dell/spt/storage/driver/coop/CoopStorageDriverBase.java
+++ b/engine/extensions/storage-drivers/primitives/coop/src/main/java/com/dell/spt/storage/driver/coop/CoopStorageDriverBase.java
@@ -243,6 +243,15 @@ public abstract class CoopStorageDriverBase<I extends Item, O extends Operation<
 	}
 
 	/**
+	 * Returns {@code true} when fast-recycle has been enabled on this driver.
+	 * Used by the dispatch task to extend its idle wait when the driver is
+	 * cycling ops inline and no new work is expected via the queues.
+	 */
+	protected boolean isFastRecycleEnabled() {
+		return fastRecycleConcurrencyThreshold > 0;
+	}
+
+	/**
 	 * Check whether the given completed operation is eligible for the fast-recycle
 	 * short-circuit.  Returns {@code true} only when:
 	 * <ul>

--- a/engine/extensions/storage-drivers/primitives/coop/src/main/java/com/dell/spt/storage/driver/coop/CoopStorageDriverBase.java
+++ b/engine/extensions/storage-drivers/primitives/coop/src/main/java/com/dell/spt/storage/driver/coop/CoopStorageDriverBase.java
@@ -41,6 +41,7 @@ public abstract class CoopStorageDriverBase<I extends Item, O extends Operation<
 	private final Condition dispatchReady = dispatchLock.newCondition();
 	private final OperationDispatchTask opDispatchTask;
 	protected volatile int fastRecycleConcurrencyThreshold = 0;
+	private volatile boolean fastRecycleQuiesceActive = false;
 
 	protected CoopStorageDriverBase(
 					final String testStepId,
@@ -249,6 +250,21 @@ public abstract class CoopStorageDriverBase<I extends Item, O extends Operation<
 	 */
 	protected boolean isFastRecycleEnabled() {
 		return fastRecycleConcurrencyThreshold > 0;
+	}
+
+	@Override
+	public void enableFastRecycleQuiesce() {
+		this.fastRecycleQuiesceActive = true;
+		Loggers.MSG.info("{}: fast-recycle quiesce active (dispatch task will extend idle wait)", toString());
+	}
+
+	/**
+	 * Returns {@code true} when quiesce mode is active — i.e. the configured
+	 * concurrency is low enough that fast-recycle handles most operations and
+	 * the dispatch/generator VTs may park on long waits.
+	 */
+	protected boolean isFastRecycleQuiesceActive() {
+		return fastRecycleQuiesceActive;
 	}
 
 	/**

--- a/engine/extensions/storage-drivers/primitives/coop/src/main/java/com/dell/spt/storage/driver/coop/CoopStorageDriverBase.java
+++ b/engine/extensions/storage-drivers/primitives/coop/src/main/java/com/dell/spt/storage/driver/coop/CoopStorageDriverBase.java
@@ -40,6 +40,7 @@ public abstract class CoopStorageDriverBase<I extends Item, O extends Operation<
 	private final ReentrantLock dispatchLock = new ReentrantLock();
 	private final Condition dispatchReady = dispatchLock.newCondition();
 	private final OperationDispatchTask opDispatchTask;
+	protected volatile int fastRecycleConcurrencyThreshold = 0;
 
 	protected CoopStorageDriverBase(
 					final String testStepId,
@@ -233,6 +234,33 @@ public abstract class CoopStorageDriverBase<I extends Item, O extends Operation<
 		} finally {
 			dispatchLock.unlock();
 		}
+	}
+
+	@Override
+	public void enableFastRecycle(final int concurrencyThreshold) {
+		this.fastRecycleConcurrencyThreshold = concurrencyThreshold;
+		Loggers.MSG.info("{}: fast-recycle enabled, concurrency threshold = {}", toString(), concurrencyThreshold);
+	}
+
+	/**
+	 * Check whether the given completed operation is eligible for the fast-recycle
+	 * short-circuit.  Returns {@code true} only when:
+	 * <ul>
+	 *   <li>fast-recycle has been enabled (threshold &gt; 0)</li>
+	 *   <li>the current active-op count is &le; the threshold</li>
+	 *   <li>the op finished successfully</li>
+	 *   <li>the op is a simple (non-composite, non-partial) operation</li>
+	 *   <li>the driver is still running</li>
+	 * </ul>
+	 */
+	protected boolean isFastRecycleEligible(final O op) {
+		final int threshold = fastRecycleConcurrencyThreshold;
+		return threshold > 0
+						&& activeOpCount() <= threshold
+						&& op.status() == Operation.Status.SUCC
+						&& !(op instanceof CompositeOperation)
+						&& !(op instanceof PartialOperation)
+						&& isStarted();
 	}
 
 	@Override

--- a/engine/extensions/storage-drivers/primitives/coop/src/main/java/com/dell/spt/storage/driver/coop/OperationDispatchTask.java
+++ b/engine/extensions/storage-drivers/primitives/coop/src/main/java/com/dell/spt/storage/driver/coop/OperationDispatchTask.java
@@ -69,11 +69,14 @@ public final class OperationDispatchTask<I extends Item, O extends Operation<I>>
 				if (buff.size() == 0) {
 					// Both queues empty — wait for signal from producer or completion callback.
 					// The VT unmounts during await(), freeing the carrier thread.
-					// The 1ms timeout is a safety net; normal wake-up is via signal().
+					// When fast-recycle is handling ops inline, extend the timeout to 100ms
+					// since no new ops are expected via the queues.  The normal 1ms timeout
+					// applies otherwise.  In both cases, signal() provides instant wake-up.
+					final long waitMs = storageDriver.isFastRecycleEnabled() ? 100 : 1;
 					dispatchLock.lock();
 					try {
 						if (childOpQueue.isEmpty() && inOpQueue.isEmpty()) {
-							dispatchReady.await(1, TimeUnit.MILLISECONDS);
+							dispatchReady.await(waitMs, TimeUnit.MILLISECONDS);
 						}
 					} finally {
 						dispatchLock.unlock();

--- a/engine/extensions/storage-drivers/primitives/coop/src/main/java/com/dell/spt/storage/driver/coop/OperationDispatchTask.java
+++ b/engine/extensions/storage-drivers/primitives/coop/src/main/java/com/dell/spt/storage/driver/coop/OperationDispatchTask.java
@@ -69,10 +69,12 @@ public final class OperationDispatchTask<I extends Item, O extends Operation<I>>
 				if (buff.size() == 0) {
 					// Both queues empty — wait for signal from producer or completion callback.
 					// The VT unmounts during await(), freeing the carrier thread.
-					// When fast-recycle is handling ops inline, extend the timeout to 100ms
-					// since no new ops are expected via the queues.  The normal 1ms timeout
-					// applies otherwise.  In both cases, signal() provides instant wake-up.
-					final long waitMs = storageDriver.isFastRecycleEnabled() ? 100 : 1;
+					// When quiesce is active (low concurrency, fast-recycle handling most
+					// ops), extend the timeout to 100ms since few ops flow via the queues.
+					// At higher concurrency ops flow normally and the 1ms timeout keeps
+					// the dispatch task responsive.  In both cases, signal() provides
+					// instant wake-up.
+					final long waitMs = storageDriver.isFastRecycleQuiesceActive() ? 100 : 1;
 					dispatchLock.lock();
 					try {
 						if (childOpQueue.isEmpty() && inOpQueue.isEmpty()) {

--- a/engine/extensions/storage-drivers/primitives/coop/src/test/java/com/dell/spt/storage/driver/coop/CoopStorageDriverBaseTest.java
+++ b/engine/extensions/storage-drivers/primitives/coop/src/test/java/com/dell/spt/storage/driver/coop/CoopStorageDriverBaseTest.java
@@ -403,6 +403,28 @@ class CoopStorageDriverBaseTest {
 		sem.release(2);
 	}
 
+	// ---------- Fast-recycle quiesce tests ----------
+
+	@Test
+	void enableFastRecycleQuiesce_activatesQuiesceState() throws Exception {
+		final var driver = newFastRecycleDriver(4);
+
+		assertFalse(driver.isFastRecycleQuiesceActive(),
+						"quiesce should be inactive by default");
+
+		driver.enableFastRecycleQuiesce();
+
+		assertTrue(driver.isFastRecycleQuiesceActive(),
+						"quiesce should be active after enableFastRecycleQuiesce()");
+	}
+
+	@Test
+	void quiesceInactiveByDefault() throws Exception {
+		final var driver = newFastRecycleDriver(4);
+		assertFalse(driver.isFastRecycleQuiesceActive(),
+						"quiesce must be inactive when only enableFastRecycle was called");
+	}
+
 	/** Set up a driver with fast-recycle infrastructure for eligibility tests. */
 	private CoopStorageDriverBase<Item, Operation<Item>> newFastRecycleDriver(int threshold) throws Exception {
 		final var driver = mock(CoopStorageDriverBase.class, withSettings().defaultAnswer(CALLS_REAL_METHODS));

--- a/engine/extensions/storage-drivers/primitives/coop/src/test/java/com/dell/spt/storage/driver/coop/CoopStorageDriverBaseTest.java
+++ b/engine/extensions/storage-drivers/primitives/coop/src/test/java/com/dell/spt/storage/driver/coop/CoopStorageDriverBaseTest.java
@@ -84,6 +84,77 @@ class CoopStorageDriverBaseTest {
 		assertTrue(driver.isIdle(), "should be idle after release");
 	}
 
+	// ---------- Simple-op completion path (characterization for fast-recycle) ----------
+
+	@Test
+	void handleCompleted_simpleSuccessOpSendsResultToOutput() throws Exception {
+		final var driver = newRetryTestDriver();
+
+		// A simple (non-composite, non-partial) op — this is the path fast-recycle targets
+		final Operation<Item> op = mock(Operation.class);
+		final Operation<Item> resultCopy = mock(Operation.class);
+		when(op.status()).thenReturn(Operation.Status.SUCC);
+		when(op.result()).thenReturn(resultCopy);
+
+		boolean result = driver.handleCompleted(op);
+
+		assertTrue(result, "handleCompleted should return true for simple successful op");
+		// Verify the result copy (not the original) was sent to opResultOut
+		final var outField = StorageDriverBase.class.getDeclaredField("opResultOut");
+		outField.setAccessible(true);
+		final Output<Operation<Item>> opResultOut = (Output<Operation<Item>>) outField.get(driver);
+		verify(opResultOut).put(resultCopy);
+	}
+
+	@Test
+	void handleCompleted_simpleOpDoesNotUseChildQueue() throws Exception {
+		final var driver = newRetryTestDriver();
+
+		final Operation<Item> op = mock(Operation.class);
+		when(op.status()).thenReturn(Operation.Status.SUCC);
+		when(op.result()).thenReturn(mock(Operation.class));
+
+		driver.handleCompleted(op);
+
+		final var queue = childQueueOf(driver);
+		assertTrue(queue.isEmpty(), "childOpQueue should remain empty for simple ops");
+	}
+
+	@Test
+	void handleCompleted_simpleOpIncrementsCompletedCount() throws Exception {
+		final var driver = newRetryTestDriver();
+
+		final Operation<Item> op = mock(Operation.class);
+		when(op.status()).thenReturn(Operation.Status.SUCC);
+		when(op.result()).thenReturn(mock(Operation.class));
+
+		assertEquals(0, driver.completedOpCount(), "precondition: count starts at 0");
+
+		driver.handleCompleted(op);
+
+		assertEquals(1, driver.completedOpCount(), "completedOpCount should be 1 after one completion");
+	}
+
+	@Test
+	void handleCompleted_returnsFalseWhenOutputFull() throws Exception {
+		final var driver = newRetryTestDriver();
+
+		// Override opResultOut to reject (simulating queue full)
+		final Output<Operation<Item>> fullOutput = mock(Output.class);
+		when(fullOutput.put(any(Operation.class))).thenReturn(false);
+		final var outField = StorageDriverBase.class.getDeclaredField("opResultOut");
+		outField.setAccessible(true);
+		outField.set(driver, fullOutput);
+
+		final Operation<Item> op = mock(Operation.class);
+		when(op.status()).thenReturn(Operation.Status.SUCC);
+		when(op.result()).thenReturn(mock(Operation.class));
+
+		boolean result = driver.handleCompleted(op);
+
+		assertFalse(result, "should return false when opResultOut rejects the result");
+	}
+
 	// ---------- Part-level retry tests ----------
 
 	/** Set up a mock CoopStorageDriverBase with the fields needed by handleCompleted(). */

--- a/engine/extensions/storage-drivers/primitives/coop/src/test/java/com/dell/spt/storage/driver/coop/CoopStorageDriverBaseTest.java
+++ b/engine/extensions/storage-drivers/primitives/coop/src/test/java/com/dell/spt/storage/driver/coop/CoopStorageDriverBaseTest.java
@@ -10,6 +10,7 @@ import com.dell.spt.base.item.Item;
 import com.dell.spt.base.item.op.OpType;
 import com.dell.spt.base.item.op.Operation;
 import com.dell.spt.base.item.op.composite.data.CompositeDataOperationImpl;
+import com.dell.spt.base.item.op.partial.PartialOperation;
 import com.dell.spt.base.item.op.partial.data.PartialDataOperationImpl;
 import com.dell.spt.base.storage.driver.StorageDriverBase;
 import com.github.akurilov.commons.io.Output;
@@ -293,5 +294,137 @@ class CoopStorageDriverBaseTest {
 
 		final var queue = childQueueOf(driver);
 		assertTrue(queue.contains(parent), "parent should be re-enqueued when all parts done");
+	}
+
+	// ---------- Fast-recycle eligibility tests ----------
+
+	@Test
+	void enableFastRecycle_setsThreshold() throws Exception {
+		final var driver = newFastRecycleDriver(4);
+		final var threshField = CoopStorageDriverBase.class.getDeclaredField("fastRecycleConcurrencyThreshold");
+		threshField.setAccessible(true);
+		assertEquals(4, threshField.getInt(driver), "threshold should be set by enableFastRecycle");
+	}
+
+	@Test
+	void isFastRecycleEligible_trueForSimpleSuccessUnderThreshold() throws Exception {
+		final var driver = newFastRecycleDriver(4);
+
+		final Operation<Item> op = mock(Operation.class);
+		when(op.status()).thenReturn(Operation.Status.SUCC);
+
+		assertTrue(driver.isFastRecycleEligible(op),
+						"simple SUCC op under threshold should be eligible");
+	}
+
+	@Test
+	void isFastRecycleEligible_falseWhenDisabled() throws Exception {
+		// threshold = 0 means disabled
+		final var driver = newFastRecycleDriver(0);
+
+		final Operation<Item> op = mock(Operation.class);
+		when(op.status()).thenReturn(Operation.Status.SUCC);
+
+		assertFalse(driver.isFastRecycleEligible(op),
+						"should not be eligible when fast-recycle is disabled");
+	}
+
+	@Test
+	void isFastRecycleEligible_falseForFailedOp() throws Exception {
+		final var driver = newFastRecycleDriver(4);
+
+		final Operation<Item> op = mock(Operation.class);
+		when(op.status()).thenReturn(Operation.Status.FAIL_IO);
+
+		assertFalse(driver.isFastRecycleEligible(op),
+						"failed op should not be eligible for fast-recycle");
+	}
+
+	@Test
+	void isFastRecycleEligible_falseForCompositeOp() throws Exception {
+		final var driver = newFastRecycleDriver(4);
+
+		final var baseItem = new DataItemImpl("obj", 0, 4096);
+		baseItem.dataInput(DataInput.instance(null, "7a42d9c483244167", new SizeInBytes("64KB"), 4, false));
+		final var compositeOp = new CompositeDataOperationImpl<DataItem>(
+						0, OpType.CREATE, baseItem, null, "/bucket", null, null, 0, 1024);
+		compositeOp.status(Operation.Status.SUCC);
+
+		assertFalse(driver.isFastRecycleEligible((Operation<Item>) (Operation<?>) compositeOp),
+						"composite op should not be eligible for fast-recycle");
+	}
+
+	@Test
+	void isFastRecycleEligible_falseForPartialOp() throws Exception {
+		final var driver = newFastRecycleDriver(4);
+
+		final PartialOperation partialOp = mock(PartialOperation.class);
+		when(partialOp.status()).thenReturn(Operation.Status.SUCC);
+
+		assertFalse(driver.isFastRecycleEligible((Operation<Item>) partialOp),
+						"partial op should not be eligible for fast-recycle");
+	}
+
+	@Test
+	void isFastRecycleEligible_falseWhenActiveCountExceedsThreshold() throws Exception {
+		final var driver = newFastRecycleDriver(2);
+
+		// Acquire 3 permits to simulate 3 active ops (threshold=2)
+		final var semField = CoopStorageDriverBase.class.getDeclaredField("concurrencyThrottle");
+		semField.setAccessible(true);
+		final Semaphore sem = (Semaphore) semField.get(driver);
+		sem.acquire(3);
+
+		final Operation<Item> op = mock(Operation.class);
+		when(op.status()).thenReturn(Operation.Status.SUCC);
+
+		assertFalse(driver.isFastRecycleEligible(op),
+						"should not be eligible when active count exceeds threshold");
+
+		sem.release(3);
+	}
+
+	@Test
+	void isFastRecycleEligible_trueWhenActiveCountEqualsThreshold() throws Exception {
+		final var driver = newFastRecycleDriver(2);
+
+		// Acquire exactly 2 permits (threshold=2)
+		final var semField = CoopStorageDriverBase.class.getDeclaredField("concurrencyThrottle");
+		semField.setAccessible(true);
+		final Semaphore sem = (Semaphore) semField.get(driver);
+		sem.acquire(2);
+
+		final Operation<Item> op = mock(Operation.class);
+		when(op.status()).thenReturn(Operation.Status.SUCC);
+
+		assertTrue(driver.isFastRecycleEligible(op),
+						"should be eligible when active count equals threshold (boundary)");
+
+		sem.release(2);
+	}
+
+	/** Set up a driver with fast-recycle infrastructure for eligibility tests. */
+	private CoopStorageDriverBase<Item, Operation<Item>> newFastRecycleDriver(int threshold) throws Exception {
+		final var driver = mock(CoopStorageDriverBase.class, withSettings().defaultAnswer(CALLS_REAL_METHODS));
+
+		// concurrencyLimit
+		final var limitField = CoopStorageDriverBase.class.getSuperclass().getDeclaredField("concurrencyLimit");
+		limitField.setAccessible(true);
+		limitField.set(driver, 8);
+
+		// concurrencyThrottle
+		final var semField = CoopStorageDriverBase.class.getDeclaredField("concurrencyThrottle");
+		semField.setAccessible(true);
+		semField.set(driver, new Semaphore(8, true));
+
+		// fastRecycleConcurrencyThreshold
+		final var threshField = CoopStorageDriverBase.class.getDeclaredField("fastRecycleConcurrencyThreshold");
+		threshField.setAccessible(true);
+		threshField.set(driver, threshold);
+
+		// Mark as started so isStarted() returns true
+		when(driver.isStarted()).thenReturn(true);
+
+		return driver;
 	}
 }

--- a/engine/extensions/storage-drivers/primitives/coop/src/test/java/com/dell/spt/storage/driver/coop/OperationDispatchTaskTest.java
+++ b/engine/extensions/storage-drivers/primitives/coop/src/test/java/com/dell/spt/storage/driver/coop/OperationDispatchTaskTest.java
@@ -218,4 +218,50 @@ class OperationDispatchTaskTest {
 		task.stop();
 		assertTrue(task.await(5, TimeUnit.SECONDS), "task should stop within timeout");
 	}
+
+	@Test
+	void fastRecycleEnabledExtendsIdleWait() throws Exception {
+		// Enable fast-recycle on the driver mock
+		when(driverMock.isFastRecycleEnabled()).thenReturn(true);
+
+		final Operation<Item> op = mock(Operation.class);
+		when(driverMock.submit(any(Operation.class))).thenReturn(true);
+
+		task.start();
+		Thread.sleep(100); // let the task enter the extended await (100ms vs 1ms)
+
+		// Even with the extended timeout, signal() still provides instant wake-up
+		inOpQueue.add(op);
+		dispatchLock.lock();
+		try {
+			dispatchReady.signal();
+		} finally {
+			dispatchLock.unlock();
+		}
+
+		verify(driverMock, timeout(1000)).submit(any(Operation.class));
+
+		task.stop();
+		assertTrue(task.await(5, TimeUnit.SECONDS), "task should stop within timeout");
+	}
+
+	@Test
+	void fastRecycleDisabledUsesShortWait() throws Exception {
+		// Fast-recycle NOT enabled (default mock returns false)
+		when(driverMock.isFastRecycleEnabled()).thenReturn(false);
+
+		final Operation<Item> op = mock(Operation.class);
+		when(driverMock.submit(any(Operation.class))).thenReturn(true);
+
+		task.start();
+		Thread.sleep(50); // let the task enter await
+
+		// With 1ms timeout, the task wakes up quickly even without signal
+		inOpQueue.add(op);
+
+		verify(driverMock, timeout(500)).submit(any(Operation.class));
+
+		task.stop();
+		assertTrue(task.await(5, TimeUnit.SECONDS), "task should stop within timeout");
+	}
 }

--- a/engine/extensions/storage-drivers/primitives/coop/src/test/java/com/dell/spt/storage/driver/coop/OperationDispatchTaskTest.java
+++ b/engine/extensions/storage-drivers/primitives/coop/src/test/java/com/dell/spt/storage/driver/coop/OperationDispatchTaskTest.java
@@ -221,8 +221,9 @@ class OperationDispatchTaskTest {
 
 	@Test
 	void fastRecycleEnabledExtendsIdleWait() throws Exception {
-		// Enable fast-recycle on the driver mock
-		when(driverMock.isFastRecycleEnabled()).thenReturn(true);
+		// Enable fast-recycle quiesce on the driver mock — this signals that
+		// concurrency is low and the dispatch task may use the 100ms timeout
+		when(driverMock.isFastRecycleQuiesceActive()).thenReturn(true);
 
 		final Operation<Item> op = mock(Operation.class);
 		when(driverMock.submit(any(Operation.class))).thenReturn(true);
@@ -247,8 +248,8 @@ class OperationDispatchTaskTest {
 
 	@Test
 	void fastRecycleDisabledUsesShortWait() throws Exception {
-		// Fast-recycle NOT enabled (default mock returns false)
-		when(driverMock.isFastRecycleEnabled()).thenReturn(false);
+		// Fast-recycle quiesce NOT active — dispatch task uses 1ms timeout
+		when(driverMock.isFastRecycleQuiesceActive()).thenReturn(false);
 
 		final Operation<Item> op = mock(Operation.class);
 		when(driverMock.submit(any(Operation.class))).thenReturn(true);

--- a/engine/extensions/storage-drivers/primitives/netty/build.gradle
+++ b/engine/extensions/storage-drivers/primitives/netty/build.gradle
@@ -25,6 +25,9 @@ dependencies {
 		libs.log4j.core,
 	)
 
+	// Test-only dependencies
+	testImplementation libs.mockito.core
+
 	// External dependencies that will be bundled
 	implementation(
 		libs.netty.connection.pool,

--- a/engine/extensions/storage-drivers/primitives/netty/src/main/java/com/dell/spt/storage/driver/coop/netty/NettyStorageDriverBase.java
+++ b/engine/extensions/storage-drivers/primitives/netty/src/main/java/com/dell/spt/storage/driver/coop/netty/NettyStorageDriverBase.java
@@ -596,8 +596,46 @@ public abstract class NettyStorageDriverBase<I extends Item, O extends Operation
 			channel.close();
 		}
 
-		// Release permit + channel BEFORE handleCompleted so that child ops submitted
-		// by handleCompleted can re-acquire a permit without deadlocking.
+		// Fast-recycle path: keep the concurrency permit, release the channel,
+		// report metrics, then directly prepare + re-submit the original op.
+		// This avoids the VirtualThread scheduling overhead of the normal
+		// LoadGenerator recycleQueue → OperationDispatchTask path.
+		if (channel != null && isFastRecycleEligible(op)) {
+			if (!channel.attr(ATTR_KEY_RELEASED).getAndSet(Boolean.TRUE)) {
+				connPool.release(channel);
+			}
+			// Mark BEFORE handleCompleted so the result copy carries the flag
+			op.driverRecycled(true);
+			handleCompleted(op);
+			// Prepare and re-submit directly (we still hold the concurrency permit)
+			prepare(op);
+			try {
+				final Channel conn = connPool.lease();
+				conn.attr(ATTR_KEY_RELEASED).set(Boolean.FALSE);
+				if (!conn.isActive()) {
+					throw new ConnectException("Connection is not active");
+				}
+				conn.attr(ATTR_KEY_OPERATION).set(op);
+				op.nodeAddr(conn.attr(ATTR_KEY_NODE).get());
+				op.startRequest();
+				sendRequest(conn, op);
+			} catch (final ConnectException e) {
+				LogUtil.exception(Level.WARN, e, "Fast-recycle: failed to lease connection");
+				op.status(Operation.Status.FAIL_IO);
+				concurrencyThrottle.release();
+				handleCompleted(op);
+			} catch (final Throwable thrown) {
+				throwUncheckedIfInterrupted(thrown);
+				LogUtil.exception(Level.WARN, thrown, "Fast-recycle: failed to re-submit");
+				op.status(Operation.Status.FAIL_UNKNOWN);
+				concurrencyThrottle.release();
+				handleCompleted(op);
+			}
+			return;
+		}
+
+		// Normal path: release permit + channel, then let the LoadGenerator
+		// recycle queue handle re-dispatch.
 		if (channel != null && !channel.attr(ATTR_KEY_RELEASED).getAndSet(Boolean.TRUE)) {
 			concurrencyThrottle.release();
 			connPool.release(channel);

--- a/engine/extensions/storage-drivers/primitives/netty/src/test/java/com/dell/spt/storage/driver/coop/netty/NettyCompletionPathTest.java
+++ b/engine/extensions/storage-drivers/primitives/netty/src/test/java/com/dell/spt/storage/driver/coop/netty/NettyCompletionPathTest.java
@@ -91,6 +91,13 @@ class NettyCompletionPathTest {
 		return channel;
 	}
 
+	private EmbeddedChannel newResubmitChannel() {
+		final var channel = new EmbeddedChannel();
+		channel.attr(NettyStorageDriver.ATTR_KEY_RELEASED).set(Boolean.FALSE);
+		channel.attr(NonBlockingConnPool.ATTR_KEY_NODE).set("test-node:9020");
+		return channel;
+	}
+
 	@Test
 	void complete_releasesPermitAndChannel() throws Exception {
 		final var channel = newChannelWithReleasedFlag();
@@ -217,6 +224,164 @@ class NettyCompletionPathTest {
 		driver.complete(channel, op);
 
 		assertEquals(1, driver.completedOpCount(), "completedOpCount should be incremented");
+		channel.close();
+	}
+
+	// ---------- Fast-recycle path tests ----------
+
+	private void enableFastRecycle(int threshold) throws Exception {
+		final var threshField = CoopStorageDriverBase.class.getDeclaredField("fastRecycleConcurrencyThreshold");
+		threshField.setAccessible(true);
+		threshField.set(driver, threshold);
+		when(driver.isStarted()).thenReturn(true);
+	}
+
+	@Test
+	void fastRecycle_setsDriverRecycledFlagOnOp() throws Exception {
+		enableFastRecycle(4);
+		// Use higher concurrency so we have room
+		final var limitField = StorageDriverBase.class.getDeclaredField("concurrencyLimit");
+		limitField.setAccessible(true);
+		limitField.set(driver, 4);
+		final var sem = new Semaphore(4, true);
+		sem.acquire(1); // 1 active op (under threshold=4)
+		final var semField = CoopStorageDriverBase.class.getDeclaredField("concurrencyThrottle");
+		semField.setAccessible(true);
+		semField.set(driver, sem);
+
+		final var channel = newChannelWithReleasedFlag();
+		final Operation<Item> op = mock(Operation.class);
+		final Operation<Item> resultCopy = mock(Operation.class);
+		when(op.status()).thenReturn(Operation.Status.SUCC);
+		when(op.result()).thenReturn(resultCopy);
+
+		// Mock connPool.lease() to return a new channel for re-submit
+		final var resubmitChannel = newResubmitChannel();
+		when(connPool.lease()).thenReturn(resubmitChannel);
+
+		driver.complete(channel, op);
+
+		// The op should have driverRecycled set to true before result() is called
+		verify(op).driverRecycled(true);
+		channel.close();
+		resubmitChannel.close();
+	}
+
+	@Test
+	void fastRecycle_keepsPermitAndReleasesChannel() throws Exception {
+		enableFastRecycle(4);
+		final var limitField = StorageDriverBase.class.getDeclaredField("concurrencyLimit");
+		limitField.setAccessible(true);
+		limitField.set(driver, 4);
+		final var sem = new Semaphore(4, true);
+		sem.acquire(1);
+		final var semField = CoopStorageDriverBase.class.getDeclaredField("concurrencyThrottle");
+		semField.setAccessible(true);
+		semField.set(driver, sem);
+
+		final var channel = newChannelWithReleasedFlag();
+		final Operation<Item> op = mock(Operation.class);
+		when(op.status()).thenReturn(Operation.Status.SUCC);
+		when(op.result()).thenReturn(mock(Operation.class));
+
+		// Mock connPool.lease() for re-submit
+		final var resubmitChannel = newResubmitChannel();
+		when(connPool.lease()).thenReturn(resubmitChannel);
+
+		driver.complete(channel, op);
+
+		// Channel should be released to the pool
+		verify(connPool).release(channel);
+		// Permit should NOT be released — it's held for the re-submitted op.
+		// Before complete: 3 available (4 total - 1 acquired).
+		// After fast-recycle: still 3 available (permit retained for new submit).
+		assertEquals(3, sem.availablePermits(),
+						"permit should be retained for the re-submitted op");
+		channel.close();
+		resubmitChannel.close();
+	}
+
+	@Test
+	void fastRecycle_resetsOpForResubmit() throws Exception {
+		enableFastRecycle(4);
+		final var limitField = StorageDriverBase.class.getDeclaredField("concurrencyLimit");
+		limitField.setAccessible(true);
+		limitField.set(driver, 4);
+		final var sem = new Semaphore(4, true);
+		sem.acquire(1);
+		final var semField = CoopStorageDriverBase.class.getDeclaredField("concurrencyThrottle");
+		semField.setAccessible(true);
+		semField.set(driver, sem);
+
+		final var channel = newChannelWithReleasedFlag();
+		final Operation<Item> op = mock(Operation.class);
+		when(op.status()).thenReturn(Operation.Status.SUCC);
+		when(op.result()).thenReturn(mock(Operation.class));
+
+		final var resubmitChannel = newResubmitChannel();
+		when(connPool.lease()).thenReturn(resubmitChannel);
+
+		driver.complete(channel, op);
+
+		// prepare() calls op.reset() internally — verify reset was called
+		verify(op).reset();
+		// Also verify the op was re-submitted (startRequest called on the re-prepared op)
+		verify(op, atLeast(1)).startRequest();
+		channel.close();
+		resubmitChannel.close();
+	}
+
+	@Test
+	void fastRecycle_fallsBackToNormalPathWhenNotEligible() throws Exception {
+		// Fast-recycle enabled but op failed — should use normal path
+		enableFastRecycle(4);
+		final var limitField = StorageDriverBase.class.getDeclaredField("concurrencyLimit");
+		limitField.setAccessible(true);
+		limitField.set(driver, 4);
+		final var sem = new Semaphore(4, true);
+		sem.acquire(1);
+		final var semField = CoopStorageDriverBase.class.getDeclaredField("concurrencyThrottle");
+		semField.setAccessible(true);
+		semField.set(driver, sem);
+
+		final var channel = newChannelWithReleasedFlag();
+		final Operation<Item> op = mock(Operation.class);
+		when(op.status()).thenReturn(Operation.Status.FAIL_IO);
+		when(op.result()).thenReturn(mock(Operation.class));
+
+		driver.complete(channel, op);
+
+		// Normal path: permit released, no driverRecycled flag set
+		verify(op, never()).driverRecycled(anyBoolean());
+		assertEquals(4, sem.availablePermits(), "permit should be released in normal path");
+		channel.close();
+	}
+
+	@Test
+	void fastRecycle_releasesPermitOnLeaseFailure() throws Exception {
+		enableFastRecycle(4);
+		final var limitField = StorageDriverBase.class.getDeclaredField("concurrencyLimit");
+		limitField.setAccessible(true);
+		limitField.set(driver, 4);
+		final var sem = new Semaphore(4, true);
+		sem.acquire(1);
+		final var semField = CoopStorageDriverBase.class.getDeclaredField("concurrencyThrottle");
+		semField.setAccessible(true);
+		semField.set(driver, sem);
+
+		final var channel = newChannelWithReleasedFlag();
+		final Operation<Item> op = mock(Operation.class);
+		when(op.status()).thenReturn(Operation.Status.SUCC);
+		when(op.result()).thenReturn(mock(Operation.class));
+
+		// connPool.lease() throws — simulating no connections available
+		when(connPool.lease()).thenThrow(new java.net.ConnectException("no connections"));
+
+		driver.complete(channel, op);
+
+		// After lease failure, permit should be released
+		assertEquals(4, sem.availablePermits(),
+						"permit should be released after fast-recycle lease failure");
 		channel.close();
 	}
 }

--- a/engine/extensions/storage-drivers/primitives/netty/src/test/java/com/dell/spt/storage/driver/coop/netty/NettyCompletionPathTest.java
+++ b/engine/extensions/storage-drivers/primitives/netty/src/test/java/com/dell/spt/storage/driver/coop/netty/NettyCompletionPathTest.java
@@ -1,0 +1,222 @@
+package com.dell.spt.storage.driver.coop.netty;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import com.dell.spt.base.item.Item;
+import com.dell.spt.base.item.op.Operation;
+import com.dell.spt.base.storage.driver.StorageDriverBase;
+import com.dell.spt.storage.driver.coop.CoopStorageDriverBase;
+import com.github.akurilov.commons.io.Output;
+import com.github.akurilov.netty.connection.pool.NonBlockingConnPool;
+import io.netty.channel.embedded.EmbeddedChannel;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.atomic.LongAdder;
+import java.util.concurrent.locks.ReentrantLock;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Characterization tests for {@link NettyStorageDriverBase#complete(io.netty.channel.Channel,
+ * Operation)}. These capture the current completion path behavior as a safety net before
+ * introducing fast-recycle dispatch.
+ */
+@SuppressWarnings("unchecked")
+class NettyCompletionPathTest {
+
+	private NettyStorageDriverBase<Item, Operation<Item>> driver;
+	private Semaphore concurrencyThrottle;
+	private NonBlockingConnPool connPool;
+	private Output<Operation<Item>> opResultOut;
+
+	@BeforeEach
+	void setUp() throws Exception {
+		driver = mock(NettyStorageDriverBase.class, withSettings().defaultAnswer(CALLS_REAL_METHODS));
+
+		// concurrencyThrottle — 1 permit, acquired (simulating an in-flight op)
+		concurrencyThrottle = new Semaphore(1, true);
+		concurrencyThrottle.acquire(); // simulate op holding the permit
+		final var semField = CoopStorageDriverBase.class.getDeclaredField("concurrencyThrottle");
+		semField.setAccessible(true);
+		semField.set(driver, concurrencyThrottle);
+
+		// concurrencyLimit (needed by activeOpCount)
+		final var limitField = StorageDriverBase.class.getDeclaredField("concurrencyLimit");
+		limitField.setAccessible(true);
+		limitField.set(driver, 1);
+
+		// connPool — mock
+		connPool = mock(NonBlockingConnPool.class);
+		final var poolField = NettyStorageDriverBase.class.getDeclaredField("connPool");
+		poolField.setAccessible(true);
+		poolField.set(driver, connPool);
+
+		// stepId
+		final var stepIdField = StorageDriverBase.class.getDeclaredField("stepId");
+		stepIdField.setAccessible(true);
+		stepIdField.set(driver, "test-step");
+
+		// completedOpCount
+		final var completedField = CoopStorageDriverBase.class.getDeclaredField("completedOpCount");
+		completedField.setAccessible(true);
+		completedField.set(driver, new LongAdder());
+
+		// childOpQueue
+		final var childQueueField = CoopStorageDriverBase.class.getDeclaredField("childOpQueue");
+		childQueueField.setAccessible(true);
+		childQueueField.set(driver, new ArrayBlockingQueue<>(100));
+
+		// dispatch lock and condition
+		final var lockField = CoopStorageDriverBase.class.getDeclaredField("dispatchLock");
+		lockField.setAccessible(true);
+		final var lock = new ReentrantLock();
+		lockField.set(driver, lock);
+		final var condField = CoopStorageDriverBase.class.getDeclaredField("dispatchReady");
+		condField.setAccessible(true);
+		condField.set(driver, lock.newCondition());
+
+		// opResultOut — mock that accepts anything
+		opResultOut = mock(Output.class);
+		when(opResultOut.put(any(Operation.class))).thenReturn(true);
+		final var outField = StorageDriverBase.class.getDeclaredField("opResultOut");
+		outField.setAccessible(true);
+		outField.set(driver, opResultOut);
+	}
+
+	private EmbeddedChannel newChannelWithReleasedFlag() {
+		final var channel = new EmbeddedChannel();
+		channel.attr(NettyStorageDriver.ATTR_KEY_RELEASED).set(Boolean.FALSE);
+		return channel;
+	}
+
+	@Test
+	void complete_releasesPermitAndChannel() throws Exception {
+		final var channel = newChannelWithReleasedFlag();
+		final Operation<Item> op = mock(Operation.class);
+		when(op.status()).thenReturn(Operation.Status.SUCC);
+		when(op.result()).thenReturn(mock(Operation.class));
+
+		assertEquals(0, concurrencyThrottle.availablePermits(), "precondition: permit held");
+
+		driver.complete(channel, op);
+
+		assertEquals(1, concurrencyThrottle.availablePermits(), "permit should be released");
+		verify(connPool).release(channel);
+		channel.close();
+	}
+
+	@Test
+	void complete_releasesPermitBeforeHandleCompleted() throws Exception {
+		// Verify the ordering guarantee: permit is freed before handleCompleted runs,
+		// so child ops submitted by handleCompleted can re-acquire a permit.
+		final var channel = newChannelWithReleasedFlag();
+		final Operation<Item> op = mock(Operation.class);
+		final Operation<Item> resultCopy = mock(Operation.class);
+		when(op.status()).thenReturn(Operation.Status.SUCC);
+		when(op.result()).thenReturn(resultCopy);
+
+		// When opResultOut.put() is called (inside handleCompleted), the permit should
+		// already be released.
+		when(opResultOut.put(any(Operation.class))).thenAnswer(inv -> {
+			assertEquals(1, concurrencyThrottle.availablePermits(),
+							"permit must be released before handleCompleted processes the result");
+			return true;
+		});
+
+		driver.complete(channel, op);
+
+		verify(opResultOut).put(resultCopy);
+		channel.close();
+	}
+
+	@Test
+	void complete_callsFinishResponse() {
+		final var channel = newChannelWithReleasedFlag();
+		final Operation<Item> op = mock(Operation.class);
+		when(op.status()).thenReturn(Operation.Status.SUCC);
+		when(op.result()).thenReturn(mock(Operation.class));
+
+		driver.complete(channel, op);
+
+		verify(op).finishResponse();
+		channel.close();
+	}
+
+	@Test
+	void complete_closesChannelOnFailure() {
+		final var channel = newChannelWithReleasedFlag();
+		final Operation<Item> op = mock(Operation.class);
+		when(op.status()).thenReturn(Operation.Status.FAIL_IO);
+		when(op.result()).thenReturn(mock(Operation.class));
+
+		driver.complete(channel, op);
+
+		// EmbeddedChannel.close() is asynchronous; check the state
+		assertFalse(channel.isActive(), "channel should be closed on failure");
+	}
+
+	@Test
+	void complete_doesNotCloseChannelOnSuccess() {
+		final var channel = newChannelWithReleasedFlag();
+		final Operation<Item> op = mock(Operation.class);
+		when(op.status()).thenReturn(Operation.Status.SUCC);
+		when(op.result()).thenReturn(mock(Operation.class));
+
+		driver.complete(channel, op);
+
+		assertTrue(channel.isOpen(), "channel should remain open on success");
+		channel.close();
+	}
+
+	@Test
+	void complete_idempotentRelease() throws Exception {
+		// Simulates a scenario where complete() is called twice for the same op
+		// (e.g., both success handler and exception handler fire).
+		// The permit and channel should only be released once.
+		final var channel = newChannelWithReleasedFlag();
+		final Operation<Item> op = mock(Operation.class);
+		when(op.status()).thenReturn(Operation.Status.SUCC);
+		when(op.result()).thenReturn(mock(Operation.class));
+
+		driver.complete(channel, op);
+		driver.complete(channel, op);
+
+		// Permit starts at 0 (acquired), gets released once → 1
+		// If released twice it would be 2, which is wrong.
+		assertEquals(1, concurrencyThrottle.availablePermits(),
+						"permit should only be released once even with double complete");
+		verify(connPool, times(1)).release(channel);
+		channel.close();
+	}
+
+	@Test
+	void complete_handlesNullChannel() {
+		// NOOP operations have a null channel
+		final Operation<Item> op = mock(Operation.class);
+		when(op.status()).thenReturn(Operation.Status.SUCC);
+		when(op.result()).thenReturn(mock(Operation.class));
+
+		// Should not throw
+		assertDoesNotThrow(() -> driver.complete(null, op));
+		// Permit should NOT be released (null channel path skips release)
+		assertEquals(0, concurrencyThrottle.availablePermits(),
+						"null channel should not release permit");
+	}
+
+	@Test
+	void complete_incrementsCompletedCount() {
+		final var channel = newChannelWithReleasedFlag();
+		final Operation<Item> op = mock(Operation.class);
+		when(op.status()).thenReturn(Operation.Status.SUCC);
+		when(op.result()).thenReturn(mock(Operation.class));
+
+		assertEquals(0, driver.completedOpCount(), "precondition: count starts at 0");
+
+		driver.complete(channel, op);
+
+		assertEquals(1, driver.completedOpCount(), "completedOpCount should be incremented");
+		channel.close();
+	}
+}


### PR DESCRIPTION
Three optimizations, applied incrementally:

  • Fast-recycle dispatch -- When a completed read op is eligible for reuse (simple success, active ops below threshold), re-submit it
  inline on the Netty I/O thread instead of round-tripping through a virtual thread. Eliminates a VT wake/schedule/park cycle per recycled
  op.
  • VT quiesce -- At low concurrency (T1-T4), the LoadGenerator and OperationDispatchTask virtual threads park with a 10ms timeout instead
  of spin-yielding when idle. Reduces context switches from ~106K/s to ~13.6K/s at T1. Gated to concurrency <= 4 to avoid park/unpark
  overhead at T8+ where the normal pipeline stays saturated.
  • JVMTI VT transition disable -- Added -XX:+UnlockExperimentalVMOptions -XX:-DoJVMTIVirtualThreadTransitions to entrypoint scripts and
  build.gradle. Eliminates JVM bookkeeping for VT mount/unmount events. ~1-2% additional.

Results

Read performance (1MB objects, SeaweedFS, single host)

Threads  Before     After              
T1       335 ops/s  492 ops/s (+46.9%) 
T4       1,586      1,738 (+9.6%)     
T8       2,482      2,277 (-8.3%)     
T32      2,203      1,729 (-21.5%)    

Full validation (overnight, all object sizes, 3-min runs x3 iterations)

Reads: SPT wins or ties 14 of 16 configurations (1KB/128KB/1MB/10MB x T1/T4/T8/T32). Largest gains at small objects and low concurrency:
1KB/T1 +14.9%, 10MB/T1 +20.0%. Two marginal losses (1MB/T32 -1.7%, 10MB/T8 -1.8%) are within run-to-run variance.

Writes: No change -- this PR touches the read/recycle path only. Write numbers match baseline across all configurations.

Changes

Engine (production):

  • NettyStorageDriverBase -- inline fast-recycle on I/O thread completion path
  • CoopStorageDriverBase -- fast-recycle eligibility check, quiesce flag, concurrency threshold
  • OperationDispatchTask -- extended idle wait (100ms) when quiesce is active, 1ms otherwise
  • LoadGeneratorImpl -- park/unpark with generatorParked guard to avoid spurious syscalls
  • LoadStepContextImpl -- wiring: fast-recycle at all concurrencies, quiesce only at concurrency <= 4
  • StorageDriver / LoadGenerator -- interface additions for enableFastRecycle, enableFastRecycleQuiesce
  • Operation / OperationImpl -- driverRecycled flag for fast-recycle tracking
  • entrypoint.sh + build.gradle -- JVMTI VT transition flag

Engine (tests):

  • NettyCompletionPathTest -- 6 tests covering fast-recycle completion path (permit retention, channel release, op reset, fallback, lease
  failure)
  • CoopStorageDriverBaseTest -- 10 tests for eligibility logic + quiesce state
  • OperationDispatchTaskTest -- 2 tests for quiesce-aware timeout behavior
  • LoadGeneratorImplRecycleTest -- 8 tests for recycle polling, quiesce park/unpark, generatorParked guard
  • OperationImplTest -- driverRecycled flag
