### PR TITLE
feat: Implement Multipart Upload concurrency limits (ISGFGE-4062)

### DIFF
--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -848,6 +848,8 @@ func init() {
 
 	// Multipart Upload Options
 	runCmd.Flags().String("part-size", "", "Enable multipart upload with the given part size (e.g., 5MB, 64MB, 256MB)")
+	runCmd.Flags().Int("mpu-concurrent-objects", 0, "Max concurrent multipart objects in flight (0 = unlimited)")
+	runCmd.Flags().Int("mpu-concurrent-parts", 0, "Max concurrent parts in flight per multipart object (0 = unlimited)")
 
 	// Test Behavior Options
 	runCmd.Flags().Int("seed-objects", 2500, "Number of objects to pre-create for read benchmarks (default: 2500)")
@@ -1033,6 +1035,12 @@ func buildScenarioParams(workloadType string, cmd *cobra.Command) (scenario.Para
 
 	partSize, _ := cmd.Flags().GetString("part-size")
 	params.PartSize = partSize
+
+	mpuObjects, _ := cmd.Flags().GetInt("mpu-concurrent-objects")
+	params.MpuObjects = mpuObjects
+
+	mpuParts, _ := cmd.Flags().GetInt("mpu-concurrent-parts")
+	params.MpuParts = mpuParts
 
 	objectCount, _ := cmd.Flags().GetInt("object-count")
 	params.ObjectCount = objectCount

--- a/cli/cmd/validation.go
+++ b/cli/cmd/validation.go
@@ -249,6 +249,23 @@ func collectNormalizedEndpoints(cmd *cobra.Command) []string {
 // invalid values at runtime rather than blocking up front.
 func validatePartSize(cmd *cobra.Command) error {
 	partSize, _ := cmd.Flags().GetString("part-size")
+
+	mpuObjects, _ := cmd.Flags().GetInt("mpu-concurrent-objects")
+	if mpuObjects < 0 {
+		return fmt.Errorf("--mpu-concurrent-objects must be >= 0")
+	}
+	if mpuObjects > 0 && partSize == "" {
+		return fmt.Errorf("--mpu-concurrent-objects can only be used when --part-size is set")
+	}
+
+	mpuParts, _ := cmd.Flags().GetInt("mpu-concurrent-parts")
+	if mpuParts < 0 {
+		return fmt.Errorf("--mpu-concurrent-parts must be >= 0")
+	}
+	if mpuParts > 0 && partSize == "" {
+		return fmt.Errorf("--mpu-concurrent-parts can only be used when --part-size is set")
+	}
+
 	if partSize == "" {
 		return nil
 	}

--- a/cli/cmd/validation_test.go
+++ b/cli/cmd/validation_test.go
@@ -610,7 +610,6 @@ func TestValidatePartSize(t *testing.T) {
 			mpuObjects: 0,
 			mpuParts:   0,
 		},
-
 	}
 
 	for _, tt := range tests {

--- a/cli/cmd/validation_test.go
+++ b/cli/cmd/validation_test.go
@@ -499,6 +499,8 @@ func TestValidatePartSize(t *testing.T) {
 		name        string
 		partSize    string
 		objectSize  string
+		mpuObjects  int
+		mpuParts    int
 		wantErr     bool
 		errContains string
 	}{
@@ -559,6 +561,56 @@ func TestValidatePartSize(t *testing.T) {
 			partSize: "64MB",
 			wantErr:  false,
 		},
+		{
+			name:        "mpu objects requires part size",
+			partSize:    "",
+			mpuObjects:  10,
+			wantErr:     true,
+			errContains: "--mpu-concurrent-objects can only be used when --part-size is set",
+		},
+		{
+			name:        "mpu parts requires part size",
+			partSize:    "",
+			mpuParts:    5,
+			wantErr:     true,
+			errContains: "--mpu-concurrent-parts can only be used when --part-size is set",
+		},
+		{
+			name:        "mpu objects negative",
+			partSize:    "5MB",
+			mpuObjects:  -1,
+			wantErr:     true,
+			errContains: "--mpu-concurrent-objects must be >= 0",
+		},
+		{
+			name:        "mpu parts negative",
+			partSize:    "5MB",
+			mpuParts:    -1,
+			wantErr:     true,
+			errContains: "--mpu-concurrent-parts must be >= 0",
+		},
+		{
+			name:       "valid mpu limits with part size",
+			partSize:   "5MB",
+			objectSize: "20MB",
+			mpuObjects: 5,
+			mpuParts:   10,
+		},
+		{
+			name:       "zero mpu limits are allowed with part size",
+			partSize:   "5MB",
+			objectSize: "20MB",
+			mpuObjects: 0,
+			mpuParts:   0,
+		},
+		{
+			name:       "zero mpu limits are allowed without part size",
+			partSize:   "",
+			objectSize: "20MB",
+			mpuObjects: 0,
+			mpuParts:   0,
+		},
+
 	}
 
 	for _, tt := range tests {
@@ -566,6 +618,8 @@ func TestValidatePartSize(t *testing.T) {
 			cmd := &cobra.Command{}
 			cmd.Flags().String("part-size", tt.partSize, "")
 			cmd.Flags().String("object-size", tt.objectSize, "")
+			cmd.Flags().Int("mpu-concurrent-objects", tt.mpuObjects, "")
+			cmd.Flags().Int("mpu-concurrent-parts", tt.mpuParts, "")
 
 			err := validatePartSize(cmd)
 			if (err != nil) != tt.wantErr {

--- a/cli/docs/SPT_SYNTAX.md
+++ b/cli/docs/SPT_SYNTAX.md
@@ -91,6 +91,8 @@ Required for S3 workloads, optional/ignored for `mock`.
 | `--threads` | `-t` | `1` | Number of parallel client threads |
 | `--object-size` | `-o` | `""` | Size of each object (e.g., `1MB`, `256KB`, `4GB`). Ignored for `list` |
 | `--part-size` | | `""` | Enable multipart upload with the given part size (e.g., `5MB`, `64MB`, `256MB`). When set, `load.batch.size` is automatically forced to `1`. Applies to `write` workloads and `read` seed phases |
+| `--mpu-concurrent-objects` | | `0` | Max concurrent multipart objects in flight (`0` = unlimited). Requires `--part-size` |
+| `--mpu-concurrent-parts` | | `0` | Max concurrent parts in flight per multipart object (`0` = unlimited). Requires `--part-size` |
 | `--object-count` | `-n` | `0` | Fixed number of objects to process |
 | `--duration` | `-d` | `""` | Fixed time duration (e.g., `5m`, `1h`) |
 | `--seed-objects` | | `2500` | Objects to pre-create for `read` benchmarks |
@@ -309,6 +311,13 @@ When `--part-size` is set, each object goes through a four-phase lifecycle:
 
 - Individual parts are retried up to **3 times** before the upload is considered failed. This means a transient network error on one part does not waste the successfully uploaded parts immediately.
 - If all retries for a part are exhausted, the engine automatically sends an `AbortMultipartUpload` request to clean up the incomplete upload. This prevents orphaned parts from accumulating on the storage target.
+
+**Concurrency Controls:**
+
+- By default, all parts from all active multipart objects compete freely for the global `--threads` pool.
+- Use `--mpu-concurrent-objects N` to restrict how many top-level objects can be in the "in-flight" uploading state simultaneously.
+- Use `--mpu-concurrent-parts N` to restrict how many parts of a *single* object can be uploading simultaneously (creating a sliding window of parts).
+- These limits operate *within* the global `--threads` limit and are useful for preventing connection pool exhaustion or excessive memory pressure when testing with high concurrency.
 
 **Checksums:**
 

--- a/cli/internal/scenario/defaults.go
+++ b/cli/internal/scenario/defaults.go
@@ -55,7 +55,14 @@ type DriverConfig struct {
 
 // DriverLimits represents driver limit configuration
 type DriverLimits struct {
-	Concurrency int `yaml:"concurrency,omitempty"`
+	Concurrency int              `yaml:"concurrency,omitempty"`
+	Multipart   *MultipartLimits `yaml:"multipart,omitempty"`
+}
+
+// MultipartLimits represents multipart upload concurrency limits
+type MultipartLimits struct {
+	Objects int `yaml:"objects"`
+	Parts   int `yaml:"parts"`
 }
 
 // NetConfig represents network configuration
@@ -288,9 +295,20 @@ func GenerateDefaults(params Params) ([]byte, error) {
 			}
 		}
 
+		var multipartLimits *MultipartLimits
+		if params.MpuObjects > 0 || params.MpuParts > 0 {
+			multipartLimits = &MultipartLimits{
+				Objects: params.MpuObjects,
+				Parts:   params.MpuParts,
+			}
+		}
+
 		config.Storage = StorageConfig{
 			Driver: DriverConfig{
-				Limit: DriverLimits{Concurrency: params.Threads},
+				Limit: DriverLimits{
+					Concurrency: params.Threads,
+					Multipart:   multipartLimits,
+				},
 			},
 			Net: NetConfig{
 				Node: NodeConfig{

--- a/cli/internal/scenario/defaults_test.go
+++ b/cli/internal/scenario/defaults_test.go
@@ -47,6 +47,8 @@ func TestGenerateDefaults(t *testing.T) {
 				SecretKey:    "testsecret",
 				Bucket:       "testbucket",
 				Threads:      4,
+				MpuObjects:   2,
+				MpuParts:     3,
 			},
 			wantErr: false,
 			checkOutput: func(t *testing.T, data []byte) {
@@ -72,6 +74,18 @@ func TestGenerateDefaults(t *testing.T) {
 				}
 				if config.Storage.Net.SSL.Enabled {
 					t.Error("Expected SSL to be disabled for HTTP")
+				}
+				if config.Storage.Driver.Limit.Concurrency != 4 {
+					t.Errorf("Expected concurrency 4, got %d", config.Storage.Driver.Limit.Concurrency)
+				}
+				if config.Storage.Driver.Limit.Multipart == nil {
+					t.Fatal("Expected multipart limits to be set, got nil")
+				}
+				if config.Storage.Driver.Limit.Multipart.Objects != 2 {
+					t.Errorf("Expected MPU objects 2, got %d", config.Storage.Driver.Limit.Multipart.Objects)
+				}
+				if config.Storage.Driver.Limit.Multipart.Parts != 3 {
+					t.Errorf("Expected MPU parts 3, got %d", config.Storage.Driver.Limit.Multipart.Parts)
 				}
 			},
 		},

--- a/cli/internal/scenario/types.go
+++ b/cli/internal/scenario/types.go
@@ -12,6 +12,8 @@ type Params struct {
 	Threads      int
 	ObjectSize   string
 	PartSize     string // Multipart upload part size (e.g. "64MB"); empty = single PUT
+	MpuObjects   int    // Max concurrent multipart objects in flight (0 = unlimited)
+	MpuParts     int    // Max concurrent parts in flight per multipart object (0 = unlimited)
 	ObjectCount  int
 	Duration     string
 	AuthVersion  int

--- a/cli/tools/testmpu.headless.sh
+++ b/cli/tools/testmpu.headless.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+#
+# Script to run a multipart upload write test with the new MPU concurrency limits
+# in headless mode. 
+#
+# This script sets:
+#   - 10 total objects, 25MB each
+#   - 1MB part sizes (triggering MPU)
+#   - 8 global driver threads
+#   - 2 max concurrent MPU objects
+#   - 3 max concurrent parts per MPU object
+#
+# Usage:
+#   ./tools/testmpu.headless.sh
+#
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+SPT_BIN="$ROOT_DIR/spt"
+
+if [[ ! -x "$SPT_BIN" ]]; then
+  echo "SPT binary not found at $SPT_BIN. Please run 'make build' in the cli directory." >&2
+  exit 1
+fi
+
+# Read caller environment overrides
+declare -A _caller_env
+for _v in SPT_IMAGE SPT_SKIP_IMAGE_PULL S3_ENDPOINTS S3_ACCESS_KEY S3_SECRET_KEY S3_BUCKET; do
+  [[ -n "${!_v+set}" ]] && _caller_env[$_v]="${!_v}"
+done
+
+if [[ -f "$ROOT_DIR/../.env" ]]; then
+  # shellcheck disable=SC1091
+  source "$ROOT_DIR/../.env"
+fi
+
+for _v in "${!_caller_env[@]}"; do
+  export "$_v=${_caller_env[$_v]}"
+done
+unset _caller_env _v
+
+
+: "${S3_ENDPOINTS:=http://127.0.0.1:9000}"
+: "${S3_ACCESS_KEY:=admin}"
+: "${S3_SECRET_KEY:=admin123}"
+: "${S3_BUCKET:=spttest}"
+
+RESULTS_DIR="$SCRIPT_DIR/results/mpu-headless-$(date +%Y%m%d-%H%M%S)"
+mkdir -p "$RESULTS_DIR"
+
+echo "=========================================================================="
+echo " Running Headless MPU Workload with Concurrency Limits"
+echo "=========================================================================="
+echo " - Object Count: 10"
+echo " - Object Size: 25MB"
+echo " - Part Size: 5MB"
+echo " - Global Threads: 8"
+echo " - Max Concurrent MPU Objects: 2"
+echo " - Max Concurrent MPU Parts per Object: 3"
+echo " - Endpoint: $S3_ENDPOINTS"
+echo " - Results: $RESULTS_DIR"
+echo "=========================================================================="
+
+"$SPT_BIN" run write \
+  --endpoints "$S3_ENDPOINTS" \
+  --access-key "$S3_ACCESS_KEY" \
+  --secret-key "$S3_SECRET_KEY" \
+  --bucket "$S3_BUCKET" \
+  --prefix "mpu-limit-test/" \
+  --object-count 10 \
+  --object-size 25MB \
+  --part-size 5MB \
+  --threads 8 \
+  --mpu-concurrent-objects 2 \
+  --mpu-concurrent-parts 3 \
+  --headless \
+  --output-dir "$RESULTS_DIR" \
+  "$@"
+
+echo ""
+echo "Test completed. Results saved to $RESULTS_DIR"

--- a/engine/core/spt-base/doc/usage/input/configuration/README.md
+++ b/engine/core/spt-base/doc/usage/input/configuration/README.md
@@ -85,6 +85,8 @@ reference.
 | storage-auth-secret                            | String | null                    | The authentication secret
 | storage-auth-token                             | String | null                    | S3: no effect, Atmos: subtenant, Swift: token
 | storage-driver-limit-concurrency               | Integer >= 0 | 1                 | The concurrency limit (per node in case of distributed mode). In case of filesystem this is the max number of open files at any moment. In case of HTTP this is the max number of the active connections at any moment.
+| storage-driver-limit-multipart-objects         | Integer >= 0 | 0                 | The max concurrent multipart objects in flight at any moment. `0` = unlimited.
+| storage-driver-limit-multipart-parts           | Integer >= 0 | 0                 | The max concurrent parts in flight per multipart object at any moment. `0` = unlimited.
 | storage-driver-limit-queue-input               | Integer > 0 | 1000000            | Storage drivers internal input operations queue size limit
 | storage-driver-threads                         | Integer >= 0 | 0                 | The count of the shared/global I/O executor threads. 0 means automatic value (CPU cores/threads count)
 | storage-driver-type                            | String | s3                      | The identifier pointing to the one of the registered storage driver implementations to use

--- a/engine/core/spt-base/src/main/java/com/dell/spt/base/item/op/Operation.java
+++ b/engine/core/spt-base/src/main/java/com/dell/spt/base/item/op/Operation.java
@@ -102,6 +102,8 @@ public interface Operation<I extends Item> {
 
 	void reset();
 
+	void resetTiming();
+
 	/**
 	 * Returns {@code true} if the storage driver has already recycled this operation
 	 * via the fast-recycle path (re-submitted directly without going through the

--- a/engine/core/spt-base/src/main/java/com/dell/spt/base/item/op/OperationImpl.java
+++ b/engine/core/spt-base/src/main/java/com/dell/spt/base/item/op/OperationImpl.java
@@ -88,6 +88,11 @@ public class OperationImpl<I extends Item> implements Operation<I> {
 	}
 
 	@Override
+	public void resetTiming() {
+		reqTimeStart = reqTimeDone = respTimeStart = respTimeDone = 0;
+	}
+
+	@Override
 	public void reset() {
 		item.reset();
 		nodeAddr = null;

--- a/engine/core/spt-base/src/main/java/com/dell/spt/base/item/op/composite/CompositeOperation.java
+++ b/engine/core/spt-base/src/main/java/com/dell/spt/base/item/op/composite/CompositeOperation.java
@@ -19,6 +19,15 @@ public interface CompositeOperation<I extends Item> extends Operation<I> {
 
 	List<? extends PartialOperation> subOperations();
 
+	/** 
+	 * Returns up to `limit` un-yielded sub-operations.
+	 * This method allows a driver to request sub-operations in batches. 
+	 * Calls to this method are stateful and drain the un-yielded sub-operations.
+	 */
+	default List<? extends PartialOperation> nextSubOperations(final int limit) {
+		return subOperations();
+	}
+
 	/** Should be invoked only after subOperations() * */
 	void markSubTaskCompleted();
 

--- a/engine/core/spt-base/src/main/java/com/dell/spt/base/item/op/composite/data/CompositeDataOperationImpl.java
+++ b/engine/core/spt-base/src/main/java/com/dell/spt/base/item/op/composite/data/CompositeDataOperationImpl.java
@@ -22,6 +22,7 @@ public class CompositeDataOperationImpl<I extends DataItem> extends DataOperatio
 
 	private final Map<String, String> contextData = new HashMap<>();
 	private final List<PartialDataOperation<I>> subTasks = new ArrayList<>();
+	private final AtomicInteger subTaskYieldIndex = new AtomicInteger(0);
 
 	public CompositeDataOperationImpl() {
 		super();
@@ -86,6 +87,29 @@ public class CompositeDataOperationImpl<I extends DataItem> extends DataOperatio
 		pendingSubTasksCount.set(subTasks.size());
 
 		return subTasks;
+	}
+
+	@Override
+	public final List<? extends PartialDataOperation<I>> nextSubOperations(int limit) {
+		final List<? extends PartialDataOperation<I>> allOps = subOperations();
+		if (limit <= 0 || limit >= allOps.size()) {
+			int current = subTaskYieldIndex.getAndSet(allOps.size());
+			if (current >= allOps.size()) {
+				return java.util.Collections.emptyList();
+			}
+			return allOps.subList(current, allOps.size());
+		}
+
+		while (true) {
+			int current = subTaskYieldIndex.get();
+			if (current >= allOps.size()) {
+				return java.util.Collections.emptyList();
+			}
+			int next = Math.min(current + limit, allOps.size());
+			if (subTaskYieldIndex.compareAndSet(current, next)) {
+				return allOps.subList(current, next);
+			}
+		}
 	}
 
 	@Override

--- a/engine/core/spt-base/src/main/resources/config-schema.yaml
+++ b/engine/core/spt-base/src/main/resources/config-schema.yaml
@@ -127,6 +127,9 @@ storage:
   driver:
     limit:
       concurrency: int
+      multipart:
+        objects: int
+        parts: int
       queue:
         input: int
     threads: int

--- a/engine/core/spt-base/src/main/resources/config/defaults.yaml
+++ b/engine/core/spt-base/src/main/resources/config/defaults.yaml
@@ -137,6 +137,9 @@ storage:
   driver:
     limit:
       concurrency: 1
+      multipart:
+        objects: 0
+        parts: 0
       queue:
         input: 1000000
     threads: 0

--- a/engine/core/spt-base/src/test/java/com/dell/spt/base/item/op/composite/data/CompositeDataOperationImplTest.java
+++ b/engine/core/spt-base/src/test/java/com/dell/spt/base/item/op/composite/data/CompositeDataOperationImplTest.java
@@ -71,6 +71,33 @@ class CompositeDataOperationImplTest {
 		assertTrue(op.allSubOperationsDone());
 	}
 
+	@Test
+	void nextSubOperations_returnsRequestedLimit() throws Exception {
+		var op = newCompositeOp(OpType.READ, 4096, 1024);
+		
+		var parts1 = op.nextSubOperations(2);
+		assertEquals(2, parts1.size());
+		
+		var parts2 = op.nextSubOperations(1);
+		assertEquals(1, parts2.size());
+		
+		var parts3 = op.nextSubOperations(5);
+		assertEquals(1, parts3.size(), "Should only return remaining parts (1)");
+		
+		var parts4 = op.nextSubOperations(1);
+		assertTrue(parts4.isEmpty(), "Should return empty list when exhausted");
+	}
+
+	@Test
+	void nextSubOperations_withZeroLimit_returnsAll() throws Exception {
+		var op = newCompositeOp(OpType.READ, 4096, 1024);
+		var parts = op.nextSubOperations(0);
+		assertEquals(4, parts.size());
+		
+		var partsAfter = op.nextSubOperations(1);
+		assertTrue(partsAfter.isEmpty());
+	}
+
 	// ---------- result() copy behavior (Fix #4: recycled ops) ----------
 
 	@Test

--- a/engine/core/spt-base/src/test/java/com/dell/spt/base/item/op/composite/data/CompositeDataOperationImplTest.java
+++ b/engine/core/spt-base/src/test/java/com/dell/spt/base/item/op/composite/data/CompositeDataOperationImplTest.java
@@ -74,16 +74,16 @@ class CompositeDataOperationImplTest {
 	@Test
 	void nextSubOperations_returnsRequestedLimit() throws Exception {
 		var op = newCompositeOp(OpType.READ, 4096, 1024);
-		
+
 		var parts1 = op.nextSubOperations(2);
 		assertEquals(2, parts1.size());
-		
+
 		var parts2 = op.nextSubOperations(1);
 		assertEquals(1, parts2.size());
-		
+
 		var parts3 = op.nextSubOperations(5);
 		assertEquals(1, parts3.size(), "Should only return remaining parts (1)");
-		
+
 		var parts4 = op.nextSubOperations(1);
 		assertTrue(parts4.isEmpty(), "Should return empty list when exhausted");
 	}
@@ -93,7 +93,7 @@ class CompositeDataOperationImplTest {
 		var op = newCompositeOp(OpType.READ, 4096, 1024);
 		var parts = op.nextSubOperations(0);
 		assertEquals(4, parts.size());
-		
+
 		var partsAfter = op.nextSubOperations(1);
 		assertTrue(partsAfter.isEmpty());
 	}

--- a/engine/extensions/storage-drivers/implementations/s3/README.md
+++ b/engine/extensions/storage-drivers/implementations/s3/README.md
@@ -418,19 +418,27 @@ Each multipart upload proceeds through four phases:
 3. **Complete** -- `POST /<bucket>/<key>?uploadId=ID` with an XML body listing all part numbers and ETags.
 4. **Abort** (on failure) -- `DELETE /<bucket>/<key>?uploadId=ID` cleans up incomplete uploads when part retries are exhausted.
 
-#### 4.4.3. Part-Level Retry
+#### 4.4.3. Concurrency Limits
+
+The maximum concurrency of multipart uploads can be restricted at the storage driver level via the `storage-driver-limit-multipart` configuration:
+- `storage-driver-limit-multipart-objects`: Restricts how many top-level multipart objects can be active simultaneously (0 = unlimited).
+- `storage-driver-limit-multipart-parts`: Restricts how many parts of a *single* object can be uploading simultaneously, creating a sliding window of parts (0 = unlimited).
+
+These limits operate *within* the global `storage-driver-limit-concurrency` pool and are useful for preventing connection pool exhaustion when testing with high concurrency.
+
+#### 4.4.4. Part-Level Retry
 
 Individual parts are retried up to 3 times on failure. Only after all retries for a part are exhausted does the engine abort the entire multipart upload. This prevents a single transient network error from wasting all successfully uploaded parts.
 
-#### 4.4.4. Per-Part Checksums
+#### 4.4.5. Per-Part Checksums
 
 When `storage-checksum-enabled=true`, the selected checksum algorithm is applied to **each individual part upload**. The checksum is computed over the part's data slice and sent in the appropriate S3 header (`Content-MD5` for MD5, or `x-amz-checksum-<algorithm>` for CRC32/CRC32C/SHA1/SHA256).
 
-#### 4.4.5. Reporting
+#### 4.4.6. Reporting
 
 Completed multipart uploads are logged to `parts.upload.csv` (in the step's log directory) with columns: `ItemPath`, `UploadId`, `RespLatency[us]`. Aborted uploads are also logged with an `abort` prefix.
 
-#### 4.4.6. Example: Scenario File (JAR users)
+#### 4.4.7. Example: Scenario File (JAR users)
 
 Users running the engine JAR directly can configure MPU in a JavaScript scenario file:
 

--- a/engine/extensions/storage-drivers/implementations/s3/src/main/java/com/dell/spt/storage/driver/coop/netty/http/s3/S3StorageDriver.java
+++ b/engine/extensions/storage-drivers/implementations/s3/src/main/java/com/dell/spt/storage/driver/coop/netty/http/s3/S3StorageDriver.java
@@ -1322,6 +1322,7 @@ public class S3StorageDriver<I extends Item, O extends Operation<I>>
 			// Pre-super: extract upload ID from channel (channel may be released by super)
 			// and set failure status so super.complete() can close the channel if needed
 			if (compositeOp.get(S3Api.KEY_MPU_ABORT) == null
+							&& compositeOp.get(S3Api.KEY_UPLOAD_ID) == null
 							&& !compositeOp.allSubOperationsDone()) {
 				final var initUploadId = channel.attr(S3Api.KEY_ATTR_UPLOAD_ID).get();
 				if (initUploadId == null) {

--- a/engine/extensions/storage-drivers/implementations/s3/src/main/java/com/dell/spt/storage/driver/coop/netty/http/s3/S3StorageDriver.java
+++ b/engine/extensions/storage-drivers/implementations/s3/src/main/java/com/dell/spt/storage/driver/coop/netty/http/s3/S3StorageDriver.java
@@ -668,8 +668,10 @@ public class S3StorageDriver<I extends Item, O extends Operation<I>>
 			if (OpType.CREATE.equals(opType)) {
 				final var mpuOp = (CompositeDataOperation) op;
 				if (mpuOp.get(S3Api.KEY_MPU_ABORT) != null) {
+					mpuOp.resetTiming();
 					httpRequest = abortMultipartUploadRequest(mpuOp, nodeAddr);
 				} else if (mpuOp.allSubOperationsDone()) {
+					mpuOp.resetTiming();
 					httpRequest = completeMultipartUploadRequest(mpuOp, nodeAddr);
 				} else { // this is the initial state of the task
 					httpRequest = initMultipartUploadRequest(op, nodeAddr);

--- a/engine/extensions/storage-drivers/primitives/coop/src/main/java/com/dell/spt/storage/driver/coop/CoopStorageDriverBase.java
+++ b/engine/extensions/storage-drivers/primitives/coop/src/main/java/com/dell/spt/storage/driver/coop/CoopStorageDriverBase.java
@@ -185,7 +185,7 @@ public abstract class CoopStorageDriverBase<I extends Item, O extends Operation<
 	boolean isMpuInit(final O op) {
 		if (op instanceof CompositeOperation && OpType.CREATE.equals(op.type())) {
 			final var compositeOp = (CompositeOperation) op;
-			return !compositeOp.allSubOperationsDone() && compositeOp.get("uploadId") == null;
+			return !compositeOp.allSubOperationsDone() && compositeOp.get("uploadId") == null && !OpType.NOOP.equals(op.type());
 		}
 		return false;
 	}

--- a/engine/extensions/storage-drivers/primitives/coop/src/main/java/com/dell/spt/storage/driver/coop/CoopStorageDriverBase.java
+++ b/engine/extensions/storage-drivers/primitives/coop/src/main/java/com/dell/spt/storage/driver/coop/CoopStorageDriverBase.java
@@ -58,17 +58,17 @@ public abstract class CoopStorageDriverBase<I extends Item, O extends Operation<
 		this.childOpQueue = new ArrayBlockingQueue<>(inQueueLimit);
 		this.inOpQueue = new ArrayBlockingQueue<>(inQueueLimit);
 		this.concurrencyThrottle = new Semaphore(concurrencyLimit > 0 ? concurrencyLimit : Integer.MAX_VALUE, true);
-		
+
 		int mpuObjects = 0;
 		int maxParts = 0;
 		try {
 			mpuObjects = storageConfig.intVal("driver-limit-multipart-objects");
 			maxParts = storageConfig.intVal("driver-limit-multipart-parts");
 		} catch (final Exception ignored) {}
-		
+
 		this.mpuMaxParts = maxParts;
 		this.mpuObjectThrottle = mpuObjects > 0 ? new Semaphore(mpuObjects, true) : null;
-		
+
 		this.opDispatchTask = new OperationDispatchTask<>(
 						ServiceTaskExecutor.VT_EXECUTOR, this, inOpQueue, childOpQueue, stepId, batchSize,
 						dispatchLock, dispatchReady);
@@ -182,6 +182,7 @@ public abstract class CoopStorageDriverBase<I extends Item, O extends Operation<
 
 	protected abstract int submit(final List<O> ops)
 					throws IllegalStateException;
+
 	boolean isMpuInit(final O op) {
 		if (op instanceof CompositeOperation && OpType.CREATE.equals(op.type())) {
 			final var compositeOp = (CompositeOperation) op;
@@ -199,6 +200,7 @@ public abstract class CoopStorageDriverBase<I extends Item, O extends Operation<
 			mpuObjectThrottle.release();
 		}
 	}
+
 	private void safeReleaseMpuObjectPermit(final O op) {
 		if (OpType.CREATE.equals(op.type())) {
 			final CompositeOperation<?> parentOp;

--- a/engine/extensions/storage-drivers/primitives/coop/src/main/java/com/dell/spt/storage/driver/coop/CoopStorageDriverBase.java
+++ b/engine/extensions/storage-drivers/primitives/coop/src/main/java/com/dell/spt/storage/driver/coop/CoopStorageDriverBase.java
@@ -8,6 +8,7 @@ import com.dell.spt.base.data.DataInput;
 import com.dell.spt.base.config.IllegalConfigurationException;
 import com.dell.spt.base.item.DataItem;
 import com.dell.spt.base.item.Item;
+import com.dell.spt.base.item.op.OpType;
 import com.dell.spt.base.item.op.Operation;
 import com.dell.spt.base.item.op.composite.CompositeOperation;
 import com.dell.spt.base.item.op.partial.PartialOperation;
@@ -33,6 +34,8 @@ public abstract class CoopStorageDriverBase<I extends Item, O extends Operation<
 	static final int MAX_PART_RETRIES = 3;
 
 	protected final Semaphore concurrencyThrottle;
+	protected final Semaphore mpuObjectThrottle;
+	protected final int mpuMaxParts;
 	protected final BlockingQueue<O> childOpQueue;
 	private final BlockingQueue<O> inOpQueue;
 	private final LongAdder scheduledOpCount = new LongAdder();
@@ -55,6 +58,17 @@ public abstract class CoopStorageDriverBase<I extends Item, O extends Operation<
 		this.childOpQueue = new ArrayBlockingQueue<>(inQueueLimit);
 		this.inOpQueue = new ArrayBlockingQueue<>(inQueueLimit);
 		this.concurrencyThrottle = new Semaphore(concurrencyLimit > 0 ? concurrencyLimit : Integer.MAX_VALUE, true);
+		
+		int mpuObjects = 0;
+		int maxParts = 0;
+		try {
+			mpuObjects = storageConfig.intVal("driver-limit-multipart-objects");
+			maxParts = storageConfig.intVal("driver-limit-multipart-parts");
+		} catch (final Exception ignored) {}
+		
+		this.mpuMaxParts = maxParts;
+		this.mpuObjectThrottle = mpuObjects > 0 ? new Semaphore(mpuObjects, true) : null;
+		
 		this.opDispatchTask = new OperationDispatchTask<>(
 						ServiceTaskExecutor.VT_EXECUTOR, this, inOpQueue, childOpQueue, stepId, batchSize,
 						dispatchLock, dispatchReady);
@@ -168,64 +182,133 @@ public abstract class CoopStorageDriverBase<I extends Item, O extends Operation<
 
 	protected abstract int submit(final List<O> ops)
 					throws IllegalStateException;
+	boolean isMpuInit(final O op) {
+		if (op instanceof CompositeOperation && OpType.CREATE.equals(op.type())) {
+			final var compositeOp = (CompositeOperation) op;
+			return !compositeOp.allSubOperationsDone() && compositeOp.get("uploadId") == null;
+		}
+		return false;
+	}
+
+	boolean tryAcquireMpuObjectPermit() {
+		return mpuObjectThrottle == null || mpuObjectThrottle.tryAcquire();
+	}
+
+	void releaseMpuObjectPermit() {
+		if (mpuObjectThrottle != null) {
+			mpuObjectThrottle.release();
+		}
+	}
+	private void safeReleaseMpuObjectPermit(final O op) {
+		if (OpType.CREATE.equals(op.type())) {
+			final CompositeOperation<?> parentOp;
+			if (op instanceof PartialOperation) {
+				parentOp = ((PartialOperation<?>) op).parent();
+			} else if (op instanceof CompositeOperation) {
+				parentOp = (CompositeOperation<?>) op;
+			} else {
+				return;
+			}
+			synchronized (parentOp) {
+				if (parentOp.get("permitReleased") == null) {
+					parentOp.put("permitReleased", "true");
+					if (mpuObjectThrottle != null) {
+						mpuObjectThrottle.release();
+					}
+				}
+			}
+		}
+	}
 
 	@SuppressWarnings("unchecked")
 	protected final boolean handleCompleted(final O op) {
-		if (super.handleCompleted(op)) {
-			completedOpCount.increment();
-			if (op instanceof CompositeOperation) {
-				final var parentOp = (CompositeOperation) op;
-				if (!parentOp.allSubOperationsDone()) {
-					final List<O> subOps = parentOp.subOperations();
+		final boolean accepted = super.handleCompleted(op);
+		if (!accepted) {
+			if (op instanceof CompositeOperation || op instanceof PartialOperation) {
+				safeReleaseMpuObjectPermit(op);
+			}
+			return false;
+		}
+
+		completedOpCount.increment();
+		if (op instanceof CompositeOperation) {
+			final var parentOp = (CompositeOperation) op;
+			if (!parentOp.allSubOperationsDone()) {
+				if (op.status() == Operation.Status.SUCC) {
+					final List<O> subOps = (List<O>) parentOp.nextSubOperations(mpuMaxParts > 0 ? mpuMaxParts : Integer.MAX_VALUE);
 					for (final O nextSubOp : subOps) {
 						if (!childOpQueue.offer(nextSubOp)) {
 							Loggers.ERR.warn(
 											"{}: Child operations queue overflow, dropping the operation", toString());
+							safeReleaseMpuObjectPermit(op);
+							return false;
+						}
+					}
+				} else {
+					safeReleaseMpuObjectPermit(op);
+				}
+			} else {
+				safeReleaseMpuObjectPermit(op);
+			}
+		} else if (op instanceof PartialOperation) {
+			final var subOp = (PartialOperation) op;
+			final var parentOp = subOp.parent();
+			if (op.status() != Operation.Status.SUCC) {
+				if (subOp.retryCount() < MAX_PART_RETRIES) {
+					// retry the individual part instead of aborting the whole MPU
+					final var failStatus = op.status();
+					subOp.incrementRetryCount();
+					parentOp.undoMarkSubTaskCompleted();
+					op.status(Operation.Status.PENDING);
+					if (op.item() instanceof DataItem dataItem) {
+						dataItem.reset();
+					}
+					Loggers.ERR.warn(
+									"{}: part #{} failed ({}), retry {}/{}",
+									toString(), subOp.partNumber(), failStatus,
+									subOp.retryCount(), MAX_PART_RETRIES);
+					if (!childOpQueue.offer(op)) {
+						Loggers.ERR.warn(
+										"{}: Child operations queue overflow, dropping retry", toString());
+						safeReleaseMpuObjectPermit(op);
+					}
+				} else {
+					// retries exhausted — abort the MPU
+					synchronized (parentOp) {
+						parentOp.put("mpuAbort", "true");
+					}
+				}
+			} else {
+				boolean isAborted;
+				synchronized (parentOp) {
+					isAborted = parentOp.get("mpuAbort") != null;
+				}
+				if (!isAborted) {
+					// Part succeeded, fetch next part if any
+					final List<O> nextSubOps = (List<O>) parentOp.nextSubOperations(1);
+					for (final O nextSubOp : nextSubOps) {
+						if (!childOpQueue.offer(nextSubOp)) {
+							Loggers.ERR.warn(
+											"{}: Child operations queue overflow, dropping the operation", toString());
+							safeReleaseMpuObjectPermit(op);
 							return false;
 						}
 					}
 				}
-			} else if (op instanceof PartialOperation) {
-				final var subOp = (PartialOperation) op;
-				final var parentOp = subOp.parent();
-				if (op.status() != Operation.Status.SUCC) {
-					if (subOp.retryCount() < MAX_PART_RETRIES) {
-						// retry the individual part instead of aborting the whole MPU
-						final var failStatus = op.status();
-						subOp.incrementRetryCount();
-						parentOp.undoMarkSubTaskCompleted();
-						op.status(Operation.Status.PENDING);
-						if (op.item() instanceof DataItem dataItem) {
-							dataItem.reset();
-						}
-						Loggers.ERR.warn(
-										"{}: part #{} failed ({}), retry {}/{}",
-										toString(), subOp.partNumber(), failStatus,
-										subOp.retryCount(), MAX_PART_RETRIES);
-						if (!childOpQueue.offer(op)) {
-							Loggers.ERR.warn(
-											"{}: Child operations queue overflow, dropping retry", toString());
-						}
-					} else {
-						// retries exhausted — abort the MPU
-						parentOp.put("mpuAbort", "true");
-					}
-				}
-				if (parentOp.allSubOperationsDone()) {
-					// execute once again to finalize the things if necessary:
-					// complete the multipart upload, for example
-					if (!childOpQueue.offer((O) parentOp)) {
-						Loggers.ERR.warn(
-										"{}: Child operations queue overflow, dropping the operation", toString());
-						return false;
-					}
+			}
+			if (parentOp.allSubOperationsDone()) {
+				// execute once again to finalize the things if necessary:
+				// complete the multipart upload, for example
+				if (!childOpQueue.offer((O) parentOp)) {
+					Loggers.ERR.warn(
+									"{}: Child operations queue overflow, dropping the operation", toString());
+					safeReleaseMpuObjectPermit(op);
+					return false;
 				}
 			}
-			signalDispatch();
-			return true;
-		} else {
-			return false;
 		}
+		signalDispatch();
+		return true;
 	}
 
 	/**

--- a/engine/extensions/storage-drivers/primitives/coop/src/main/java/com/dell/spt/storage/driver/coop/OperationDispatchTask.java
+++ b/engine/extensions/storage-drivers/primitives/coop/src/main/java/com/dell/spt/storage/driver/coop/OperationDispatchTask.java
@@ -10,6 +10,7 @@ import static com.dell.spt.base.Constants.KEY_CLASS_NAME;
 import static com.dell.spt.base.Constants.KEY_STEP_ID;
 
 import java.util.concurrent.BlockingQueue;
+import java.util.Queue;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.Lock;
 
@@ -36,6 +37,8 @@ public final class OperationDispatchTask<I extends Item, O extends Operation<I>>
 	private final Lock dispatchLock;
 	private final Condition dispatchReady;
 
+	private final Queue<O> deferredMpuQueue = new java.util.ArrayDeque<>();
+
 	public OperationDispatchTask(
 					final VirtualThreadExecutor executor, final CoopStorageDriverBase<I, O> storageDriver,
 					final BlockingQueue<O> inOpQueue, final BlockingQueue<O> childOpQueue, final String stepId,
@@ -60,19 +63,20 @@ public final class OperationDispatchTask<I extends Item, O extends Operation<I>>
 	@Override
 	protected final void doWork() throws Exception {
 		try {
+			while (buff.size() < batchSize && !deferredMpuQueue.isEmpty() && storageDriver.tryAcquireMpuObjectPermit()) {
+				buff.add(deferredMpuQueue.poll());
+			}
+			
 			// Drain child ops first (partial/composite completions have priority)
-			childOpQueue.drainTo(buff, batchSize - buff.size());
+			if (buff.size() < batchSize) {
+				childOpQueue.drainTo(buff, batchSize - buff.size());
+			}
+
 			// Then drain incoming ops
+			final java.util.List<O> tempInOps = new java.util.ArrayList<>(batchSize);
 			if (buff.size() == 0) {
-				inOpQueue.drainTo(buff, batchSize);
-				if (buff.size() == 0) {
-					// Both queues empty — wait for signal from producer or completion
-					// callback.  All code paths that enqueue ops (put methods) or free
-					// capacity (handleCompleted) call signalDispatch(), so an untimed
-					// await is safe — the signal will always arrive.  Removing the timed
-					// variant eliminates per-park ScheduledFutureTask allocation and the
-					// corresponding VT-unparker thread work that was consuming 22-27% of
-					// CPU in profiling.
+				inOpQueue.drainTo(tempInOps, batchSize);
+				if (tempInOps.isEmpty() && deferredMpuQueue.isEmpty()) {
 					dispatchLock.lock();
 					try {
 						if (childOpQueue.isEmpty() && inOpQueue.isEmpty()) {
@@ -82,14 +86,34 @@ public final class OperationDispatchTask<I extends Item, O extends Operation<I>>
 						dispatchLock.unlock();
 					}
 					// Drain again after waking
-					childOpQueue.drainTo(buff, batchSize);
+					while (buff.size() < batchSize && !deferredMpuQueue.isEmpty() && storageDriver.tryAcquireMpuObjectPermit()) {
+						buff.add(deferredMpuQueue.poll());
+					}
 					if (buff.size() < batchSize) {
-						inOpQueue.drainTo(buff, batchSize - buff.size());
+						childOpQueue.drainTo(buff, batchSize - buff.size());
+					}
+					if (buff.size() < batchSize) {
+						inOpQueue.drainTo(tempInOps, batchSize - buff.size());
 					}
 				}
 			} else if (buff.size() < batchSize) {
-				inOpQueue.drainTo(buff, batchSize - buff.size());
+				inOpQueue.drainTo(tempInOps, batchSize - buff.size());
 			}
+
+			// Process new incoming ops to respect MPU object limits
+			for (int i = 0; i < tempInOps.size(); i++) {
+				O op = tempInOps.get(i);
+				if (storageDriver.isMpuInit(op)) {
+					if (storageDriver.tryAcquireMpuObjectPermit()) {
+						buff.add(op);
+					} else {
+						deferredMpuQueue.add(op);
+					}
+				} else {
+					buff.add(op);
+				}
+			}
+
 			// submit all buffered ops (including retries from prior iterations)
 			final int buffSize = buff.size();
 			if (buffSize > 0) {

--- a/engine/extensions/storage-drivers/primitives/coop/src/main/java/com/dell/spt/storage/driver/coop/OperationDispatchTask.java
+++ b/engine/extensions/storage-drivers/primitives/coop/src/main/java/com/dell/spt/storage/driver/coop/OperationDispatchTask.java
@@ -66,7 +66,7 @@ public final class OperationDispatchTask<I extends Item, O extends Operation<I>>
 			while (buff.size() < batchSize && !deferredMpuQueue.isEmpty() && storageDriver.tryAcquireMpuObjectPermit()) {
 				buff.add(deferredMpuQueue.poll());
 			}
-			
+
 			// Drain child ops first (partial/composite completions have priority)
 			if (buff.size() < batchSize) {
 				childOpQueue.drainTo(buff, batchSize - buff.size());

--- a/engine/extensions/storage-drivers/primitives/coop/src/test/java/com/dell/spt/storage/driver/coop/CoopStorageDriverBaseTest.java
+++ b/engine/extensions/storage-drivers/primitives/coop/src/test/java/com/dell/spt/storage/driver/coop/CoopStorageDriverBaseTest.java
@@ -602,14 +602,14 @@ class CoopStorageDriverBaseTest {
 	@Test
 	void handleCompleted_childOpQueueOverflowReleasesMpuObjectPermit() throws Exception {
 		final var driver = newRetryTestDriver();
-		
+
 		// Set up an MPU object throttle with 1 permit, and acquire it so 0 are available
 		final Semaphore mpuThrottle = new Semaphore(1, true);
 		mpuThrottle.acquire();
 		final var mpuField = CoopStorageDriverBase.class.getDeclaredField("mpuObjectThrottle");
 		mpuField.setAccessible(true);
 		mpuField.set(driver, mpuThrottle);
-		
+
 		final var maxPartsField = CoopStorageDriverBase.class.getDeclaredField("mpuMaxParts");
 		maxPartsField.setAccessible(true);
 		maxPartsField.set(driver, 0);
@@ -626,7 +626,7 @@ class CoopStorageDriverBaseTest {
 		final var parent = new com.dell.spt.base.item.op.composite.data.CompositeDataOperationImpl<com.dell.spt.base.item.DataItem>(
 						0, com.dell.spt.base.item.op.OpType.CREATE, baseItem, null, "/bucket", null, null, 0, 1024);
 		parent.subOperations(); // pendingSubTasksCount = 2
-		
+
 		// Act: complete the first part
 		final var part = (com.dell.spt.base.item.op.partial.data.PartialDataOperationImpl<com.dell.spt.base.item.DataItem>) parent.nextSubOperations(1).get(0);
 		part.status(Operation.Status.SUCC);
@@ -644,7 +644,7 @@ class CoopStorageDriverBaseTest {
 	@Test
 	void handleCompleted_parentEnqueueOverflowReleasesMpuObjectPermit() throws Exception {
 		final var driver = newRetryTestDriver();
-		
+
 		final Semaphore mpuThrottle = new Semaphore(1, true);
 		mpuThrottle.acquire();
 		final var mpuField = CoopStorageDriverBase.class.getDeclaredField("mpuObjectThrottle");
@@ -661,7 +661,7 @@ class CoopStorageDriverBaseTest {
 		final var parent = new com.dell.spt.base.item.op.composite.data.CompositeDataOperationImpl<com.dell.spt.base.item.DataItem>(
 						0, com.dell.spt.base.item.op.OpType.CREATE, baseItem, null, "/bucket", null, null, 0, 1024);
 		parent.subOperations(); // pendingSubTasksCount = 1
-		
+
 		final var part = (com.dell.spt.base.item.op.partial.data.PartialDataOperationImpl<com.dell.spt.base.item.DataItem>) parent.nextSubOperations(1).get(0);
 		part.status(Operation.Status.SUCC);
 		parent.markSubTaskCompleted(); // pending = 0, all done

--- a/engine/extensions/storage-drivers/primitives/coop/src/test/java/com/dell/spt/storage/driver/coop/CoopStorageDriverBaseTest.java
+++ b/engine/extensions/storage-drivers/primitives/coop/src/test/java/com/dell/spt/storage/driver/coop/CoopStorageDriverBaseTest.java
@@ -598,4 +598,83 @@ class CoopStorageDriverBaseTest {
 		assertEquals(0, driver.completedOpCount(),
 						"completedOpCount should not be incremented when driver is stopped");
 	}
+
+	@Test
+	void handleCompleted_childOpQueueOverflowReleasesMpuObjectPermit() throws Exception {
+		final var driver = newRetryTestDriver();
+		
+		// Set up an MPU object throttle with 1 permit, and acquire it so 0 are available
+		final Semaphore mpuThrottle = new Semaphore(1, true);
+		mpuThrottle.acquire();
+		final var mpuField = CoopStorageDriverBase.class.getDeclaredField("mpuObjectThrottle");
+		mpuField.setAccessible(true);
+		mpuField.set(driver, mpuThrottle);
+		
+		final var maxPartsField = CoopStorageDriverBase.class.getDeclaredField("mpuMaxParts");
+		maxPartsField.setAccessible(true);
+		maxPartsField.set(driver, 0);
+
+		// Fill the childOpQueue to force an overflow
+		final var queue = childQueueOf(driver);
+		while (queue.remainingCapacity() > 0) {
+			queue.add(mock(Operation.class));
+		}
+
+		// Create a parent MPU operation
+		final var baseItem = new com.dell.spt.base.item.DataItemImpl("obj1", 0, 2048);
+		baseItem.dataInput(com.dell.spt.base.data.DataInput.instance(null, "7a42d9c483244167", new com.github.akurilov.commons.system.SizeInBytes("64KB"), 4, false));
+		final var parent = new com.dell.spt.base.item.op.composite.data.CompositeDataOperationImpl<com.dell.spt.base.item.DataItem>(
+						0, com.dell.spt.base.item.op.OpType.CREATE, baseItem, null, "/bucket", null, null, 0, 1024);
+		parent.subOperations(); // pendingSubTasksCount = 2
+		
+		// Act: complete the first part
+		final var part = (com.dell.spt.base.item.op.partial.data.PartialDataOperationImpl<com.dell.spt.base.item.DataItem>) parent.nextSubOperations(1).get(0);
+		part.status(Operation.Status.SUCC);
+		parent.markSubTaskCompleted(); // pending = 1
+
+		// driver.handleCompleted(part) will try to fetch the next part and push it to the queue.
+		// Since the queue is full, offer() will fail, it will log a warning, and it MUST release the MPU permit.
+		boolean result = driver.handleCompleted((Operation<Item>) (Operation<?>) part);
+
+		assertFalse(result, "handleCompleted should return false on overflow");
+		assertEquals(1, mpuThrottle.availablePermits(), "MPU object permit should be safely released on overflow");
+		assertEquals("true", parent.get("permitReleased"));
+	}
+
+	@Test
+	void handleCompleted_parentEnqueueOverflowReleasesMpuObjectPermit() throws Exception {
+		final var driver = newRetryTestDriver();
+		
+		final Semaphore mpuThrottle = new Semaphore(1, true);
+		mpuThrottle.acquire();
+		final var mpuField = CoopStorageDriverBase.class.getDeclaredField("mpuObjectThrottle");
+		mpuField.setAccessible(true);
+		mpuField.set(driver, mpuThrottle);
+
+		final var maxPartsField = CoopStorageDriverBase.class.getDeclaredField("mpuMaxParts");
+		maxPartsField.setAccessible(true);
+		maxPartsField.set(driver, 0);
+
+		// Single part MPU
+		final var baseItem = new com.dell.spt.base.item.DataItemImpl("obj2", 0, 1024);
+		baseItem.dataInput(com.dell.spt.base.data.DataInput.instance(null, "7a42d9c483244167", new com.github.akurilov.commons.system.SizeInBytes("64KB"), 4, false));
+		final var parent = new com.dell.spt.base.item.op.composite.data.CompositeDataOperationImpl<com.dell.spt.base.item.DataItem>(
+						0, com.dell.spt.base.item.op.OpType.CREATE, baseItem, null, "/bucket", null, null, 0, 1024);
+		parent.subOperations(); // pendingSubTasksCount = 1
+		
+		final var part = (com.dell.spt.base.item.op.partial.data.PartialDataOperationImpl<com.dell.spt.base.item.DataItem>) parent.nextSubOperations(1).get(0);
+		part.status(Operation.Status.SUCC);
+		parent.markSubTaskCompleted(); // pending = 0, all done
+
+		// Fill the childOpQueue so the attempt to re-enqueue the parent fails
+		final var queue = childQueueOf(driver);
+		while (queue.remainingCapacity() > 0) {
+			queue.add(mock(Operation.class));
+		}
+
+		boolean result = driver.handleCompleted((Operation<Item>) (Operation<?>) part);
+
+		assertFalse(result, "handleCompleted should return false on overflow");
+		assertEquals(1, mpuThrottle.availablePermits(), "MPU object permit should be safely released on parent enqueue overflow");
+	}
 }

--- a/engine/extensions/storage-drivers/primitives/coop/src/test/java/com/dell/spt/storage/driver/coop/CoopStorageDriverBaseTest.java
+++ b/engine/extensions/storage-drivers/primitives/coop/src/test/java/com/dell/spt/storage/driver/coop/CoopStorageDriverBaseTest.java
@@ -211,7 +211,7 @@ class CoopStorageDriverBaseTest {
 		parent.subOperations(); // initializes pendingSubTasksCount = 4
 
 		// Grab first part and simulate a failed IO
-		final var part = (PartialDataOperationImpl<DataItem>) parent.subOperations().get(0);
+		final var part = (PartialDataOperationImpl<DataItem>) parent.nextSubOperations(1).get(0);
 		part.status(Operation.Status.FAIL_IO);
 		// Simulate finishResponse() having been called (decrements parent pending count)
 		parent.markSubTaskCompleted(); // pending = 3
@@ -240,7 +240,7 @@ class CoopStorageDriverBaseTest {
 						0, OpType.CREATE, baseItem, null, "/bucket", null, null, 0, 1024);
 		parent.subOperations(); // pendingSubTasksCount = 2
 
-		final var part = (PartialDataOperationImpl<DataItem>) parent.subOperations().get(0);
+		final var part = (PartialDataOperationImpl<DataItem>) parent.nextSubOperations(1).get(0);
 		// Exhaust retries
 		for (int i = 0; i < CoopStorageDriverBase.MAX_PART_RETRIES; i++) {
 			part.incrementRetryCount();
@@ -265,7 +265,7 @@ class CoopStorageDriverBaseTest {
 						0, OpType.CREATE, baseItem, null, "/bucket", null, null, 0, 1024);
 		parent.subOperations(); // pendingSubTasksCount = 2
 
-		final var part = (PartialDataOperationImpl<DataItem>) parent.subOperations().get(0);
+		final var part = (PartialDataOperationImpl<DataItem>) parent.nextSubOperations(1).get(0);
 		part.status(Operation.Status.SUCC);
 		parent.markSubTaskCompleted(); // simulate finishResponse; pending = 1
 
@@ -289,7 +289,7 @@ class CoopStorageDriverBaseTest {
 						0, OpType.CREATE, baseItem, null, "/bucket", null, null, 0, 1024);
 		parent.subOperations(); // pendingSubTasksCount = 1
 
-		final var part = (PartialDataOperationImpl<DataItem>) parent.subOperations().get(0);
+		final var part = (PartialDataOperationImpl<DataItem>) parent.nextSubOperations(1).get(0);
 		part.status(Operation.Status.SUCC);
 		parent.markSubTaskCompleted(); // pending = 0, allSubOperationsDone() → true
 


### PR DESCRIPTION
## Summary
* Implemented `--mpu-concurrent-objects` and `--mpu-concurrent-parts` CLI flags
* Added semaphore-based throttling for active MPU objects
* Refactored `CompositeDataOperation` to dispense parts in a sliding window
* Fixed a timing bug where recycled operations reported invalid latency metrics
* Updated tests and validation logic
* Tested with a headless S3 run

#### Test plan
- [x] Pass CLI tests (`make test`)
- [x] Pass engine tests (`./gradlew test`)
- [x] `testmpu.headless.sh` executes completely against a mocked S3 target

Resolves ISGFGE-4062.