### PR TITLE
Add --checksum CLI flag and S3 checksum support across drivers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Added
+
+- **`--checksum` CLI flag** — enable per-object (and per-part for MPU) checksum validation with `crc32`, `crc32c`, `sha1`, or `sha256`. Environment variable: `SPT_CHECKSUM`. Works with both the Netty and AWS SDK S3 drivers.
+- **S3-AWS driver checksum support** — the `s3-aws` driver now reads `storage.checksum.enabled` / `storage.checksum.algorithm` from config and sets the corresponding `ChecksumAlgorithm` on `PutObjectRequest` via the AWS SDK flexible checksum API. Supported algorithms: CRC32, CRC32C, SHA1, SHA256.
+- **Netty S3 driver MPU checksum completeness** — multipart upload init requests now include the `x-amz-checksum-algorithm` header, the response handler captures per-part checksum headers, and the complete-upload XML body includes per-part checksum elements.
+
 ## [5.7.0] - 2026-04-09
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ For the full CLI reference (all flags, workload types, distributed options, RDMA
 - **Multi-Workload Support** -- write, read, list, and mock workloads out of the box, with S3 Tables (Iceberg) benchmarks.
 - **Pluggable S3 Storage Drivers** -- choose the backend that fits your target: `default` (Netty), `aws` (AWS SDK v2), or `rdma` (hardware-accelerated). Select with `--s3-driver`.
 - **S3 Multipart Upload** -- upload large objects in parallel parts with automatic abort on failure, per-part retry (up to 3 attempts), and per-part checksum support. Enable with `--part-size`.
+- **S3 Checksum Validation** -- compute and send checksums on write requests with `--checksum` (`crc32`, `crc32c`, `sha1`, `sha256`). When combined with multipart upload, checksums are applied per part. Supported by both the Netty and AWS SDK drivers.
 - **Interactive & Headless** -- flip between a terminal UI for live monitoring and headless mode for CI/CD.
 - **Distributed Runs** – preflight checks, node orchestration, and attachment support are built into the CLI.
 - **Scenario Generation** – the CLI generates scenario files on the fly for the engine, sparing users from manual scripting.

--- a/cli/README.md
+++ b/cli/README.md
@@ -359,6 +359,7 @@ Executes a benchmark test with the specified workload type.
 - `--threads, -t`: Number of parallel client threads (default: 1)
 - `--object-size, -o`: Size of each object (e.g., 1MB, 256KB, 4GB)
 - `--part-size`: Enable S3 multipart upload with the given part size (e.g., 5MB, 64MB). When set, `load.batch.size` is forced to `1`. The engine automatically retries individual parts (up to 3 times) and aborts incomplete uploads on failure. Per-part checksums are applied when checksum is enabled. See [`SPT_SYNTAX.md`](docs/SPT_SYNTAX.md) for details
+- `--checksum`: Enable S3 checksum validation with the specified algorithm: `crc32`, `crc32c`, `sha1`, `sha256`. When used with `--part-size`, checksums are applied per part. (env: `SPT_CHECKSUM`)
 - `--cleanup`: Delete all created objects after test completion
 - `--create-prefix`: Ensure target prefix exists before testing
 - `--output-dir, -O`: Directory to save detailed Spt reports

--- a/cli/cmd/envdefaults.go
+++ b/cli/cmd/envdefaults.go
@@ -157,6 +157,9 @@ func applyEnvDefaultsToRunFlags(cmd *cobra.Command) error {
 		}
 	}
 
+	// Checksum algorithm: SPT_CHECKSUM env var (values: crc32, crc32c, sha1, sha256)
+	_ = setIf("checksum", constants.EnvChecksum)
+
 	return nil
 }
 

--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -915,6 +915,11 @@ Shorthand: --use-rdma is equivalent to --s3-driver rdma. (env: SPT_S3_DRIVER)`)
 	runCmd.Flags().String("rdma-log-level", "WARN", "RDMA native library log level (env: RDMA_LOG_LEVEL)")
 	runCmd.Flags().Int64("rdma-timeout-ms", 30000, "RDMA operation timeout in milliseconds (env: RDMA_TIMEOUT_MS)")
 
+	// Checksum Options
+	runCmd.Flags().String("checksum", "",
+		`Enable checksum validation with the specified algorithm: crc32, crc32c, sha1, sha256.
+Omit to disable checksums. (env: SPT_CHECKSUM)`)
+
 	// S3 Tables Options
 	runCmd.Flags().String("test-vector", "tps", "Tables test vector: tps | compaction | catalog")
 	runCmd.Flags().String("table-bucket", "spt-tables", "S3 Table bucket name")
@@ -1137,6 +1142,20 @@ func buildScenarioParams(workloadType string, cmd *cobra.Command) (scenario.Para
 		params.RdmaDevice, _ = cmd.Flags().GetString("rdma-device")
 		params.RdmaLogLevel, _ = cmd.Flags().GetString("rdma-log-level")
 		params.RdmaTimeoutMs, _ = cmd.Flags().GetInt64("rdma-timeout-ms")
+	}
+
+	// Checksum validation
+	checksumAlgo, _ := cmd.Flags().GetString("checksum")
+	if checksumAlgo != "" {
+		checksumAlgo = strings.ToLower(strings.TrimSpace(checksumAlgo))
+		switch checksumAlgo {
+		case scenario.ChecksumCRC32, scenario.ChecksumCRC32C,
+			scenario.ChecksumSHA1, scenario.ChecksumSHA256:
+			// valid
+		default:
+			return params, fmt.Errorf("invalid --checksum value %q: must be one of: crc32, crc32c, sha1, sha256", checksumAlgo)
+		}
+		params.Checksum = checksumAlgo
 	}
 
 	// TUI layout

--- a/cli/docs/SPT_SYNTAX.md
+++ b/cli/docs/SPT_SYNTAX.md
@@ -40,6 +40,7 @@ You can use these variables to avoid repeating sensitive or commonly used parame
 - **Docker:** `SPT_SKIP_IMAGE_PULL` (skip pulling the engine image)
 - **Engine tuning:** `SPT_SERVICE_THREADS` (virtual-thread carrier parallelism)
 - **Multipart upload:** `SPT_PART_SIZE` (part size, e.g. `64MB`)
+- **Checksum:** `SPT_CHECKSUM` (algorithm: `crc32`, `crc32c`, `sha1`, `sha256`)
 - **Storage driver:** `SPT_S3_DRIVER` (driver backend: `default`, `aws`, `rdma`)
 - **RDMA:** `SPT_RDMA_ENABLED`, `RDMA_LOCAL_IP`, `RDMA_DEVICE`, `RDMA_LOG_LEVEL`, `RDMA_THRESHOLD_BYTES`, `RDMA_TIMEOUT_MS`, `RDMA_FALLBACK_ENABLED`
 
@@ -93,6 +94,7 @@ Required for S3 workloads, optional/ignored for `mock`.
 | `--object-count` | `-n` | `0` | Fixed number of objects to process |
 | `--duration` | `-d` | `""` | Fixed time duration (e.g., `5m`, `1h`) |
 | `--seed-objects` | | `2500` | Objects to pre-create for `read` benchmarks |
+| `--checksum` | | `""` | Enable S3 checksum validation with the specified algorithm: `crc32`, `crc32c`, `sha1`, `sha256`. Omit to disable checksums. When set with `--part-size`, checksums are applied per part. (env: `SPT_CHECKSUM`) |
 | `--save-items` | | `false` | Save `items.csv` listing created objects (`write` only) |
 | `--items-file` | | `""` | Path to a saved `items.csv` for `read` (skips seed phase) |
 
@@ -444,6 +446,40 @@ spt run write \
     --cleanup
 ```
 
