### PR TITLE
upgrade Docker runtime to JDK 25 to improve small object writes

### DIFF
--- a/engine/build.gradle
+++ b/engine/build.gradle
@@ -33,6 +33,10 @@ subprojects {
             targetCompatibility = JavaVersion.VERSION_21
         }
         
+        tasks.withType(JavaCompile).configureEach {
+            options.release = 21
+        }
+        
         jacoco {
             toolVersion = "0.8.13"
         }

--- a/engine/bundle/Dockerfile
+++ b/engine/bundle/Dockerfile
@@ -5,10 +5,10 @@
 #
 # Build context should be the bundle directory after running the build.
 
-# Allow overriding the base image (default pins Eclipse Temurin JRE 21 LTS)
+# Allow overriding the base image (default pins Eclipse Temurin JRE 25 LTS)
 # Pinned to digest for reproducibility - update via Dependabot/Renovate
-# To find latest digest: docker buildx imagetools inspect eclipse-temurin:21-jre-jammy
-ARG BASE_IMAGE=eclipse-temurin:21.0.10_7-jre-jammy@sha256:763795421d2991e4c5b7f06a0776a3a89c9eb1688074b6f3a4efa34336867a17
+# To find latest digest: docker buildx imagetools inspect eclipse-temurin:25-jre-jammy
+ARG BASE_IMAGE=eclipse-temurin:25-jre-jammy@sha256:305fb0c3e5f47ea70ed6670845deb8bddbc362ad4c42354e85273ec9a31bd064
 ARG SPT_VERSION=0.0.0-dev
 ARG SPT_RELEASE_VERSION=${SPT_VERSION}
 FROM ${BASE_IMAGE}

--- a/engine/bundle/docker/entrypoint.sh
+++ b/engine/bundle/docker/entrypoint.sh
@@ -16,7 +16,7 @@ set -eu
 # Use parameter expansion to handle unset JAVA_OPTS safely
 JAVA_OPTS="${JAVA_OPTS:-}"
 if [ -z "$JAVA_OPTS" ]; then
-    # Default Java options for Spt (JDK 21+)
+    # Default Java options for Spt (JDK 25 LTS Docker image)
     # - ZGC: sub-millisecond GC pauses; avoids GC jitter in latency measurements
     # - Xmx 4g: bounded heap for Java objects (GC works best with a defined ceiling)
     # - MaxDirectMemorySize 64g: separate ceiling for off-heap ByteBuffers (RDMA/NIO);
@@ -27,7 +27,9 @@ if [ -z "$JAVA_OPTS" ]; then
     # - UseAVX=2: avoid AVX-512 EVEX glibc code paths with known SIGBUS crashes
     # - DoJVMTIVirtualThreadTransitions: skip JVMTI mount/unmount notifications on every
     #   VirtualThread context switch; reduces per-op overhead when no debugging agent is attached
-    export JAVA_OPTS="-XX:+UseZGC -Xms1g -Xmx4g -XX:MaxDirectMemorySize=64g -XX:+AlwaysPreTouch -XX:+UseNUMA -Xshare:off -XX:UseAVX=2 -XX:+UnlockExperimentalVMOptions -XX:-DoJVMTIVirtualThreadTransitions"
+    # - UseCompactObjectHeaders (JEP 519): 64-bit object headers instead of 128-bit;
+    #   reduces heap footprint and GC pressure for high-rate short-lived objects
+    export JAVA_OPTS="-XX:+UseZGC -Xms1g -Xmx4g -XX:MaxDirectMemorySize=64g -XX:+AlwaysPreTouch -XX:+UseNUMA -Xshare:off -XX:UseAVX=2 -XX:+UnlockExperimentalVMOptions -XX:-DoJVMTIVirtualThreadTransitions -XX:+UseCompactObjectHeaders"
 fi
 
 # Additional Java options that can be set via environment variables


### PR DESCRIPTION

Summary

  • Upgrade Docker base image from Eclipse Temurin JRE 21 to JRE 25 (pinned to digest)
  • Enable -XX:+UseCompactObjectHeaders (JEP 519) in default JAVA_OPTS
  • Add options.release = 21 to Gradle build to prevent accidental use of JDK 22+ APIs

Motivation

Profiling small-object (1KB) S3 writes at high concurrency (T32) revealed that ~24% of CPU was spent in JVM virtual-thread scheduling overhead — specifically the VT-
unparker ScheduledThreadPoolExecutor and per-park ScheduledFutureTask allocations. JDK 25 includes two changes that directly address this:

  • JDK-8319447 / JDK-8351927: Replaces VT timed-park handling with ForkJoinPool's native delayed-task scheduler, eliminating the separate VT-unparker thread pool
  • JEP 519 (Compact Object Headers): Reduces object header size from 128-bit to 64-bit, lowering heap footprint and GC pressure for high-rate short-lived objects

Combined with the dispatch await changes in #75, overnight comparison benchmarks against Warp show the 1KB T32 write gap narrowing from -9.4% to -3.0% (within run-to-run
variance). 128KB T4/T8 gaps improved by ~5pp each. Read performance remains a strong SPT advantage (+11-16% for 1KB reads).

Changes

File                                Change
engine/build.gradle                 options.release = 21 — compile-time safety net
engine/bundle/Dockerfile            Base image eclipse-temurin:21 → eclipse-temurin:25-jre-jammy (digest-pinned)
engine/bundle/docker/entrypoint.sh  Add -XX:+UseCompactObjectHeaders, update comments