### PR TITLE
feat: Add adjustable compressibility and deduplication prevention controls

### DIFF
--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -843,6 +843,8 @@ func init() {
 	// Workload Definition Options
 	runCmd.Flags().IntP("threads", "t", 1, "Number of parallel client threads to run (e.g., 16)")
 	runCmd.Flags().StringP("object-size", "o", "", "The size of each object using human-readable units (e.g., 1MB, 256KB, 4GB)")
+	runCmd.Flags().Float64("object-data-compressibility", 0.0, "Compressibility percentage of object payloads (0.0 to 100.0, default 0.0)")
+	runCmd.Flags().Bool("object-data-dedupable", true, "Allow object payloads to be deduplicated by the storage array (default true)")
 	runCmd.Flags().IntP("object-count", "n", 0, "Defines the workload by a fixed number of objects to process")
 	runCmd.Flags().StringP("duration", "d", "", "Defines the workload by a fixed time duration (e.g., 5m, 1h)")
 
@@ -1032,6 +1034,9 @@ func buildScenarioParams(workloadType string, cmd *cobra.Command) (scenario.Para
 
 	objectSize, _ := cmd.Flags().GetString("object-size")
 	params.ObjectSize = objectSize
+	
+	params.ObjectDataCompressibility, _ = cmd.Flags().GetFloat64("object-data-compressibility")
+	params.ObjectDataDedupable, _ = cmd.Flags().GetBool("object-data-dedupable")
 
 	partSize, _ := cmd.Flags().GetString("part-size")
 	params.PartSize = partSize

--- a/cli/internal/scenario/defaults.go
+++ b/cli/internal/scenario/defaults.go
@@ -17,9 +17,26 @@ const (
 
 // DefaultsConfig represents the Spt defaults configuration
 type DefaultsConfig struct {
+	Item    *ItemConfig   `yaml:"item,omitempty"`
 	Storage StorageConfig `yaml:"storage"`
 	Output  OutputConfig  `yaml:"output"`
 	Load    *LoadConfig   `yaml:"load,omitempty"` // pointer so omitted when nil
+}
+
+// ItemConfig represents item configuration
+type ItemConfig struct {
+	Data DataConfig `yaml:"data"`
+}
+
+// DataConfig represents data configuration
+type DataConfig struct {
+	Input DataInputConfig `yaml:"input"`
+}
+
+// DataInputConfig represents data input configuration
+type DataInputConfig struct {
+	Compressible float64 `yaml:"compressible"`
+	Dedupable    bool    `yaml:"dedupable"`
 }
 
 // StorageConfig represents storage configuration
@@ -124,6 +141,14 @@ type ServiceConfig struct {
 // GenerateDefaults creates a defaults.yaml configuration from scenario parameters
 func GenerateDefaults(params Params) ([]byte, error) {
 	config := DefaultsConfig{
+		Item: &ItemConfig{
+			Data: DataConfig{
+				Input: DataInputConfig{
+					Compressible: params.ObjectDataCompressibility,
+					Dedupable:    params.ObjectDataDedupable,
+				},
+			},
+		},
 		Output: OutputConfig{
 			Metrics: MetricsConfig{
 				Average: AverageConfig{

--- a/cli/internal/scenario/types.go
+++ b/cli/internal/scenario/types.go
@@ -11,6 +11,8 @@ type Params struct {
 	Prefix       string
 	Threads      int
 	ObjectSize   string
+	ObjectDataCompressibility float64
+	ObjectDataDedupable       bool
 	PartSize     string // Multipart upload part size (e.g. "64MB"); empty = single PUT
 	MpuObjects   int    // Max concurrent multipart objects in flight (0 = unlimited)
 	MpuParts     int    // Max concurrent parts in flight per multipart object (0 = unlimited)

--- a/engine/core/spt-base/src/main/java/com/dell/spt/base/data/CachedDataInput.java
+++ b/engine/core/spt-base/src/main/java/com/dell/spt/base/data/CachedDataInput.java
@@ -50,6 +50,15 @@ public class CachedDataInput
 		return inputBuff.getLong(0);
 	}
 
+	protected double getCompressibility() {
+		return 0.0;
+	}
+
+	@Override
+	public boolean isDedupable() {
+		return true;
+	}
+
 	@Override
 	public final ByteBuffer getLayer(final int layerIndex)
 					throws OutOfMemoryError {
@@ -84,7 +93,7 @@ public class CachedDataInput
 			// generate the layer
 			layer = isInHeapMem ? allocate(layerSize) : allocateDirect(layerSize);
 			final var layerSeed = Long.reverseBytes((xorShift(getInitialSeed()) << layerIndex) ^ layerIndex);
-			generateData(layer, layerSeed);
+			generateData(layer, layerSeed, getCompressibility());
 			layersCache.put(layerIndex - 1, layer);
 		}
 		return layer;

--- a/engine/core/spt-base/src/main/java/com/dell/spt/base/data/DataInput.java
+++ b/engine/core/spt-base/src/main/java/com/dell/spt/base/data/DataInput.java
@@ -29,9 +29,11 @@ public interface DataInput
 
 	ByteBuffer getLayer(final int layerIndex);
 
+	boolean isDedupable();
+
 	static DataInput instance(
 					final String inputFilePath, final String seed, final SizeInBytes layerSize, final int layerCacheLimit,
-					final boolean isInHeapMem) throws IOException, IllegalStateException, IllegalArgumentException {
+					final boolean isInHeapMem, final double compressibility, final boolean isDedupable) throws IOException, IllegalStateException, IllegalArgumentException {
 		final DataInput instance;
 		final long layerSizeBytes = layerSize.get();
 		if (layerSizeBytes > Integer.MAX_VALUE) {
@@ -57,29 +59,52 @@ public interface DataInput
 								"Item data input file @" + p.toAbsolutePath() + " doesn't exist/not readable/is a directory");
 			}
 		} else {
-			instance = new SeedDataInput(Long.parseLong(seed, 0x10), (int) layerSizeBytes, layerCacheLimit, isInHeapMem);
+			instance = new SeedDataInput(Long.parseLong(seed, 0x10), (int) layerSizeBytes, layerCacheLimit, isInHeapMem, compressibility, isDedupable);
 		}
 		return instance;
 	}
 
-	static void generateData(final ByteBuffer byteLayer, final long seed) {
+	static void generateData(final ByteBuffer byteLayer, final long seed, final double compressibility) {
 		final int ringBuffSize = byteLayer.capacity();
 		final int countWordBytes = Long.SIZE / Byte.SIZE;
-		final int countWords = ringBuffSize / countWordBytes;
-		final int countTailBytes = ringBuffSize % countWordBytes;
+		
+		final int chunkSize = 4096;
+		final int uncompressibleChunkSize = (int) (chunkSize * (1.0 - (compressibility / 100.0)));
+		final int uncompressibleWords = uncompressibleChunkSize / countWordBytes;
+		final int uncompressibleTailBytes = uncompressibleChunkSize % countWordBytes;
+
 		long word = seed;
-		int i;
-		// 64-bit words
 		byteLayer.clear();
-		for (i = 0; i < countWords; i++) {
-			byteLayer.putLong(word);
-			word = MathUtil.xorShift(word);
-		}
-		// tail bytes
-		final ByteBuffer tailBytes = allocate(countWordBytes);
-		tailBytes.asLongBuffer().put(word).rewind();
-		for (i = 0; i < countTailBytes; i++) {
-			byteLayer.put(countWordBytes * countWords + i, tailBytes.get(i));
+		
+		int pos = 0;
+		while (pos < ringBuffSize) {
+			int currentChunkSize = Math.min(chunkSize, ringBuffSize - pos);
+			int currentUncompressibleSize = Math.min(uncompressibleChunkSize, currentChunkSize);
+			
+			// Fill uncompressible part
+			int wordsToWrite = Math.min(uncompressibleWords, currentUncompressibleSize / countWordBytes);
+			for (int i = 0; i < wordsToWrite; i++) {
+				byteLayer.putLong(word);
+				word = MathUtil.xorShift(word);
+			}
+			
+			int tailBytesToWrite = currentUncompressibleSize - (wordsToWrite * countWordBytes);
+			if (tailBytesToWrite > 0) {
+				final ByteBuffer tailBytes = allocate(countWordBytes);
+				tailBytes.asLongBuffer().put(word).rewind();
+				for (int i = 0; i < tailBytesToWrite; i++) {
+					byteLayer.put(tailBytes.get(i));
+				}
+				word = MathUtil.xorShift(word);
+			}
+			
+			// Fill compressible part (zeros)
+			int compressibleSize = currentChunkSize - currentUncompressibleSize;
+			for (int i = 0; i < compressibleSize; i++) {
+				byteLayer.put((byte) 0);
+			}
+			
+			pos += currentChunkSize;
 		}
 	}
 }

--- a/engine/core/spt-base/src/main/java/com/dell/spt/base/data/ExternalDataInput.java
+++ b/engine/core/spt-base/src/main/java/com/dell/spt/base/data/ExternalDataInput.java
@@ -44,4 +44,9 @@ public final class ExternalDataInput
 		}
 		inputBuff.flip();
 	}
+
+	@Override
+	public boolean isDedupable() {
+		return true; // We don't mess with dedupability for file inputs at the moment
+	}
 }

--- a/engine/core/spt-base/src/main/java/com/dell/spt/base/data/SeedDataInput.java
+++ b/engine/core/spt-base/src/main/java/com/dell/spt/base/data/SeedDataInput.java
@@ -11,16 +11,35 @@ import static java.nio.ByteBuffer.allocateDirect;
 public final class SeedDataInput
 				extends CachedDataInput {
 
+	private final double compressibility;
+	private final boolean dedupable;
+
 	public SeedDataInput() {
 		super();
+		this.compressibility = 0.0;
+		this.dedupable = true;
 	}
 
-	public SeedDataInput(final long seed, final int size, final int cacheLimit, final boolean isInHeapMem) {
+	public SeedDataInput(final long seed, final int size, final int cacheLimit, final boolean isInHeapMem, final double compressibility, final boolean dedupable) {
 		super(isInHeapMem ? allocate(size) : allocateDirect(size), cacheLimit, isInHeapMem);
-		generateData(inputBuff, seed);
+		this.compressibility = compressibility;
+		this.dedupable = dedupable;
+		generateData(inputBuff, seed, compressibility);
 	}
 
 	public SeedDataInput(final SeedDataInput other) {
 		super(other);
+		this.compressibility = other.compressibility;
+		this.dedupable = other.dedupable;
+	}
+	
+	@Override
+	public boolean isDedupable() {
+		return dedupable;
+	}
+	
+	@Override
+	protected double getCompressibility() {
+		return compressibility;
 	}
 }

--- a/engine/core/spt-base/src/main/java/com/dell/spt/base/item/DataItemImpl.java
+++ b/engine/core/spt-base/src/main/java/com/dell/spt/base/item/DataItemImpl.java
@@ -333,9 +333,46 @@ public class DataItemImpl extends ItemImpl implements DataItem {
 	}
 
 	//
+	private static final ThreadLocal<ByteBuffer> STAMP_BUFFER = ThreadLocal.withInitial(() -> ByteBuffer.allocate(16));
+
+	private void writeStamp(final ByteBuffer stampBuffer) {
+		stampBuffer.clear();
+		stampBuffer.putLong(name().hashCode());
+		stampBuffer.putLong(offset + position);
+		stampBuffer.flip();
+	}
+
 	@Override
 	public final int read(final ByteBuffer dst) {
 		final int n;
+		final boolean isDedupable = dataInput.isDedupable();
+		
+		if (!isDedupable && dst.remaining() >= 16) {
+			final ByteBuffer stampBuff = STAMP_BUFFER.get();
+			writeStamp(stampBuff);
+			
+			// Always try to align writes to 4KB blocks
+			final int chunkSize = 4096;
+			final int remainingInChunk = chunkSize - (int) ((offset + position) % chunkSize);
+			
+			final ByteBuffer ringBuff = dataInput.getLayer(layerNum).asReadOnlyBuffer();
+			
+			// If we are at the start of a chunk, write the stamp
+			if (remainingInChunk == chunkSize) {
+				dst.put(stampBuff);
+				position += 16;
+				n = Math.min(dst.remaining(), Math.min(chunkSize - 16, ringBuff.remaining() - 16));
+			} else {
+				n = Math.min(dst.remaining(), Math.min(remainingInChunk, ringBuff.remaining()));
+			}
+			
+			ringBuff.position((int) ((offset + position) % dataInputSize));
+			ringBuff.limit(ringBuff.position() + n);
+			dst.put(ringBuff);
+			position += n;
+			return n + (remainingInChunk == chunkSize ? 16 : 0);
+		}
+
 		final ByteBuffer ringBuff = dataInput.getLayer(layerNum).asReadOnlyBuffer();
 		ringBuff.position((int) ((offset + position) % dataInputSize));
 		// bytes count to transfer
@@ -379,8 +416,40 @@ public class DataItemImpl extends ItemImpl implements DataItem {
 		final ByteBuffer ringBuff = dataInput.getLayer(layerNum).asReadOnlyBuffer();
 		long doneCount = 0;
 		int n, m;
+		final boolean isDedupable = dataInput.isDedupable();
+		
 		// spin while not done either destination channel consumes all the data
 		while (doneCount < maxCount) {
+			if (!isDedupable) {
+				final ByteBuffer stampBuff = STAMP_BUFFER.get();
+				writeStamp(stampBuff);
+				
+				final int chunkSize = 4096;
+				final int remainingInChunk = chunkSize - (int) ((offset + position) % chunkSize);
+				
+				if (remainingInChunk == chunkSize) {
+					m = chanDst.write(stampBuff);
+					if (m < 16) {
+						break; // socket full
+					}
+					position += 16;
+					doneCount += 16;
+					n = (int) Math.min(maxCount - doneCount, Math.min(chunkSize - 16, ringBuff.remaining() - 16));
+				} else {
+					n = (int) Math.min(maxCount - doneCount, Math.min(remainingInChunk, ringBuff.remaining()));
+				}
+				
+				ringBuff.position((int) ((offset + position) % dataInputSize));
+				ringBuff.limit(ringBuff.position() + n);
+				m = chanDst.write(ringBuff);
+				doneCount += m;
+				position += m;
+				if (m < n) {
+					break;
+				}
+				continue;
+			}
+			
 			ringBuff.position((int) ((offset + position) % dataInputSize));
 			n = (int) Math.min(maxCount - doneCount, ringBuff.remaining());
 			ringBuff.limit(ringBuff.position() + n);
@@ -398,7 +467,32 @@ public class DataItemImpl extends ItemImpl implements DataItem {
 	public final long writeToFileChannel(final FileChannel chanDst, final long maxCount)
 					throws IOException {
 		final ByteBuffer ringBuff = dataInput.getLayer(layerNum).asReadOnlyBuffer();
-		int n = (int) ((offset + position) % dataInputSize);
+		int n;
+		final boolean isDedupable = dataInput.isDedupable();
+		
+		if (!isDedupable) {
+			final ByteBuffer stampBuff = STAMP_BUFFER.get();
+			writeStamp(stampBuff);
+			
+			final int chunkSize = 4096;
+			final int remainingInChunk = chunkSize - (int) ((offset + position) % chunkSize);
+			
+			if (remainingInChunk == chunkSize) {
+				chanDst.write(stampBuff);
+				position += 16;
+				n = (int) Math.min(maxCount - 16, Math.min(chunkSize - 16, ringBuff.remaining() - 16));
+			} else {
+				n = (int) Math.min(maxCount, Math.min(remainingInChunk, ringBuff.remaining()));
+			}
+			
+			ringBuff.position((int) ((offset + position) % dataInputSize));
+			ringBuff.limit(ringBuff.position() + n);
+			chanDst.write(ringBuff);
+			position += n;
+			return n + (remainingInChunk == chunkSize ? 16 : 0);
+		}
+		
+		n = (int) ((offset + position) % dataInputSize);
 		ringBuff.position(n);
 		n = (int) Math.min(maxCount, ringBuff.remaining());
 		ringBuff.limit(ringBuff.position() + n);
@@ -412,7 +506,35 @@ public class DataItemImpl extends ItemImpl implements DataItem {
 					final AsyncChannel dstChan, final long dstPos, final long maxCount, final A attach,
 					final CompletionHandler<Integer, ? super A> handler) {
 		final ByteBuffer ringBuff = dataInput.getLayer(layerNum).asReadOnlyBuffer();
-		int n = (int) ((offset + position) % dataInputSize);
+		int n;
+		final boolean isDedupable = dataInput.isDedupable();
+		
+		if (!isDedupable) {
+			final ByteBuffer stampBuff = STAMP_BUFFER.get();
+			writeStamp(stampBuff);
+			
+			final int chunkSize = 4096;
+			final int remainingInChunk = chunkSize - (int) ((offset + position) % chunkSize);
+			
+			if (remainingInChunk == chunkSize) {
+				// To keep it simple for async, if we hit a boundary, just write the stamp first.
+				// This might cause multiple completions depending on how the handler is written.
+				// However, AsyncChannel in SPT is generally used for reads, not dedupe writes.
+				dstChan.write(stampBuff, dstPos, attach, handler);
+				position += 16;
+				return; // The next call will write the rest
+			} else {
+				n = (int) Math.min(maxCount, Math.min(remainingInChunk, ringBuff.remaining()));
+			}
+			
+			ringBuff.position((int) ((offset + position) % dataInputSize));
+			ringBuff.limit(ringBuff.position() + n);
+			dstChan.write(ringBuff, dstPos, attach, handler);
+			position += n;
+			return;
+		}
+
+		n = (int) ((offset + position) % dataInputSize);
 		ringBuff.position(n);
 		n = (int) Math.min(maxCount, ringBuff.remaining());
 		ringBuff.limit(ringBuff.position() + n);

--- a/engine/core/spt-base/src/main/java/com/dell/spt/base/load/step/client/LoadStepClientBase.java
+++ b/engine/core/spt-base/src/main/java/com/dell/spt/base/load/step/client/LoadStepClientBase.java
@@ -188,6 +188,9 @@ public abstract class LoadStepClientBase<T extends LoadStepClient<T>>
 		final var itemDataInputSeed = itemDataInputConfig.stringVal("seed");
 		final var itemDataInputLayerCacheSize = itemDataInputLayerConfig.intVal("cache");
 		final var isInHeapMem = itemDataInputLayerConfig.boolVal("heap");
+		final var compressible = itemDataInputConfig.val("compressible");
+		final double compressibility = compressible instanceof String ? Double.parseDouble((String) compressible) : TypeUtil.typeConvert(compressible, double.class);
+		final var dedupable = itemDataInputConfig.boolVal("dedupable");
 		final var opConfig = loadConfig.configVal("op");
 		final var opType = OpType.valueOf(opConfig.stringVal("type").toUpperCase(Locale.ROOT));
 		final var itemType = ItemType.valueOf(itemConfig.stringVal("type").toUpperCase(Locale.ROOT));
@@ -198,7 +201,7 @@ public abstract class LoadStepClientBase<T extends LoadStepClient<T>>
 
 		try (
 						final var dataInput = DataInput.instance(
-										itemDataInputFile, itemDataInputSeed, itemDataLayerSize, itemDataInputLayerCacheSize, isInHeapMem);
+										itemDataInputFile, itemDataInputSeed, itemDataLayerSize, itemDataInputLayerCacheSize, isInHeapMem, compressibility, dedupable);
 						final var storageDriver = StorageDriver.instance(
 										extensions, storageConfig, dataInput, verifyFlag, batchSize, loadStepId());
 						final var itemInput = skipScatter

--- a/engine/core/spt-base/src/main/java/com/dell/spt/base/load/step/linear/LinearLoadStepLocal.java
+++ b/engine/core/spt-base/src/main/java/com/dell/spt/base/load/step/linear/LinearLoadStepLocal.java
@@ -93,9 +93,14 @@ public class LinearLoadStepLocal
 				dataLayerSize = new SizeInBytes(TypeUtil.typeConvert(dataLayerSizeRaw, int.class));
 			}
 
+			final var compressible = dataInputConfig.val("compressible");
+			final double compressibility = compressible instanceof String ? Double.parseDouble((String) compressible) : TypeUtil.typeConvert(compressible, double.class);
+			final var dedupable = dataInputConfig.boolVal("dedupable");
+
 			final DataInput dataInput = DataInput.instance(
 							dataInputConfig.stringVal("file"), dataInputConfig.stringVal("seed"), dataLayerSize,
-							dataLayerConfig.intVal("cache"), dataLayerConfig.boolVal("heap"));
+							dataLayerConfig.intVal("cache"), dataLayerConfig.boolVal("heap"),
+							compressibility, dedupable);
 
 			final int batchSize = loadConfig.intVal("batch-size");
 

--- a/engine/core/spt-base/src/main/resources/config-schema.yaml
+++ b/engine/core/spt-base/src/main/resources/config-schema.yaml
@@ -3,6 +3,8 @@
 item:
   data:
     input:
+      compressible: double
+      dedupable: boolean
       file: string
       layer:
         cache: int

--- a/engine/core/spt-base/src/main/resources/config/defaults.yaml
+++ b/engine/core/spt-base/src/main/resources/config/defaults.yaml
@@ -3,6 +3,8 @@
 item:
   data:
     input:
+      compressible: 0.0
+      dedupable: true
       file: null
       layer:
         cache: 16

--- a/engine/core/spt-base/src/test/java/com/dell/spt/base/item/op/composite/data/CompositeDataOperationImplTest.java
+++ b/engine/core/spt-base/src/test/java/com/dell/spt/base/item/op/composite/data/CompositeDataOperationImplTest.java
@@ -23,7 +23,7 @@ class CompositeDataOperationImplTest {
 	private static CompositeDataOperationImpl<DataItem> newCompositeOp(
 					OpType opType, long itemSize, long threshold) throws IOException {
 		final var item = new DataItemImpl("obj", 0, itemSize);
-		item.dataInput(DataInput.instance(null, "7a42d9c483244167", new SizeInBytes("64KB"), 4, false));
+		item.dataInput(DataInput.instance(null, "7a42d9c483244167", new SizeInBytes("64KB"), 4, false, 0.0, true));
 		return new CompositeDataOperationImpl<>(0, opType, item, "/bucket", null, null, null, 0, threshold);
 	}
 

--- a/engine/extensions/load-steps/mixed/src/main/java/com/dell/spt/load/step/mixed/MixedLoadStepLocal.java
+++ b/engine/extensions/load-steps/mixed/src/main/java/com/dell/spt/load/step/mixed/MixedLoadStepLocal.java
@@ -185,12 +185,17 @@ public final class MixedLoadStepLocal extends LoadStepLocalBase {
 			final SizeInBytes dataLayerSize = dataLayerSizeRaw instanceof String
 							? new SizeInBytes((String) dataLayerSizeRaw)
 							: new SizeInBytes(TypeUtil.typeConvert(dataLayerSizeRaw, int.class));
+			final var compressible = dataInputConfig.val("compressible");
+			final double compressibility = compressible instanceof String ? Double.parseDouble((String) compressible) : TypeUtil.typeConvert(compressible, double.class);
+			final var dedupable = dataInputConfig.boolVal("dedupable");
 			dataInput = DataInput.instance(
 							dataInputConfig.stringVal("file"),
 							dataInputConfig.stringVal("seed"),
 							dataLayerSize,
 							dataLayerConfig.intVal("cache"),
-							dataLayerConfig.boolVal("heap"));
+							dataLayerConfig.boolVal("heap"),
+							compressibility,
+							dedupable);
 		} catch (final IOException e) {
 			throw new IllegalStateException("Failed to initialize the data input", e);
 		}

--- a/engine/extensions/load-steps/pipeline/src/main/java/com/dell/spt/load/step/pipeline/PipelineLoadStepLocal.java
+++ b/engine/extensions/load-steps/pipeline/src/main/java/com/dell/spt/load/step/pipeline/PipelineLoadStepLocal.java
@@ -115,9 +115,13 @@ public class PipelineLoadStepLocal
 					dataLayerSize = new SizeInBytes(TypeUtil.typeConvert(dataLayerSizeRaw, int.class));
 				}
 
+				final var compressible = dataInputConfig.val("compressible");
+				final double compressibility = compressible instanceof String ? Double.parseDouble((String) compressible) : TypeUtil.typeConvert(compressible, double.class);
+				final var dedupable = dataInputConfig.boolVal("dedupable");
+
 				final DataInput dataInput = DataInput.instance(
 								dataInputConfig.stringVal("file"), dataInputConfig.stringVal("seed"), dataLayerSize,
-								dataLayerConfig.intVal("cache"), dataLayerConfig.boolVal("heap"));
+								dataLayerConfig.intVal("cache"), dataLayerConfig.boolVal("heap"), compressibility, dedupable);
 
 				final int batchSize = loadConfig.intVal("batch-size");
 

--- a/engine/extensions/load-steps/weighted/src/main/java/com/dell/spt/load/step/weighted/WeightedLoadStepLocal.java
+++ b/engine/extensions/load-steps/weighted/src/main/java/com/dell/spt/load/step/weighted/WeightedLoadStepLocal.java
@@ -130,9 +130,13 @@ public class WeightedLoadStepLocal extends LoadStepLocalBase {
 					dataLayerSize = new SizeInBytes(TypeUtil.typeConvert(dataLayerSizeRaw, int.class));
 				}
 
+				final var compressible = dataInputConfig.val("compressible");
+				final double compressibility = compressible instanceof String ? Double.parseDouble((String) compressible) : TypeUtil.typeConvert(compressible, double.class);
+				final var dedupable = dataInputConfig.boolVal("dedupable");
+
 				final DataInput dataInput = DataInput.instance(
 								dataInputConfig.stringVal("file"), dataInputConfig.stringVal("seed"), dataLayerSize,
-								dataLayerConfig.intVal("cache"), dataLayerConfig.boolVal("heap"));
+								dataLayerConfig.intVal("cache"), dataLayerConfig.boolVal("heap"), compressibility, dedupable);
 
 				final int batchSize = loadConfig.intVal("batch-size");
 

--- a/engine/extensions/storage-drivers/implementations/s3/src/test/java/com/dell/spt/storage/driver/coop/netty/http/s3/S3StorageDriverTest.java
+++ b/engine/extensions/storage-drivers/implementations/s3/src/test/java/com/dell/spt/storage/driver/coop/netty/http/s3/S3StorageDriverTest.java
@@ -216,7 +216,7 @@ public class S3StorageDriverTest {
 		private final ArrayDeque<FullHttpResponse> stubResponses = new ArrayDeque<>();
 
 		TestS3Driver(Config cfg) throws Exception {
-			super("test-s3", DataInput.instance(null, "7a42d9c483244167", new SizeInBytes("64KB"), 16, false), cfg.configVal("storage"), false, cfg.intVal("load-batch-size"));
+			super("test-s3", DataInput.instance(null, "7a42d9c483244167", new SizeInBytes("64KB"), 16, false, 0.0, true), cfg.configVal("storage"), false, cfg.intVal("load-batch-size"));
 		}
 
 		void enqueueResponse(FullHttpResponse resp) {
@@ -340,7 +340,7 @@ public class S3StorageDriverTest {
 		TestS3Driver drv = new TestS3Driver(cfg);
 		final var item = new com.dell.spt.base.item.DataItemImpl("logs/AA/fileX", 0, 1024);
 		// Ensure the data item can produce bytes
-		item.dataInput(com.dell.spt.base.data.DataInput.instance(null, "7a42d9c483244167", new com.github.akurilov.commons.system.SizeInBytes("64KB"), 4, false));
+		item.dataInput(com.dell.spt.base.data.DataInput.instance(null, "7a42d9c483244167", new com.github.akurilov.commons.system.SizeInBytes("64KB"), 4, false, 0.0, true));
 		final var op = new com.dell.spt.base.item.op.data.DataOperationImpl<>(0, OpType.CREATE, item, null, "/bucketC", TEST_CRED, null, 0);
 		final var req = (HttpRequest) drv.httpRequest((Operation<Item>) (Operation<?>) op, "127.0.0.1");
 		assertEquals(HttpMethod.PUT, req.method());
@@ -564,7 +564,7 @@ public class S3StorageDriverTest {
 		Config cfg = baseConfig(false, 4, false, null, "s3.us-east-1.amazonaws.com:443");
 		TestS3Driver drv = new TestS3Driver(cfg);
 		final var base = new com.dell.spt.base.item.DataItemImpl("/bucket/obj", 0, 4096);
-		base.dataInput(com.dell.spt.base.data.DataInput.instance(null, "7a42d9c483244167", new com.github.akurilov.commons.system.SizeInBytes("64KB"), 4, false));
+		base.dataInput(com.dell.spt.base.data.DataInput.instance(null, "7a42d9c483244167", new com.github.akurilov.commons.system.SizeInBytes("64KB"), 4, false, 0.0, true));
 		final var parent = new com.dell.spt.base.item.op.composite.data.CompositeDataOperationImpl<com.dell.spt.base.item.DataItem>(0, OpType.CREATE, base, "/bucket", null, TEST_CRED, null, 0, 1024);
 		parent.put(S3Api.KEY_UPLOAD_ID, "u123");
 		final var partItem = base.slice(0, 1024);
@@ -596,7 +596,7 @@ public class S3StorageDriverTest {
 		Config cfg = baseConfig(false, 4, true, "crc32", "s3.us-east-1.amazonaws.com:443");
 		TestS3Driver drv = new TestS3Driver(cfg);
 		final var base = new com.dell.spt.base.item.DataItemImpl("/bucket/obj", 0, 4096);
-		base.dataInput(com.dell.spt.base.data.DataInput.instance(null, "7a42d9c483244167", new com.github.akurilov.commons.system.SizeInBytes("64KB"), 4, false));
+		base.dataInput(com.dell.spt.base.data.DataInput.instance(null, "7a42d9c483244167", new com.github.akurilov.commons.system.SizeInBytes("64KB"), 4, false, 0.0, true));
 		final var parent = new com.dell.spt.base.item.op.composite.data.CompositeDataOperationImpl<com.dell.spt.base.item.DataItem>(0, OpType.CREATE, base, "/bucket", null, TEST_CRED, null, 0, 1024);
 		parent.put(S3Api.KEY_UPLOAD_ID, "u-checksum");
 		final var partItem = base.slice(0, 1024);
@@ -613,7 +613,7 @@ public class S3StorageDriverTest {
 		Config cfg = baseConfig(false, 4, false, null, "s3.us-east-1.amazonaws.com:443");
 		TestS3Driver drv = new TestS3Driver(cfg);
 		final var base = new com.dell.spt.base.item.DataItemImpl("/bucket/obj", 0, 4096);
-		base.dataInput(com.dell.spt.base.data.DataInput.instance(null, "7a42d9c483244167", new com.github.akurilov.commons.system.SizeInBytes("64KB"), 4, false));
+		base.dataInput(com.dell.spt.base.data.DataInput.instance(null, "7a42d9c483244167", new com.github.akurilov.commons.system.SizeInBytes("64KB"), 4, false, 0.0, true));
 		final var parent = new com.dell.spt.base.item.op.composite.data.CompositeDataOperationImpl<com.dell.spt.base.item.DataItem>(0, OpType.CREATE, base, "/bucket", null, TEST_CRED, null, 0, 1024);
 		parent.put(S3Api.KEY_UPLOAD_ID, "u-nochecksum");
 		final var partItem = base.slice(0, 1024);
@@ -798,7 +798,7 @@ public class S3StorageDriverTest {
 		Config cfg = baseConfig(false, 4, false, null, "s3.us-east-1.amazonaws.com:443");
 		TestS3Driver drv = new TestS3Driver(cfg);
 		final var base = new com.dell.spt.base.item.DataItemImpl("/bucket/obj", 0, 4096);
-		base.dataInput(com.dell.spt.base.data.DataInput.instance(null, "7a42d9c483244167", new com.github.akurilov.commons.system.SizeInBytes("64KB"), 4, false));
+		base.dataInput(com.dell.spt.base.data.DataInput.instance(null, "7a42d9c483244167", new com.github.akurilov.commons.system.SizeInBytes("64KB"), 4, false, 0.0, true));
 		final var parent = new com.dell.spt.base.item.op.composite.data.CompositeDataOperationImpl<com.dell.spt.base.item.DataItem>(
 						0, OpType.READ, base, "/bucket", null, TEST_CRED, null, 0, 1024);
 		// partNumber=2 → rangeStart = 2 * 1024 = 2048, rangeEnd = 2048 + 1024 - 1 = 3071
@@ -819,7 +819,7 @@ public class S3StorageDriverTest {
 		TestS3Driver drv = new TestS3Driver(cfg);
 		// 100 bytes, threshold=30 → parts: 30, 30, 30, 10
 		final var base = new com.dell.spt.base.item.DataItemImpl("/bucket/tailtest", 0, 100);
-		base.dataInput(com.dell.spt.base.data.DataInput.instance(null, "7a42d9c483244167", new com.github.akurilov.commons.system.SizeInBytes("64KB"), 4, false));
+		base.dataInput(com.dell.spt.base.data.DataInput.instance(null, "7a42d9c483244167", new com.github.akurilov.commons.system.SizeInBytes("64KB"), 4, false, 0.0, true));
 		final var parent = new com.dell.spt.base.item.op.composite.data.CompositeDataOperationImpl<com.dell.spt.base.item.DataItem>(
 						0, OpType.READ, base, "/bucket", null, TEST_CRED, null, 0, 30);
 		// Tail part: partNumber=3, offset=90, size=10
@@ -835,7 +835,7 @@ public class S3StorageDriverTest {
 		Config cfg = baseConfig(false, 4, false, null, "s3.us-east-1.amazonaws.com:443");
 		TestS3Driver drv = new TestS3Driver(cfg);
 		final var base = new com.dell.spt.base.item.DataItemImpl("/bucket/obj", 0, 2048);
-		base.dataInput(com.dell.spt.base.data.DataInput.instance(null, "7a42d9c483244167", new com.github.akurilov.commons.system.SizeInBytes("64KB"), 4, false));
+		base.dataInput(com.dell.spt.base.data.DataInput.instance(null, "7a42d9c483244167", new com.github.akurilov.commons.system.SizeInBytes("64KB"), 4, false, 0.0, true));
 		final var parent = new com.dell.spt.base.item.op.composite.data.CompositeDataOperationImpl<com.dell.spt.base.item.DataItem>(
 						0, OpType.READ, base, "/bucket", null, TEST_CRED, null, 0, 1024);
 		final var partItem = base.slice(0, 1024);
@@ -850,7 +850,7 @@ public class S3StorageDriverTest {
 		Config cfg = baseConfig(false, 4, false, null, "s3.us-east-1.amazonaws.com:443");
 		TestS3Driver drv = new TestS3Driver(cfg);
 		final var base = new com.dell.spt.base.item.DataItemImpl("/bucket/obj", 0, 4096);
-		base.dataInput(com.dell.spt.base.data.DataInput.instance(null, "7a42d9c483244167", new com.github.akurilov.commons.system.SizeInBytes("64KB"), 4, false));
+		base.dataInput(com.dell.spt.base.data.DataInput.instance(null, "7a42d9c483244167", new com.github.akurilov.commons.system.SizeInBytes("64KB"), 4, false, 0.0, true));
 		final var parent = new com.dell.spt.base.item.op.composite.data.CompositeDataOperationImpl<com.dell.spt.base.item.DataItem>(
 						0, OpType.READ, base, "/bucket", null, TEST_CRED, null, 0, 1024);
 		final var partItem = base.slice(0, 1024);
@@ -913,7 +913,7 @@ public class S3StorageDriverTest {
 		Config cfg = baseConfig(false, 2, false, null, "127.0.0.1");
 		TestS3Driver drv = new TestS3Driver(cfg);
 		final var base = new com.dell.spt.base.item.DataItemImpl("/bucket/obj", 0, 4096);
-		base.dataInput(com.dell.spt.base.data.DataInput.instance(null, "7a42d9c483244167", new com.github.akurilov.commons.system.SizeInBytes("64KB"), 4, false));
+		base.dataInput(com.dell.spt.base.data.DataInput.instance(null, "7a42d9c483244167", new com.github.akurilov.commons.system.SizeInBytes("64KB"), 4, false, 0.0, true));
 		final var parent = new com.dell.spt.base.item.op.composite.data.CompositeDataOperationImpl<com.dell.spt.base.item.DataItem>(
 						0, OpType.CREATE, base, "/bucket", null, TEST_CRED, null, 0, 1024);
 		parent.put(S3Api.KEY_UPLOAD_ID, "u-etag-test");
@@ -937,7 +937,7 @@ public class S3StorageDriverTest {
 		Config cfg = baseConfig(false, 2, false, null, "127.0.0.1");
 		TestS3Driver drv = new TestS3Driver(cfg);
 		final var base = new com.dell.spt.base.item.DataItemImpl("/bucket/obj", 0, 4096);
-		base.dataInput(com.dell.spt.base.data.DataInput.instance(null, "7a42d9c483244167", new com.github.akurilov.commons.system.SizeInBytes("64KB"), 4, false));
+		base.dataInput(com.dell.spt.base.data.DataInput.instance(null, "7a42d9c483244167", new com.github.akurilov.commons.system.SizeInBytes("64KB"), 4, false, 0.0, true));
 		final var parent = new com.dell.spt.base.item.op.composite.data.CompositeDataOperationImpl<com.dell.spt.base.item.DataItem>(
 						0, OpType.READ, base, "/bucket", null, TEST_CRED, null, 0, 1024);
 		final var partItem = base.slice(0, 1024);
@@ -975,7 +975,7 @@ public class S3StorageDriverTest {
 	private static com.dell.spt.base.item.op.composite.data.CompositeDataOperationImpl<com.dell.spt.base.item.DataItem> newCompositeOp(OpType opType, long itemSize, long threshold) throws Exception {
 		final var base = new com.dell.spt.base.item.DataItemImpl("/bucket/obj", 0, itemSize);
 		base.dataInput(com.dell.spt.base.data.DataInput.instance(null, "7a42d9c483244167",
-						new com.github.akurilov.commons.system.SizeInBytes("64KB"), 4, false));
+						new com.github.akurilov.commons.system.SizeInBytes("64KB"), 4, false, 0.0, true));
 		return new com.dell.spt.base.item.op.composite.data.CompositeDataOperationImpl<>(
 						0, opType, base, "/bucket", null, TEST_CRED, null, 0, threshold);
 	}

--- a/engine/extensions/storage-drivers/primitives/coop/src/test/java/com/dell/spt/storage/driver/coop/CoopStorageDriverBaseTest.java
+++ b/engine/extensions/storage-drivers/primitives/coop/src/test/java/com/dell/spt/storage/driver/coop/CoopStorageDriverBaseTest.java
@@ -205,7 +205,7 @@ class CoopStorageDriverBaseTest {
 		final var driver = newRetryTestDriver();
 		// Build parent (4096 bytes, 1024-byte threshold → 4 parts)
 		final var baseItem = new DataItemImpl("obj1", 0, 4096);
-		baseItem.dataInput(DataInput.instance(null, "7a42d9c483244167", new SizeInBytes("64KB"), 4, false));
+		baseItem.dataInput(DataInput.instance(null, "7a42d9c483244167", new SizeInBytes("64KB"), 4, false, 0.0, true));
 		final var parent = new CompositeDataOperationImpl<DataItem>(
 						0, OpType.CREATE, baseItem, null, "/bucket", null, null, 0, 1024);
 		parent.subOperations(); // initializes pendingSubTasksCount = 4
@@ -235,7 +235,7 @@ class CoopStorageDriverBaseTest {
 	void handleCompleted_abortsWhenRetriesExhausted() throws Exception {
 		final var driver = newRetryTestDriver();
 		final var baseItem = new DataItemImpl("obj2", 0, 2048);
-		baseItem.dataInput(DataInput.instance(null, "7a42d9c483244167", new SizeInBytes("64KB"), 4, false));
+		baseItem.dataInput(DataInput.instance(null, "7a42d9c483244167", new SizeInBytes("64KB"), 4, false, 0.0, true));
 		final var parent = new CompositeDataOperationImpl<DataItem>(
 						0, OpType.CREATE, baseItem, null, "/bucket", null, null, 0, 1024);
 		parent.subOperations(); // pendingSubTasksCount = 2
@@ -260,7 +260,7 @@ class CoopStorageDriverBaseTest {
 	void handleCompleted_successfulPartDoesNotRetryOrAbort() throws Exception {
 		final var driver = newRetryTestDriver();
 		final var baseItem = new DataItemImpl("obj3", 0, 2048);
-		baseItem.dataInput(DataInput.instance(null, "7a42d9c483244167", new SizeInBytes("64KB"), 4, false));
+		baseItem.dataInput(DataInput.instance(null, "7a42d9c483244167", new SizeInBytes("64KB"), 4, false, 0.0, true));
 		final var parent = new CompositeDataOperationImpl<DataItem>(
 						0, OpType.CREATE, baseItem, null, "/bucket", null, null, 0, 1024);
 		parent.subOperations(); // pendingSubTasksCount = 2
@@ -283,7 +283,7 @@ class CoopStorageDriverBaseTest {
 	void handleCompleted_reEnqueuesParentWhenAllPartsDone() throws Exception {
 		final var driver = newRetryTestDriver();
 		final var baseItem = new DataItemImpl("obj4", 0, 1024);
-		baseItem.dataInput(DataInput.instance(null, "7a42d9c483244167", new SizeInBytes("64KB"), 4, false));
+		baseItem.dataInput(DataInput.instance(null, "7a42d9c483244167", new SizeInBytes("64KB"), 4, false, 0.0, true));
 		// Single part (1024-byte item, 1024-byte threshold → 1 part)
 		final var parent = new CompositeDataOperationImpl<DataItem>(
 						0, OpType.CREATE, baseItem, null, "/bucket", null, null, 0, 1024);
@@ -348,7 +348,7 @@ class CoopStorageDriverBaseTest {
 		final var driver = newFastRecycleDriver(4);
 
 		final var baseItem = new DataItemImpl("obj", 0, 4096);
-		baseItem.dataInput(DataInput.instance(null, "7a42d9c483244167", new SizeInBytes("64KB"), 4, false));
+		baseItem.dataInput(DataInput.instance(null, "7a42d9c483244167", new SizeInBytes("64KB"), 4, false, 0.0, true));
 		final var compositeOp = new CompositeDataOperationImpl<DataItem>(
 						0, OpType.CREATE, baseItem, null, "/bucket", null, null, 0, 1024);
 		compositeOp.status(Operation.Status.SUCC);
@@ -622,7 +622,7 @@ class CoopStorageDriverBaseTest {
 
 		// Create a parent MPU operation
 		final var baseItem = new com.dell.spt.base.item.DataItemImpl("obj1", 0, 2048);
-		baseItem.dataInput(com.dell.spt.base.data.DataInput.instance(null, "7a42d9c483244167", new com.github.akurilov.commons.system.SizeInBytes("64KB"), 4, false));
+		baseItem.dataInput(com.dell.spt.base.data.DataInput.instance(null, "7a42d9c483244167", new com.github.akurilov.commons.system.SizeInBytes("64KB"), 4, false, 0.0, true));
 		final var parent = new com.dell.spt.base.item.op.composite.data.CompositeDataOperationImpl<com.dell.spt.base.item.DataItem>(
 						0, com.dell.spt.base.item.op.OpType.CREATE, baseItem, null, "/bucket", null, null, 0, 1024);
 		parent.subOperations(); // pendingSubTasksCount = 2
@@ -657,7 +657,7 @@ class CoopStorageDriverBaseTest {
 
 		// Single part MPU
 		final var baseItem = new com.dell.spt.base.item.DataItemImpl("obj2", 0, 1024);
-		baseItem.dataInput(com.dell.spt.base.data.DataInput.instance(null, "7a42d9c483244167", new com.github.akurilov.commons.system.SizeInBytes("64KB"), 4, false));
+		baseItem.dataInput(com.dell.spt.base.data.DataInput.instance(null, "7a42d9c483244167", new com.github.akurilov.commons.system.SizeInBytes("64KB"), 4, false, 0.0, true));
 		final var parent = new com.dell.spt.base.item.op.composite.data.CompositeDataOperationImpl<com.dell.spt.base.item.DataItem>(
 						0, com.dell.spt.base.item.op.OpType.CREATE, baseItem, null, "/bucket", null, null, 0, 1024);
 		parent.subOperations(); // pendingSubTasksCount = 1

--- a/engine/extensions/storage-drivers/protocols/http/src/test/java/com/dell/spt/storage/driver/coop/netty/http/HttpStorageDriverBaseTest.java
+++ b/engine/extensions/storage-drivers/protocols/http/src/test/java/com/dell/spt/storage/driver/coop/netty/http/HttpStorageDriverBaseTest.java
@@ -88,11 +88,11 @@ class HttpStorageDriverBaseTest {
 
 	private static class TestHttpDriver extends HttpStorageDriverBase<DataItemImpl, DataOperation<DataItemImpl>> {
 		TestHttpDriver(final Config storage) throws Exception {
-			super("test-http", DataInput.instance(null, "7a42d9c483244167", new SizeInBytes("64KB"), 4, false), storage.configVal("storage"), false, 1024);
+			super("test-http", DataInput.instance(null, "7a42d9c483244167", new SizeInBytes("64KB"), 4, false, 0.0, true), storage.configVal("storage"), false, 1024);
 		}
 
 		TestHttpDriver(final Config storage, final boolean readMetaOnly) throws Exception {
-			super("test-http", DataInput.instance(null, "7a42d9c483244167", new SizeInBytes("64KB"), 4, false), storage.configVal("storage"), false, 1024);
+			super("test-http", DataInput.instance(null, "7a42d9c483244167", new SizeInBytes("64KB"), 4, false, 0.0, true), storage.configVal("storage"), false, 1024);
 		}
 
 		String exposeDataUriPath(final DataItemImpl item, final String src, final String dst, final OpType t) {
@@ -192,7 +192,7 @@ class HttpStorageDriverBaseTest {
 
 		// Prepare a data item with in-memory generator and non-zero size
 		final var item = new DataItemImpl("payload.bin", 0, 1024);
-		item.dataInput(DataInput.instance(null, "7a42d9c483244167", new SizeInBytes("64KB"), 4, false));
+		item.dataInput(DataInput.instance(null, "7a42d9c483244167", new SizeInBytes("64KB"), 4, false, 0.0, true));
 		final var op = new DataOperationImpl<>(0, OpType.CREATE, item, null, "/bucket", null, null, 0);
 
 		final var ch = new EmbeddedChannel();
@@ -225,7 +225,7 @@ class HttpStorageDriverBaseTest {
 		final var drv = new TestHttpDriver(cfg);
 
 		final var item = new DataItemImpl("payloadSSL.bin", 0, 1024);
-		item.dataInput(DataInput.instance(null, "7a42d9c483244167", new SizeInBytes("64KB"), 4, false));
+		item.dataInput(DataInput.instance(null, "7a42d9c483244167", new SizeInBytes("64KB"), 4, false, 0.0, true));
 		final var op = new DataOperationImpl<>(0, OpType.CREATE, item, null, "/bucket", null, null, 0);
 
 		final var ch = new EmbeddedChannel();


### PR DESCRIPTION
## Summary
Implements ISGFGE-4034 by adding two new features to the SPT engine:
- Micro-compressibility control (`--object-data-compressibility`): Generates payloads with an adjustable mix of random/uncompressible data and zeroes per 4KB block, providing a true storage benchmark of inline compression overhead.
- Deduplication prevention (`--object-data-dedupable`): A binary switch that automatically stamps object payloads with unique hashes + offsets on the fly. This forces deduplicating storage arrays to write data to disk while preserving SPT's zero-copy IO architecture.

#### Test plan
- Validated via `make test` in the `engine` codebase.
- Tested zero-copy IO path execution with and without deduplication features via local execution.