+### Checksum Validation
+
+Enable per-object (or per-part, when using multipart upload) checksum validation with `--checksum`:
+
+```bash
+# Write with CRC32C checksums
+spt run write \
+    --endpoints https://s3.example.com \
+    --access-key "$S3_ACCESS_KEY" \
+    --secret-key "$S3_SECRET_KEY" \
+    --bucket benchmark-test \
+    --threads 16 \
+    --object-size 1MB \
+    --duration 5m \
+    --checksum crc32c \
+    --cleanup
+```
+
+```bash
+# Multipart upload with per-part SHA-256 checksums
+spt run write \
+    --endpoints https://s3.example.com \
+    --access-key "$S3_ACCESS_KEY" \
+    --secret-key "$S3_SECRET_KEY" \
+    --bucket benchmark-test \
+    --threads 16 \
+    --object-size 1GB \
+    --part-size 64MB \
+    --object-count 50 \
+    --checksum sha256
+```
+
+Supported algorithms: `crc32`, `crc32c`, `sha1`, `sha256`. The flag works with both the default Netty driver and the AWS SDK driver (`--s3-driver aws`).
+
 ### Distributed / Attach Mode
 
 If operators have already started SPT worker containers, `spt` can attach to those workers and only launch the entry node:
@@ -619,6 +655,7 @@ Node status (port 9999)
 | Post-test cleanup (`--cleanup`) | Implemented |
 | Auto-results retrieval | Implemented |
 | Save/reuse item lists (`--save-items` / `--items-file`) | Implemented |
+| Checksum validation (`--checksum`) | Implemented |
 | RDMA acceleration | Implemented |
 | TUI live dashboard | Implemented |
 | Headless / CI mode | Implemented |

--- a/cli/internal/constants/envvars.go
+++ b/cli/internal/constants/envvars.go
@@ -17,6 +17,9 @@ const (
 	// Multipart upload configuration
 	EnvPartSize = "SPT_PART_SIZE"
 
+	// Checksum configuration
+	EnvChecksum = "SPT_CHECKSUM"
+
 	// RDMA configuration environment variables
 	EnvRdmaLocalIP   = "RDMA_LOCAL_IP"
 	EnvRdmaThreshold = "RDMA_THRESHOLD_BYTES"

--- a/cli/internal/scenario/constants.go
+++ b/cli/internal/scenario/constants.go
@@ -21,6 +21,15 @@ const (
 	// S3DriverRdma selects the RDMA-accelerated S3 driver.
 	S3DriverRdma = "rdma"
 
+	// ChecksumCRC32 selects CRC-32 checksum validation.
+	ChecksumCRC32 = "crc32"
+	// ChecksumCRC32C selects CRC-32C checksum validation.
+	ChecksumCRC32C = "crc32c"
+	// ChecksumSHA1 selects SHA-1 checksum validation.
+	ChecksumSHA1 = "sha1"
+	// ChecksumSHA256 selects SHA-256 checksum validation.
+	ChecksumSHA256 = "sha256"
+
 	itemTypeData         = "data"
 	itemTypePath         = "path"
 	itemNamingTypeRandom = "random"

--- a/cli/internal/scenario/defaults.go
+++ b/cli/internal/scenario/defaults.go
@@ -24,10 +24,17 @@ type DefaultsConfig struct {
 
 // StorageConfig represents storage configuration
 type StorageConfig struct {
-	Driver DriverConfig `yaml:"driver,omitempty"`
-	Net    NetConfig    `yaml:"net,omitempty"`
-	Auth   AuthConfig   `yaml:"auth,omitempty"`
-	Rdma   *RdmaConfig  `yaml:"rdma,omitempty"` // pointer so omitted when nil
+	Driver   DriverConfig    `yaml:"driver,omitempty"`
+	Net      NetConfig       `yaml:"net,omitempty"`
+	Auth     AuthConfig      `yaml:"auth,omitempty"`
+	Checksum *ChecksumConfig `yaml:"checksum,omitempty"` // pointer so omitted when nil
+	Rdma     *RdmaConfig     `yaml:"rdma,omitempty"`     // pointer so omitted when nil
+}
+
+// ChecksumConfig represents storage checksum configuration
+type ChecksumConfig struct {
+	Enabled   bool   `yaml:"enabled"`
+	Algorithm string `yaml:"algorithm"`
 }
 
 // RdmaConfig represents RDMA acceleration configuration for the s3-rdma driver
@@ -327,6 +334,14 @@ func GenerateDefaults(params Params) ([]byte, error) {
 				LocalIP:   params.RdmaLocalIP,
 				LogLevel:  logLevel,
 				TimeoutMs: timeoutMs,
+			}
+		}
+
+		// Checksum validation: populate checksum config when algorithm is specified
+		if params.Checksum != "" {
+			config.Storage.Checksum = &ChecksumConfig{
+				Enabled:   true,
+				Algorithm: params.Checksum,
 			}
 		}
 

--- a/cli/internal/scenario/defaults_test.go
+++ b/cli/internal/scenario/defaults_test.go
@@ -847,6 +847,130 @@ func TestGenerateDefaults(t *testing.T) {
 		tests = append(tests, tt)
 	}
 
+	// Checksum test cases
+	checksumCases := []struct {
+		name        string
+		params      Params
+		wantErr     bool
+		checkOutput func(t *testing.T, data []byte)
+	}{
+		{
+			name: "checksum crc32 enables checksum section",
+			params: Params{
+				WorkloadType: "write",
+				Endpoint:     "http://s3.example.com",
+				AccessKey:    "key",
+				SecretKey:    "secret",
+				Bucket:       "bucket",
+				Threads:      4,
+				Checksum:     "crc32",
+			},
+			wantErr: false,
+			checkOutput: func(t *testing.T, data []byte) {
+				t.Helper()
+				var config DefaultsConfig
+				if err := yaml.Unmarshal(data, &config); err != nil {
+					t.Fatalf("Failed to unmarshal YAML: %v", err)
+				}
+				if config.Storage.Checksum == nil {
+					t.Fatal("Expected storage.checksum section to be present")
+				}
+				if !config.Storage.Checksum.Enabled {
+					t.Error("Expected checksum.enabled to be true")
+				}
+				if config.Storage.Checksum.Algorithm != "crc32" {
+					t.Errorf("Expected algorithm 'crc32', got %q", config.Storage.Checksum.Algorithm)
+				}
+			},
+		},
+		{
+			name: "checksum sha256",
+			params: Params{
+				WorkloadType: "write",
+				Endpoint:     "http://s3.example.com",
+				AccessKey:    "key",
+				SecretKey:    "secret",
+				Bucket:       "bucket",
+				Threads:      4,
+				Checksum:     "sha256",
+			},
+			wantErr: false,
+			checkOutput: func(t *testing.T, data []byte) {
+				t.Helper()
+				var config DefaultsConfig
+				if err := yaml.Unmarshal(data, &config); err != nil {
+					t.Fatalf("Failed to unmarshal YAML: %v", err)
+				}
+				if config.Storage.Checksum == nil {
+					t.Fatal("Expected storage.checksum section")
+				}
+				if config.Storage.Checksum.Algorithm != "sha256" {
+					t.Errorf("Expected algorithm 'sha256', got %q", config.Storage.Checksum.Algorithm)
+				}
+			},
+		},
+		{
+			name: "no checksum omits checksum section",
+			params: Params{
+				WorkloadType: "write",
+				Endpoint:     "http://s3.example.com",
+				AccessKey:    "key",
+				SecretKey:    "secret",
+				Bucket:       "bucket",
+				Threads:      4,
+			},
+			wantErr: false,
+			checkOutput: func(t *testing.T, data []byte) {
+				t.Helper()
+				var config DefaultsConfig
+				if err := yaml.Unmarshal(data, &config); err != nil {
+					t.Fatalf("Failed to unmarshal YAML: %v", err)
+				}
+				if config.Storage.Checksum != nil {
+					t.Error("Expected no storage.checksum section when checksum is empty")
+				}
+				if strings.Contains(string(data), "checksum:") {
+					t.Error("Raw YAML should not contain 'checksum:' when disabled")
+				}
+			},
+		},
+		{
+			name: "checksum with RDMA both present",
+			params: Params{
+				WorkloadType:       "write",
+				Endpoint:           "http://s3.example.com",
+				AccessKey:          "key",
+				SecretKey:          "secret",
+				Bucket:             "bucket",
+				Threads:            4,
+				S3Driver:           S3DriverRdma,
+				RdmaThresholdBytes: 0,
+				RdmaTimeoutMs:      30000,
+				Checksum:           "crc32c",
+			},
+			wantErr: false,
+			checkOutput: func(t *testing.T, data []byte) {
+				t.Helper()
+				var config DefaultsConfig
+				if err := yaml.Unmarshal(data, &config); err != nil {
+					t.Fatalf("Failed to unmarshal YAML: %v", err)
+				}
+				if config.Storage.Checksum == nil {
+					t.Fatal("Expected checksum section with RDMA")
+				}
+				if config.Storage.Checksum.Algorithm != "crc32c" {
+					t.Errorf("Expected algorithm 'crc32c', got %q", config.Storage.Checksum.Algorithm)
+				}
+				if config.Storage.Rdma == nil {
+					t.Fatal("Expected RDMA section with checksum")
+				}
+			},
+		},
+	}
+	for _, tt := range checksumCases {
+		tests = append(tests, tt)
+	}
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			data, err := GenerateDefaults(tt.params)

--- a/cli/internal/scenario/types.go
+++ b/cli/internal/scenario/types.go
@@ -39,6 +39,9 @@ type Params struct {
 	RdmaLogLevel       string // Native RDMA log level (default: "WARN")
 	RdmaTimeoutMs      int64  // RDMA operation timeout (default: 30000)
 
+	// Checksum validation
+	Checksum string // Checksum algorithm: crc32, crc32c, sha1, sha256 (empty = disabled)
+
 	// Stable timestamp for step IDs.  When set, all Generate*Scenario
 	// functions use this value instead of calling time.Now(), ensuring that
 	// repeated generation from the same Params produces identical step IDs.

--- a/engine/extensions/storage-drivers/implementations/s3-aws/README.md
+++ b/engine/extensions/storage-drivers/implementations/s3-aws/README.md
@@ -11,6 +11,7 @@ This module provides an AWS SDK implementation of the S3 Storage Driver for SPT 
 - **Error Handling**: Comprehensive error handling with proper exception translation
 - **Metadata Support**: Full support for custom metadata
 - **Performance Optimized**: Configurable connection pooling and timeouts
+- **Checksum Validation**: Per-object and per-part checksum support (CRC32, CRC32C, SHA1, SHA256) via AWS SDK flexible checksums
 
 ## Dependencies
 
@@ -110,6 +111,8 @@ S3StorageDriver driver = S3StorageDriverFactory.create(config);
 | socketTimeout | int | 30000 | Socket timeout in milliseconds |
 | connectionTimeout | int | 10000 | Connection timeout in milliseconds |
 | enableRequestMetrics | boolean | false | Enable AWS SDK request metrics |
+| checksumEnabled | boolean | false | Compute and send a checksum on write requests |
+| checksumAlgorithm | String | null | Checksum algorithm: `crc32`, `crc32c`, `sha1`, `sha256`. MD5 is not supported as a flexible checksum by the AWS SDK |
 
 ## API Methods
 

--- a/engine/extensions/storage-drivers/implementations/s3-aws/impl_status.md
+++ b/engine/extensions/storage-drivers/implementations/s3-aws/impl_status.md
@@ -57,6 +57,7 @@ All AWS SDK v2 dependencies are now included for comprehensive S3 feature suppor
 | Copy Operations | ✅ | ✅ | Complete |
 | Bulk Operations | ✅ | ✅ | Complete |
 | Metadata Operations | ✅ | ✅ | Complete |
+| Checksum Validation | ✅ | ✅ | Complete (CRC32, CRC32C, SHA1, SHA256; MD5 N/A for AWS SDK flexible checksums) |
 
 ## Key Implementation Details
 

--- a/engine/extensions/storage-drivers/implementations/s3-aws/s3-aws-s3-driver_comparision.md
+++ b/engine/extensions/storage-drivers/implementations/s3-aws/s3-aws-s3-driver_comparision.md
@@ -151,7 +151,7 @@ List<S3Object> objects = resp.contents();
 | **Multipart Upload** | ✅ Manual MPU protocol | ✅ SDK MPU | AWS (easier) |
 | **Object Tagging** | ✅ Custom XML generation | ✅ SDK tagging | AWS (type-safe) |
 | **Versioning** | ✅ Manual version handling | ✅ SDK versioning | AWS (automatic) |
-| **Checksums** | ✅ Multiple algorithms | ✅ SDK checksums | REST (more options) |
+| **Checksums** | ✅ Multiple algorithms | ✅ SDK checksums | Tie (both support CRC32, CRC32C, SHA1, SHA256; REST also supports MD5) |
 | **Auth Versions** | ✅ v2 and v4 | ✅ v4 only | REST (flexibility) |
 | **Custom Endpoints** | ✅ Full control | ✅ Endpoint override | Tie |
 | **Error Handling** | ⚠️ Manual parsing | ✅ Typed exceptions | AWS (better) |
@@ -225,7 +225,7 @@ List<S3Object> objects = resp.contents();
 ### 10. Advanced Features
 
 #### S3 REST Driver Unique Features
-1. **Custom Checksum Algorithms**: MD5, CRC32, CRC32C, SHA1, SHA256
+1. **Custom Checksum Algorithms**: MD5, CRC32, CRC32C, SHA1, SHA256 (MD5 is only available in the REST driver)
 2. **AWS Signature v2 Support**: For legacy systems
 3. **Fine-grained HTTP Control**: Direct access to Netty
 4. **Custom Expression Tagging**: Dynamic tag generation
@@ -236,7 +236,8 @@ List<S3Object> objects = resp.contents();
 2. **Automatic Retry Logic**: Exponential backoff with jitter
 3. **Request Metrics**: Built-in CloudWatch integration
 4. **Type Safety**: Compile-time validation
-5. **Future AWS Features**: Automatic support for new S3 features
+5. **Flexible Checksums**: CRC32, CRC32C, SHA1, SHA256 via AWS SDK flexible checksum API
+6. **Future AWS Features**: Automatic support for new S3 features
 
 ### 11. Error Handling
 
@@ -386,7 +387,7 @@ s3Client.putObject(req, RequestBody.fromInputStream(data, length));
 
 **Keep S3 REST Driver** if:
 - Need Signature v2 support
-- Require custom checksum algorithms
+- Need MD5 checksum algorithm specifically
 - Need maximum HTTP control
 - Working with non-AWS S3 storage
 

--- a/engine/extensions/storage-drivers/implementations/s3-aws/src/main/java/com/dell/spt/storage/driver/coop/aws/s3/S3AwsStorageDriver.java
+++ b/engine/extensions/storage-drivers/implementations/s3-aws/src/main/java/com/dell/spt/storage/driver/coop/aws/s3/S3AwsStorageDriver.java
@@ -31,6 +31,7 @@ import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.*;
+import software.amazon.awssdk.services.s3.model.ChecksumAlgorithm;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -46,6 +47,8 @@ public class S3AwsStorageDriver<I extends Item, O extends Operation<I>> extends 
 
 	private final S3Client s3Client;
 	private final String bucketName;
+	private final boolean checksumEnabled;
+	private final ChecksumAlgorithm checksumAlgorithm;
 
 	public S3AwsStorageDriver(
 					final String stepId,
@@ -63,6 +66,51 @@ public class S3AwsStorageDriver<I extends Item, O extends Operation<I>> extends 
 		this.s3Client = s3Client;
 
 		this.bucketName = resolveBucketName(config);
+
+		boolean ckEnabled = false;
+		ChecksumAlgorithm ckAlgo = null;
+		try {
+			ckEnabled = config.boolVal("checksum-enabled");
+		} catch (Exception e) {
+			LOG.debug("Could not read checksum-enabled from config: {}", e.toString());
+		}
+		if (ckEnabled) {
+			try {
+				final String algo = config.stringVal("checksum-algorithm");
+				ckAlgo = resolveChecksumAlgorithm(algo);
+				if (ckAlgo == null) {
+					LOG.warn("Unsupported checksum algorithm '{}' for s3-aws driver; checksums will not be applied", algo);
+					ckEnabled = false;
+				}
+			} catch (Exception e) {
+				LOG.warn("Could not read checksum-algorithm from config: {}", e.toString());
+				ckEnabled = false;
+			}
+		}
+		this.checksumEnabled = ckEnabled;
+		this.checksumAlgorithm = ckAlgo;
+	}
+
+	/**
+	 * Map a config algorithm name to the AWS SDK ChecksumAlgorithm enum.
+	 * Returns null for unsupported algorithms (e.g. MD5 — use Content-MD5 header instead).
+	 */
+	static ChecksumAlgorithm resolveChecksumAlgorithm(final String algorithm) {
+		if (algorithm == null || algorithm.isEmpty()) {
+			return null;
+		}
+		switch (algorithm.toLowerCase()) {
+		case "crc32":
+			return ChecksumAlgorithm.CRC32;
+		case "crc32c":
+			return ChecksumAlgorithm.CRC32_C;
+		case "sha1":
+			return ChecksumAlgorithm.SHA1;
+		case "sha256":
+			return ChecksumAlgorithm.SHA256;
+		default:
+			return null;
+		}
 	}
 
 	/**
@@ -314,24 +362,24 @@ public class S3AwsStorageDriver<I extends Item, O extends Operation<I>> extends 
 
 	private void putObject(final O op) throws Exception {
 		final var bk = resolveBucketAndKey(op);
+		var reqBuilder = PutObjectRequest.builder()
+						.bucket(bk[0])
+						.key(bk[1]);
+		if (checksumEnabled && checksumAlgorithm != null) {
+			reqBuilder.checksumAlgorithm(checksumAlgorithm);
+		}
 
 		if (op.item() instanceof DataItem) {
 			DataItem dataItem = (DataItem) op.item();
 			dataItem.position(0);
 			s3Client.putObject(
-							PutObjectRequest.builder()
-											.bucket(bk[0])
-											.key(bk[1])
-											.build(),
+							reqBuilder.build(),
 							RequestBody.fromInputStream(new DataItemInputStream(dataItem), dataItem.size()));
 		} else if (op.item() instanceof PathItem) {
 			PathItem pathItem = (PathItem) op.item();
 			Path path = Path.of(pathItem.name());
 			s3Client.putObject(
-							PutObjectRequest.builder()
-											.bucket(bk[0])
-											.key(bk[1])
-											.build(),
+							reqBuilder.build(),
 							RequestBody.fromFile(path));
 		} else {
 			throw new UnsupportedOperationException("s3-aws PUT requires DataItem or PathItem");

--- a/engine/extensions/storage-drivers/implementations/s3-aws/src/test/java/com/dell/spt/storage/driver/coop/aws/s3/S3AwsStorageDriverTest.java
+++ b/engine/extensions/storage-drivers/implementations/s3-aws/src/test/java/com/dell/spt/storage/driver/coop/aws/s3/S3AwsStorageDriverTest.java
@@ -24,6 +24,7 @@ import software.amazon.awssdk.core.ResponseInputStream;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.*;
+import software.amazon.awssdk.services.s3.model.ChecksumAlgorithm;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -59,6 +60,18 @@ public class S3AwsStorageDriverTest {
 		Field clientField = S3AwsStorageDriver.class.getDeclaredField("s3Client");
 		clientField.setAccessible(true);
 		clientField.set(driver, s3Client);
+	}
+
+	private void setChecksumFields(
+					S3AwsStorageDriver<Item, Operation<Item>> driver,
+					boolean enabled,
+					ChecksumAlgorithm algorithm) throws Exception {
+		Field enabledField = S3AwsStorageDriver.class.getDeclaredField("checksumEnabled");
+		enabledField.setAccessible(true);
+		enabledField.set(driver, enabled);
+		Field algoField = S3AwsStorageDriver.class.getDeclaredField("checksumAlgorithm");
+		algoField.setAccessible(true);
+		algoField.set(driver, algorithm);
 	}
 
 	@BeforeEach
@@ -1512,6 +1525,154 @@ public class S3AwsStorageDriverTest {
 							.cause(new IllegalStateException("bad state"))
 							.build();
 			assertEquals(Operation.Status.FAIL_UNKNOWN, S3AwsStorageDriver.classifyFailure(e));
+		}
+	}
+
+	// -----------------------------------------------------------------------
+	// resolveChecksumAlgorithm — static, maps config string to SDK enum
+	// -----------------------------------------------------------------------
+
+	@Nested
+	class ResolveChecksumAlgorithmTest {
+
+		@Test
+		void crc32() {
+			assertEquals(ChecksumAlgorithm.CRC32, S3AwsStorageDriver.resolveChecksumAlgorithm("crc32"));
+		}
+
+		@Test
+		void crc32c() {
+			assertEquals(ChecksumAlgorithm.CRC32_C, S3AwsStorageDriver.resolveChecksumAlgorithm("crc32c"));
+		}
+
+		@Test
+		void sha1() {
+			assertEquals(ChecksumAlgorithm.SHA1, S3AwsStorageDriver.resolveChecksumAlgorithm("sha1"));
+		}
+
+		@Test
+		void sha256() {
+			assertEquals(ChecksumAlgorithm.SHA256, S3AwsStorageDriver.resolveChecksumAlgorithm("sha256"));
+		}
+
+		@Test
+		void caseInsensitive() {
+			assertEquals(ChecksumAlgorithm.CRC32, S3AwsStorageDriver.resolveChecksumAlgorithm("CRC32"));
+			assertEquals(ChecksumAlgorithm.CRC32_C, S3AwsStorageDriver.resolveChecksumAlgorithm("CRC32C"));
+			assertEquals(ChecksumAlgorithm.SHA1, S3AwsStorageDriver.resolveChecksumAlgorithm("SHA1"));
+			assertEquals(ChecksumAlgorithm.SHA256, S3AwsStorageDriver.resolveChecksumAlgorithm("SHA256"));
+		}
+
+		@Test
+		void md5_returnsNull() {
+			assertNull(S3AwsStorageDriver.resolveChecksumAlgorithm("md5"));
+		}
+
+		@Test
+		void nullInput_returnsNull() {
+			assertNull(S3AwsStorageDriver.resolveChecksumAlgorithm(null));
+		}
+
+		@Test
+		void emptyInput_returnsNull() {
+			assertNull(S3AwsStorageDriver.resolveChecksumAlgorithm(""));
+		}
+
+		@Test
+		void unknownAlgorithm_returnsNull() {
+			assertNull(S3AwsStorageDriver.resolveChecksumAlgorithm("blake2b"));
+		}
+	}
+
+	// -----------------------------------------------------------------------
+	// putObject checksum integration — verifies checksumAlgorithm on request
+	// -----------------------------------------------------------------------
+
+	@Nested
+	class PutObjectChecksumTest {
+
+		@SuppressWarnings("unchecked")
+		@Test
+		void putObject_setsChecksumAlgorithm_whenEnabled() throws Exception {
+			setChecksumFields(drv, true, ChecksumAlgorithm.CRC32);
+
+			DataItem dataItem = mock(DataItem.class);
+			when(dataItem.name()).thenReturn("obj.bin");
+			when(dataItem.size()).thenReturn(1024L);
+
+			Operation<Item> op = mock(Operation.class, Mockito.withSettings().extraInterfaces(DataOperation.class));
+			when(op.type()).thenReturn(OpType.CREATE);
+			when(op.dstPath()).thenReturn("/bucket");
+			when(op.item()).thenReturn((Item) dataItem);
+
+			drv.execute(op);
+
+			ArgumentCaptor<PutObjectRequest> cap = ArgumentCaptor.forClass(PutObjectRequest.class);
+			verify(mockS3Client).putObject(cap.capture(), any(RequestBody.class));
+			assertEquals(ChecksumAlgorithm.CRC32, cap.getValue().checksumAlgorithm());
+		}
+
+		@SuppressWarnings("unchecked")
+		@Test
+		void putObject_noChecksumAlgorithm_whenDisabled() throws Exception {
+			setChecksumFields(drv, false, null);
+
+			DataItem dataItem = mock(DataItem.class);
+			when(dataItem.name()).thenReturn("obj.bin");
+			when(dataItem.size()).thenReturn(1024L);
+
+			Operation<Item> op = mock(Operation.class, Mockito.withSettings().extraInterfaces(DataOperation.class));
+			when(op.type()).thenReturn(OpType.CREATE);
+			when(op.dstPath()).thenReturn("/bucket");
+			when(op.item()).thenReturn((Item) dataItem);
+
+			drv.execute(op);
+
+			ArgumentCaptor<PutObjectRequest> cap = ArgumentCaptor.forClass(PutObjectRequest.class);
+			verify(mockS3Client).putObject(cap.capture(), any(RequestBody.class));
+			assertNull(cap.getValue().checksumAlgorithm());
+		}
+
+		@SuppressWarnings("unchecked")
+		@Test
+		void putObject_sha256Checksum() throws Exception {
+			setChecksumFields(drv, true, ChecksumAlgorithm.SHA256);
+
+			DataItem dataItem = mock(DataItem.class);
+			when(dataItem.name()).thenReturn("obj.bin");
+			when(dataItem.size()).thenReturn(512L);
+
+			Operation<Item> op = mock(Operation.class, Mockito.withSettings().extraInterfaces(DataOperation.class));
+			when(op.type()).thenReturn(OpType.CREATE);
+			when(op.dstPath()).thenReturn("/bucket");
+			when(op.item()).thenReturn((Item) dataItem);
+
+			drv.execute(op);
+
+			ArgumentCaptor<PutObjectRequest> cap = ArgumentCaptor.forClass(PutObjectRequest.class);
+			verify(mockS3Client).putObject(cap.capture(), any(RequestBody.class));
+			assertEquals(ChecksumAlgorithm.SHA256, cap.getValue().checksumAlgorithm());
+		}
+
+		@SuppressWarnings("unchecked")
+		@Test
+		void putObject_update_setsChecksumAlgorithm() throws Exception {
+			setChecksumFields(drv, true, ChecksumAlgorithm.CRC32_C);
+
+			DataItem dataItem = mock(DataItem.class);
+			when(dataItem.name()).thenReturn("upd.bin");
+			when(dataItem.size()).thenReturn(256L);
+
+			Operation<Item> op = mock(Operation.class, Mockito.withSettings().extraInterfaces(DataOperation.class));
+			when(op.type()).thenReturn(OpType.UPDATE);
+			when(op.dstPath()).thenReturn("/bucket");
+			when(op.item()).thenReturn((Item) dataItem);
+
+			drv.execute(op);
+
+			ArgumentCaptor<PutObjectRequest> cap = ArgumentCaptor.forClass(PutObjectRequest.class);
+			verify(mockS3Client).putObject(cap.capture(), any(RequestBody.class));
+			assertEquals(ChecksumAlgorithm.CRC32_C, cap.getValue().checksumAlgorithm());
 		}
 	}
 }

--- a/engine/extensions/storage-drivers/implementations/s3/src/main/java/com/dell/spt/storage/driver/coop/netty/http/s3/S3Api.java
+++ b/engine/extensions/storage-drivers/implementations/s3/src/main/java/com/dell/spt/storage/driver/coop/netty/http/s3/S3Api.java
@@ -64,7 +64,8 @@ public interface S3Api {
 	String COMPLETE_MPU_HEADER = "<CompleteMultipartUpload>\n";
 	String COMPLETE_MPU_PART_NUM_START = "\t<Part>\n\t\t<PartNumber>";
 	String COMPLETE_MPU_PART_NUM_END = "</PartNumber>\n\t\t<ETag>";
-	String COMPLETE_MPU_PART_ETAG_END = "</ETag>\n\t</Part>\n";
+	String COMPLETE_MPU_PART_ETAG_END = "</ETag>";
+	String COMPLETE_MPU_PART_CLOSE = "\n\t</Part>\n";
 	String COMPLETE_MPU_FOOTER = "</CompleteMultipartUpload>";
 
 	String TAGGING_HEADER = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
@@ -90,9 +91,24 @@ public interface S3Api {
 	String QNAME_NEXT_VERSION_ID_MARKER = "NextVersionIdMarker";
 
 	String AMZ_CHECKSUM_PREFIX = "x-amz-checksum-";
+	String AMZ_CHECKSUM_ALGORITHM_HEADER = "x-amz-checksum-algorithm";
+
+	/** Key prefix used to store per-part checksum values in the MPU context map. */
+	String KEY_PART_CHECKSUM_PREFIX = "checksum-";
 
 	enum AMZChecksum {
 		MD5, CRC32, CRC32C, SHA1, SHA256;
+
+		/** Returns the XML element name used inside CompleteMultipartUpload, e.g. "ChecksumCRC32C". */
+		String xmlElementName() {
+			return switch (this) {
+			case CRC32 -> "ChecksumCRC32";
+			case CRC32C -> "ChecksumCRC32C";
+			case SHA1 -> "ChecksumSHA1";
+			case SHA256 -> "ChecksumSHA256";
+			case MD5 -> "ChecksumMD5";
+			};
+		}
 	}
 
 	static String amzChecksumRegex() {

--- a/engine/extensions/storage-drivers/implementations/s3/src/main/java/com/dell/spt/storage/driver/coop/netty/http/s3/S3ResponseHandler.java
+++ b/engine/extensions/storage-drivers/implementations/s3/src/main/java/com/dell/spt/storage/driver/coop/netty/http/s3/S3ResponseHandler.java
@@ -41,11 +41,15 @@ public final class S3ResponseHandler<I extends Item, O extends Operation<I>>
 	private static final Pattern PATTERN_UPLOAD_ID = Pattern.compile(
 					"<UploadId>([^<]+)</UploadId>", Pattern.MULTILINE);
 	private final boolean versioningEnabled;
+	private final String checksumHeader; // e.g. "x-amz-checksum-crc32c", or null if disabled
 
 	public S3ResponseHandler(final S3StorageDriver<I, O> driver, final boolean verifyFlag,
-					final boolean versioningEnabled) {
+					final boolean versioningEnabled, final String checksumAlgorithm) {
 		super(driver, verifyFlag);
 		this.versioningEnabled = versioningEnabled;
+		this.checksumHeader = checksumAlgorithm != null
+						? S3Api.AMZ_CHECKSUM_PREFIX + checksumAlgorithm.toLowerCase(java.util.Locale.ROOT)
+						: null;
 	}
 
 	@Override
@@ -55,7 +59,15 @@ public final class S3ResponseHandler<I extends Item, O extends Operation<I>>
 			final PartialDataOperation subTask = (PartialDataOperation) op;
 			final String eTag = respHeaders.get(HttpHeaderNames.ETAG);
 			final CompositeDataOperation mpuTask = subTask.parent();
-			mpuTask.put(Integer.toString(subTask.partNumber() + 1), eTag);
+			final int partNum = subTask.partNumber() + 1;
+			mpuTask.put(Integer.toString(partNum), eTag);
+			// Capture per-part checksum value if the server echoed one back
+			if (checksumHeader != null) {
+				final String checksumVal = respHeaders.get(checksumHeader);
+				if (checksumVal != null) {
+					mpuTask.put(S3Api.KEY_PART_CHECKSUM_PREFIX + partNum, checksumVal);
+				}
+			}
 		}
 		if (versioningEnabled) {
 			op.item().name(op.item().name() + "~" + respHeaders.get("x-amz-version-id"));

--- a/engine/extensions/storage-drivers/implementations/s3/src/main/java/com/dell/spt/storage/driver/coop/netty/http/s3/S3StorageDriver.java
+++ b/engine/extensions/storage-drivers/implementations/s3/src/main/java/com/dell/spt/storage/driver/coop/netty/http/s3/S3StorageDriver.java
@@ -1013,6 +1013,9 @@ public class S3StorageDriver<I extends Item, O extends Operation<I>>
 			httpHeaders.set(HttpHeaderNames.HOST, nodeAddr);
 		}
 		httpHeaders.set(HttpHeaderNames.CONTENT_LENGTH, 0);
+		if (checksumAlgorithm != null) {
+			httpHeaders.set(S3Api.AMZ_CHECKSUM_ALGORITHM_HEADER, checksumAlgorithm.toUpperCase(Locale.ROOT));
+		}
 		final var httpMethod = HttpMethod.POST;
 		final var httpRequest = (HttpRequest) new DefaultHttpRequest(HTTP_1_1, httpMethod, uri, httpHeaders);
 		applyMetaDataHeaders(httpHeaders);
@@ -1104,6 +1107,18 @@ public class S3StorageDriver<I extends Item, O extends Operation<I>>
 							.append(S3Api.COMPLETE_MPU_PART_NUM_END)
 							.append(nextEtag)
 							.append(S3Api.COMPLETE_MPU_PART_ETAG_END);
+			if (checksumAlgorithm != null) {
+				final var partChecksum = mpuTask.get(
+								S3Api.KEY_PART_CHECKSUM_PREFIX + nextPartNum);
+				if (partChecksum != null) {
+					final var xmlElem = AMZChecksum.valueOf(
+									checksumAlgorithm.toUpperCase(Locale.ROOT)).xmlElementName();
+					content.append("\n\t\t<").append(xmlElem).append('>')
+									.append(partChecksum)
+									.append("</").append(xmlElem).append('>');
+				}
+			}
+			content.append(S3Api.COMPLETE_MPU_PART_CLOSE);
 		}
 		content.append(S3Api.COMPLETE_MPU_FOOTER);
 		final var srcPath = mpuTask.srcPath();
@@ -1374,7 +1389,7 @@ public class S3StorageDriver<I extends Item, O extends Operation<I>>
 	@Override
 	protected void appendHandlers(final Channel channel) {
 		super.appendHandlers(channel);
-		channel.pipeline().addLast(new S3ResponseHandler<>(this, verifyFlag, versioning));
+		channel.pipeline().addLast(new S3ResponseHandler<>(this, verifyFlag, versioning, checksumAlgorithm));
 	}
 
 	@Override

--- a/engine/extensions/storage-drivers/implementations/s3/src/test/java/com/dell/spt/storage/driver/coop/netty/http/s3/S3ResponseHandlerListTest.java
+++ b/engine/extensions/storage-drivers/implementations/s3/src/test/java/com/dell/spt/storage/driver/coop/netty/http/s3/S3ResponseHandlerListTest.java
@@ -28,7 +28,7 @@ final class S3ResponseHandlerListTest {
 
 	@BeforeEach
 	void setUp() {
-		handler = new S3ResponseHandler<>(null, false, false);
+		handler = new S3ResponseHandler<>(null, false, false, null);
 		content = Unpooled.copiedBuffer(LIST_V2_RESPONSE, StandardCharsets.UTF_8);
 	}
 

--- a/engine/extensions/storage-drivers/implementations/s3/src/test/java/com/dell/spt/storage/driver/coop/netty/http/s3/S3StorageDriverTest.java
+++ b/engine/extensions/storage-drivers/implementations/s3/src/test/java/com/dell/spt/storage/driver/coop/netty/http/s3/S3StorageDriverTest.java
@@ -628,6 +628,114 @@ public class S3StorageDriverTest {
 	}
 
 	@Test
+	void mpu_init_includesChecksumAlgorithmHeaderWhenEnabled() throws Exception {
+		Config cfg = baseConfig(false, 4, true, "crc32c", "s3.us-east-1.amazonaws.com:443");
+		TestS3Driver drv = new TestS3Driver(cfg);
+		Item item = new ItemImpl("/bucket/obj");
+		Operation<Item> op = new OperationImpl<>(1, OpType.CREATE, item, null, "/bucket", TEST_CRED);
+		HttpRequest req = drv.initMultipartUploadRequest(op, "s3.us-east-1.amazonaws.com");
+		assertEquals("CRC32C", req.headers().get(S3Api.AMZ_CHECKSUM_ALGORITHM_HEADER),
+						"InitiateMultipartUpload should include x-amz-checksum-algorithm when checksums enabled");
+	}
+
+	@Test
+	void mpu_init_noChecksumAlgorithmHeaderWhenDisabled() throws Exception {
+		Config cfg = baseConfig(false, 4, false, null, "s3.us-east-1.amazonaws.com:443");
+		TestS3Driver drv = new TestS3Driver(cfg);
+		Item item = new ItemImpl("/bucket/obj");
+		Operation<Item> op = new OperationImpl<>(1, OpType.CREATE, item, null, "/bucket", TEST_CRED);
+		HttpRequest req = drv.initMultipartUploadRequest(op, "s3.us-east-1.amazonaws.com");
+		assertNull(req.headers().get(S3Api.AMZ_CHECKSUM_ALGORITHM_HEADER),
+						"InitiateMultipartUpload should not include x-amz-checksum-algorithm when checksums disabled");
+	}
+
+	@Test
+	void mpu_complete_includesPerPartChecksums() throws Exception {
+		Config cfg = baseConfig(false, 4, true, "crc32c", "s3.us-east-1.amazonaws.com:443");
+		TestS3Driver drv = new TestS3Driver(cfg);
+		final var base = new com.dell.spt.base.item.DataItemImpl("/bucket/obj", 0, 4096);
+		final var parent = new com.dell.spt.base.item.op.composite.data.CompositeDataOperationImpl<com.dell.spt.base.item.DataItem>(
+						0, OpType.CREATE, base, "/bucket", null, TEST_CRED, null, 0, 1024);
+		parent.put(S3Api.KEY_UPLOAD_ID, "u-complete-checksum");
+		parent.put("1", "\"etag-1\"");
+		parent.put("2", "\"etag-2\"");
+		parent.put(S3Api.KEY_PART_CHECKSUM_PREFIX + "1", "AAAAAA==");
+		parent.put(S3Api.KEY_PART_CHECKSUM_PREFIX + "2", "BBBBBB==");
+		final var req = drv.completeMultipartUploadRequest(parent, "s3.us-east-1.amazonaws.com");
+		final String body = req.content().toString(java.nio.charset.StandardCharsets.UTF_8);
+		assertTrue(body.contains("<ChecksumCRC32C>AAAAAA==</ChecksumCRC32C>"),
+						"CompleteMultipartUpload XML should include part 1 checksum: " + body);
+		assertTrue(body.contains("<ChecksumCRC32C>BBBBBB==</ChecksumCRC32C>"),
+						"CompleteMultipartUpload XML should include part 2 checksum: " + body);
+		assertTrue(body.contains("<ETag>\"etag-1\"</ETag>"), "XML should still include ETags: " + body);
+	}
+
+	@Test
+	void mpu_complete_noChecksumElementsWhenDisabled() throws Exception {
+		Config cfg = baseConfig(false, 4, false, null, "s3.us-east-1.amazonaws.com:443");
+		TestS3Driver drv = new TestS3Driver(cfg);
+		final var base = new com.dell.spt.base.item.DataItemImpl("/bucket/obj", 0, 4096);
+		final var parent = new com.dell.spt.base.item.op.composite.data.CompositeDataOperationImpl<com.dell.spt.base.item.DataItem>(
+						0, OpType.CREATE, base, "/bucket", null, TEST_CRED, null, 0, 1024);
+		parent.put(S3Api.KEY_UPLOAD_ID, "u-complete-nochecksum");
+		parent.put("1", "\"etag-1\"");
+		parent.put("2", "\"etag-2\"");
+		final var req = drv.completeMultipartUploadRequest(parent, "s3.us-east-1.amazonaws.com");
+		final String body = req.content().toString(java.nio.charset.StandardCharsets.UTF_8);
+		assertFalse(body.contains("Checksum"),
+						"CompleteMultipartUpload XML should not include checksum elements when disabled: " + body);
+		assertTrue(body.contains("<ETag>\"etag-1\"</ETag>"), "XML should include ETags: " + body);
+	}
+
+	@Test
+	void responseHandler_capturesPartChecksum() throws Exception {
+		Config cfg = baseConfig(false, 4, true, "crc32c", "s3.us-east-1.amazonaws.com:443");
+		TestS3Driver drv = new TestS3Driver(cfg);
+		final var base = new com.dell.spt.base.item.DataItemImpl("/bucket/obj", 0, 4096);
+		final var parent = new com.dell.spt.base.item.op.composite.data.CompositeDataOperationImpl<com.dell.spt.base.item.DataItem>(
+						0, OpType.CREATE, base, "/bucket", null, TEST_CRED, null, 0, 1024);
+		parent.put(S3Api.KEY_UPLOAD_ID, "u-resp-checksum");
+		final var partItem = base.slice(0, 1024);
+		final var partOp = new com.dell.spt.base.item.op.partial.data.PartialDataOperationImpl<com.dell.spt.base.item.DataItem>(
+						0, OpType.CREATE, partItem, "/bucket", null, TEST_CRED, 0, parent);
+		final var handler = new S3ResponseHandler<>(drv, false, false, "crc32c");
+		final var headers = new DefaultHttpHeaders();
+		headers.set(HttpHeaderNames.ETAG, "\"etag-part1\"");
+		headers.set("x-amz-checksum-crc32c", "XYZABC==");
+		Method m = S3ResponseHandler.class.getDeclaredMethod(
+						"handleResponseHeaders", Channel.class, Operation.class, HttpHeaders.class);
+		m.setAccessible(true);
+		m.invoke(handler, null, partOp, headers);
+		assertEquals("\"etag-part1\"", parent.get("1"), "ETag should be captured");
+		assertEquals("XYZABC==", parent.get(S3Api.KEY_PART_CHECKSUM_PREFIX + "1"),
+						"Per-part checksum should be captured from response header");
+	}
+
+	@Test
+	void responseHandler_noChecksumCaptureWhenDisabled() throws Exception {
+		Config cfg = baseConfig(false, 4, false, null, "s3.us-east-1.amazonaws.com:443");
+		TestS3Driver drv = new TestS3Driver(cfg);
+		final var base = new com.dell.spt.base.item.DataItemImpl("/bucket/obj", 0, 4096);
+		final var parent = new com.dell.spt.base.item.op.composite.data.CompositeDataOperationImpl<com.dell.spt.base.item.DataItem>(
+						0, OpType.CREATE, base, "/bucket", null, TEST_CRED, null, 0, 1024);
+		parent.put(S3Api.KEY_UPLOAD_ID, "u-resp-nochecksum");
+		final var partItem = base.slice(0, 1024);
+		final var partOp = new com.dell.spt.base.item.op.partial.data.PartialDataOperationImpl<com.dell.spt.base.item.DataItem>(
+						0, OpType.CREATE, partItem, "/bucket", null, TEST_CRED, 0, parent);
+		final var handler = new S3ResponseHandler<>(drv, false, false, null);
+		final var headers = new DefaultHttpHeaders();
+		headers.set(HttpHeaderNames.ETAG, "\"etag-part1\"");
+		headers.set("x-amz-checksum-crc32c", "XYZABC==");
+		Method m = S3ResponseHandler.class.getDeclaredMethod(
+						"handleResponseHeaders", Channel.class, Operation.class, HttpHeaders.class);
+		m.setAccessible(true);
+		m.invoke(handler, null, partOp, headers);
+		assertEquals("\"etag-part1\"", parent.get("1"), "ETag should still be captured");
+		assertNull(parent.get(S3Api.KEY_PART_CHECKSUM_PREFIX + "1"),
+						"Per-part checksum should NOT be captured when checksums disabled");
+	}
+
+	@Test
 	void mpu_abort_sendsDeleteWithUploadId() throws Exception {
 		Config cfg = baseConfig(false, 4, false, null, "s3.us-east-1.amazonaws.com:443");
 		TestS3Driver drv = new TestS3Driver(cfg);
@@ -782,7 +890,7 @@ public class S3StorageDriverTest {
 		final var partItem = base.slice(0, 1024);
 		final var partOp = new com.dell.spt.base.item.op.partial.data.PartialDataOperationImpl<com.dell.spt.base.item.DataItem>(
 						0, OpType.CREATE, partItem, "/bucket", null, TEST_CRED, 0, parent);
-		final var handler = new S3ResponseHandler<>(drv, false, false);
+		final var handler = new S3ResponseHandler<>(drv, false, false, null);
 		final var headers = new DefaultHttpHeaders();
 		headers.set(HttpHeaderNames.ETAG, "\"abc123\"");
 		// Use reflection to call protected handleResponseHeaders
@@ -805,7 +913,7 @@ public class S3StorageDriverTest {
 		final var partItem = base.slice(0, 1024);
 		final var partOp = new com.dell.spt.base.item.op.partial.data.PartialDataOperationImpl<com.dell.spt.base.item.DataItem>(
 						0, OpType.READ, partItem, "/bucket", null, TEST_CRED, 0, parent);
-		final var handler = new S3ResponseHandler<>(drv, false, false);
+		final var handler = new S3ResponseHandler<>(drv, false, false, null);
 		final var headers = new DefaultHttpHeaders();
 		headers.set(HttpHeaderNames.ETAG, "\"def456\"");
 		Method m = S3ResponseHandler.class.getDeclaredMethod(


### PR DESCRIPTION
## Summary

Adds end-to-end S3 checksum support spanning the CLI, both S3 storage drivers, and documentation.

### CLI (`--checksum` flag)
- New `--checksum` flag accepting `crc32`, `crc32c`, `sha1`, `sha256` (env: `SPT_CHECKSUM`)
- Generates `storage.checksum.enabled: true` and `storage.checksum.algorithm: <value>` in defaults.yaml
- Works with both Netty and AWS SDK drivers, and composes with `--part-size` for per-part checksums

### S3-AWS driver (checksum support)
- Reads `checksum-enabled` / `checksum-algorithm` from config via confuse
- Maps algorithm strings to AWS SDK `ChecksumAlgorithm` enum (CRC32, CRC32C, SHA1, SHA256)
- Sets `checksumAlgorithm` on `PutObjectRequest` — AWS SDK computes checksums automatically
- MD5 intentionally returns `null` (not supported as a flexible checksum by the AWS SDK)

### Netty S3 driver (MPU checksum completeness)
- `initMultipartUploadRequest()` now sends `x-amz-checksum-algorithm` header
- `S3ResponseHandler` captures per-part checksum headers from upload-part responses
- `completeMultipartUploadRequest()` includes per-part checksum XML elements in the completion body

### Tests
- 12 new S3-AWS driver tests (algorithm resolution + PutObject checksum behavior)
- 8 new Netty S3 driver tests (MPU init header, complete XML, response handler)
- 4 new CLI defaults tests (crc32, sha256, disabled, checksum+RDMA coexistence)

### Documentation
- `cli/docs/SPT_SYNTAX.md`: flag in options table, `SPT_CHECKSUM` in env vars, checksum examples, implementation status
- `cli/README.md`: `--checksum` in Optional Flags
- `README.md` (root): "S3 Checksum Validation" in Features
- `CHANGELOG.md`: three entries under `[Unreleased]`
- `s3-aws/README.md`: checksum in Features list and Configuration Options table
- `s3-aws/impl_status.md`: checksum row in Feature Parity table
- `s3-aws/s3-aws-s3-driver_comparision.md`: updated checksum comparison (REST→Tie), added flexible checksums to AWS driver features

#### Test plan

- [x] Engine Netty S3 tests pass (`./gradlew :extensions:storage-drivers:implementations:s3:test`)
- [x] Engine S3-AWS tests pass (`./gradlew :extensions:storage-drivers:implementations:s3-aws:test`)
- [x] CLI tests pass (`make -C cli test`)
- [x] CLI lint clean (`make -C cli lint`)