### PR TITLE
harden coop MPU dispatch backpressure

### DIFF
--- a/engine/extensions/storage-drivers/primitives/coop/src/main/java/com/dell/spt/storage/driver/coop/CoopStorageDriverBase.java
+++ b/engine/extensions/storage-drivers/primitives/coop/src/main/java/com/dell/spt/storage/driver/coop/CoopStorageDriverBase.java
@@ -16,9 +16,11 @@ import com.dell.spt.base.logging.Loggers;
 import com.dell.spt.base.storage.driver.StorageDriver;
 import com.dell.spt.base.storage.driver.StorageDriverBase;
 import com.github.akurilov.confuse.Config;
+import com.github.akurilov.confuse.exceptions.InvalidValuePathException;
 import java.io.EOFException;
 import java.io.IOException;
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.Semaphore;
@@ -63,8 +65,12 @@ public abstract class CoopStorageDriverBase<I extends Item, O extends Operation<
 		int maxParts = 0;
 		try {
 			mpuObjects = storageConfig.intVal("driver-limit-multipart-objects");
+		} catch (final NoSuchElementException | InvalidValuePathException ignored) {} catch (final Exception e) {
+			Loggers.ERR.warn("{}: Failed to parse multipart limits: {}. Proceeding with unlimited.", testStepId, e.getMessage());
+		}
+		try {
 			maxParts = storageConfig.intVal("driver-limit-multipart-parts");
-		} catch (final Exception e) {
+		} catch (final NoSuchElementException | InvalidValuePathException ignored) {} catch (final Exception e) {
 			Loggers.ERR.warn("{}: Failed to parse multipart limits: {}. Proceeding with unlimited.", testStepId, e.getMessage());
 		}
 

--- a/engine/extensions/storage-drivers/primitives/coop/src/main/java/com/dell/spt/storage/driver/coop/CoopStorageDriverBase.java
+++ b/engine/extensions/storage-drivers/primitives/coop/src/main/java/com/dell/spt/storage/driver/coop/CoopStorageDriverBase.java
@@ -64,14 +64,16 @@ public abstract class CoopStorageDriverBase<I extends Item, O extends Operation<
 		try {
 			mpuObjects = storageConfig.intVal("driver-limit-multipart-objects");
 			maxParts = storageConfig.intVal("driver-limit-multipart-parts");
-		} catch (final Exception ignored) {}
+		} catch (final Exception e) {
+			Loggers.ERR.warn("{}: Failed to parse multipart limits: {}. Proceeding with unlimited.", testStepId, e.getMessage());
+		}
 
 		this.mpuMaxParts = maxParts;
 		this.mpuObjectThrottle = mpuObjects > 0 ? new Semaphore(mpuObjects, true) : null;
 
 		this.opDispatchTask = new OperationDispatchTask<>(
 						ServiceTaskExecutor.VT_EXECUTOR, this, inOpQueue, childOpQueue, stepId, batchSize,
-						dispatchLock, dispatchReady);
+						dispatchLock, dispatchReady, inQueueLimit);
 	}
 
 	@Override
@@ -198,6 +200,7 @@ public abstract class CoopStorageDriverBase<I extends Item, O extends Operation<
 	void releaseMpuObjectPermit() {
 		if (mpuObjectThrottle != null) {
 			mpuObjectThrottle.release();
+			signalDispatch();
 		}
 	}
 
@@ -216,6 +219,7 @@ public abstract class CoopStorageDriverBase<I extends Item, O extends Operation<
 					parentOp.put("permitReleased", "true");
 					if (mpuObjectThrottle != null) {
 						mpuObjectThrottle.release();
+						signalDispatch();
 					}
 				}
 			}

--- a/engine/extensions/storage-drivers/primitives/coop/src/main/java/com/dell/spt/storage/driver/coop/OperationDispatchTask.java
+++ b/engine/extensions/storage-drivers/primitives/coop/src/main/java/com/dell/spt/storage/driver/coop/OperationDispatchTask.java
@@ -105,7 +105,7 @@ public final class OperationDispatchTask<I extends Item, O extends Operation<I>>
 						boolean childEmpty = childOpQueue.isEmpty();
 						boolean inEmpty = inOpQueue.isEmpty();
 						boolean canDrainIn = deferredMpuQueue.size() < deferredQueueCapacity;
-						
+
 						if (childEmpty && (inEmpty || !canDrainIn)) {
 							if (!storageDriver.tryAcquireMpuObjectPermit()) {
 								dispatchReady.await();

--- a/engine/extensions/storage-drivers/primitives/coop/src/main/java/com/dell/spt/storage/driver/coop/OperationDispatchTask.java
+++ b/engine/extensions/storage-drivers/primitives/coop/src/main/java/com/dell/spt/storage/driver/coop/OperationDispatchTask.java
@@ -36,13 +36,14 @@ public final class OperationDispatchTask<I extends Item, O extends Operation<I>>
 	private final CircularBuffer<O> buff;
 	private final Lock dispatchLock;
 	private final Condition dispatchReady;
+	private final int deferredQueueCapacity;
 
-	private final Queue<O> deferredMpuQueue = new java.util.ArrayDeque<>();
+	private final Queue<O> deferredMpuQueue;
 
 	public OperationDispatchTask(
 					final VirtualThreadExecutor executor, final CoopStorageDriverBase<I, O> storageDriver,
 					final BlockingQueue<O> inOpQueue, final BlockingQueue<O> childOpQueue, final String stepId,
-					final int batchSize, final Lock dispatchLock, final Condition dispatchReady) {
+					final int batchSize, final Lock dispatchLock, final Condition dispatchReady, final int deferredQueueCapacity) {
 		super(executor);
 		this.buff = new CircularArrayBuffer<>(batchSize);
 		this.storageDriver = storageDriver;
@@ -52,6 +53,8 @@ public final class OperationDispatchTask<I extends Item, O extends Operation<I>>
 		this.batchSize = batchSize;
 		this.dispatchLock = dispatchLock;
 		this.dispatchReady = dispatchReady;
+		this.deferredQueueCapacity = deferredQueueCapacity;
+		this.deferredMpuQueue = new java.util.ArrayDeque<>(deferredQueueCapacity);
 	}
 
 	@Override
@@ -75,7 +78,7 @@ public final class OperationDispatchTask<I extends Item, O extends Operation<I>>
 			// Then drain incoming ops
 			final java.util.List<O> tempInOps = new java.util.ArrayList<>(batchSize);
 			if (buff.size() == 0) {
-				inOpQueue.drainTo(tempInOps, batchSize);
+				inOpQueue.drainTo(tempInOps, Math.max(0, Math.min(batchSize, deferredQueueCapacity - deferredMpuQueue.size())));
 				if (tempInOps.isEmpty() && deferredMpuQueue.isEmpty()) {
 					dispatchLock.lock();
 					try {
@@ -93,11 +96,38 @@ public final class OperationDispatchTask<I extends Item, O extends Operation<I>>
 						childOpQueue.drainTo(buff, batchSize - buff.size());
 					}
 					if (buff.size() < batchSize) {
-						inOpQueue.drainTo(tempInOps, batchSize - buff.size());
+						inOpQueue.drainTo(tempInOps, Math.max(0, Math.min(batchSize - buff.size(), deferredQueueCapacity - deferredMpuQueue.size())));
+					}
+				} else if (tempInOps.isEmpty() && !deferredMpuQueue.isEmpty()) {
+					// We might have no actionable work (MPU permits are exhausted, or deferred queue is full and inOpQueue is blocked).
+					dispatchLock.lock();
+					try {
+						boolean childEmpty = childOpQueue.isEmpty();
+						boolean inEmpty = inOpQueue.isEmpty();
+						boolean canDrainIn = deferredMpuQueue.size() < deferredQueueCapacity;
+						
+						if (childEmpty && (inEmpty || !canDrainIn)) {
+							if (!storageDriver.tryAcquireMpuObjectPermit()) {
+								dispatchReady.await();
+							} else {
+								// We acquired a permit just now, we can process a deferred op
+								if (buff.size() < batchSize && !deferredMpuQueue.isEmpty()) {
+									buff.add(deferredMpuQueue.poll());
+								}
+							}
+						}
+					} finally {
+						dispatchLock.unlock();
+					}
+					if (buff.size() < batchSize) {
+						childOpQueue.drainTo(buff, batchSize - buff.size());
+					}
+					if (buff.size() < batchSize) {
+						inOpQueue.drainTo(tempInOps, Math.max(0, Math.min(batchSize - buff.size(), deferredQueueCapacity - deferredMpuQueue.size())));
 					}
 				}
 			} else if (buff.size() < batchSize) {
-				inOpQueue.drainTo(tempInOps, batchSize - buff.size());
+				inOpQueue.drainTo(tempInOps, Math.max(0, Math.min(batchSize - buff.size(), deferredQueueCapacity - deferredMpuQueue.size())));
 			}
 
 			// Process new incoming ops to respect MPU object limits

--- a/engine/extensions/storage-drivers/primitives/coop/src/test/java/com/dell/spt/storage/driver/coop/CoopStorageDriverBaseTest.java
+++ b/engine/extensions/storage-drivers/primitives/coop/src/test/java/com/dell/spt/storage/driver/coop/CoopStorageDriverBaseTest.java
@@ -18,9 +18,11 @@ import com.dell.spt.storage.driver.coop.mock.CoopStorageDriverMock;
 import com.github.akurilov.commons.io.Output;
 import com.github.akurilov.commons.system.SizeInBytes;
 import com.github.akurilov.confuse.Config;
+import com.github.akurilov.confuse.exceptions.InvalidValuePathException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CountDownLatch;
@@ -84,6 +86,15 @@ class CoopStorageDriverBaseTest {
 	private static Config storageConfigWithMalformedMultipartLimit(final RuntimeException parseException) {
 		final var storageConfig = storageConfigForMultipartLimits(0, 0);
 		when(storageConfig.intVal("driver-limit-multipart-objects")).thenThrow(parseException);
+		return storageConfig;
+	}
+
+	private static Config storageConfigWithMissingMultipartLimits() {
+		final var storageConfig = storageConfigForMultipartLimits(0, 0);
+		when(storageConfig.intVal("driver-limit-multipart-objects"))
+						.thenThrow(new NoSuchElementException("driver-limit-multipart-objects"));
+		when(storageConfig.intVal("driver-limit-multipart-parts"))
+						.thenThrow(new InvalidValuePathException("driver-limit-multipart-parts"));
 		return storageConfig;
 	}
 
@@ -184,6 +195,47 @@ class CoopStorageDriverBaseTest {
 							.filter(msg -> msg.contains("Failed to parse multipart limits"))
 							.count();
 			assertEquals(0, parseWarnCount, "valid multipart limits should not produce parse warnings");
+		} finally {
+			try {
+				if (driver != null) {
+					driver.close();
+				} else {
+					dataInput.close();
+				}
+			} finally {
+				logger.removeAppender(appender);
+				logger.setLevel(originalLevel);
+				appender.stop();
+			}
+		}
+	}
+
+	@Test
+	void missingMultipartLimitsDoNotEmitParseWarnings() throws Exception {
+		final var storageConfig = storageConfigWithMissingMultipartLimits();
+		final var appender = new CapturingAppender();
+		appender.start();
+
+		final var loggerCtx = LoggerContext.getContext(false);
+		final var logger = loggerCtx.getLogger(Loggers.ERR.getName());
+		final var originalLevel = logger.getLevel();
+		logger.addAppender(appender);
+		logger.setLevel(Level.WARN);
+
+		final var dataInput = DataInput.instance(null, "7a42d9c483244167", new SizeInBytes("64KB"), 4, false, 0.0, true);
+		CoopStorageDriverMock<Item, Operation<Item>> driver = null;
+		try {
+			driver = new CoopStorageDriverMock<>("parse-missing-step", dataInput, storageConfig, false, 16);
+
+			assertNull(mpuObjectThrottleOf(driver), "missing multipart object limit should keep MPU objects unlimited");
+			assertEquals(0, mpuMaxPartsOf(driver), "missing multipart part limit should keep MPU parts unlimited");
+
+			final var parseWarnCount = appender.events().stream()
+							.filter(e -> Level.WARN.equals(e.getLevel()))
+							.map(e -> e.getMessage().getFormattedMessage())
+							.filter(msg -> msg.contains("Failed to parse multipart limits"))
+							.count();
+			assertEquals(0, parseWarnCount, "missing optional multipart limits should not emit parse warnings");
 		} finally {
 			try {
 				if (driver != null) {
@@ -866,7 +918,8 @@ class CoopStorageDriverBaseTest {
 
 		final var waiterReady = new CountDownLatch(1);
 		final var waiterDone = new CountDownLatch(1);
-		final boolean[] awakened = {false};
+		final boolean[] awakened = {false
+		};
 
 		Thread.ofVirtual().start(() -> {
 			lock.lock();

--- a/engine/extensions/storage-drivers/primitives/coop/src/test/java/com/dell/spt/storage/driver/coop/CoopStorageDriverBaseTest.java
+++ b/engine/extensions/storage-drivers/primitives/coop/src/test/java/com/dell/spt/storage/driver/coop/CoopStorageDriverBaseTest.java
@@ -12,9 +12,15 @@ import com.dell.spt.base.item.op.Operation;
 import com.dell.spt.base.item.op.composite.data.CompositeDataOperationImpl;
 import com.dell.spt.base.item.op.partial.PartialOperation;
 import com.dell.spt.base.item.op.partial.data.PartialDataOperationImpl;
+import com.dell.spt.base.logging.Loggers;
 import com.dell.spt.base.storage.driver.StorageDriverBase;
+import com.dell.spt.storage.driver.coop.mock.CoopStorageDriverMock;
 import com.github.akurilov.commons.io.Output;
 import com.github.akurilov.commons.system.SizeInBytes;
+import com.github.akurilov.confuse.Config;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CountDownLatch;
@@ -23,6 +29,11 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.LongAdder;
 import java.util.concurrent.locks.ReentrantLock;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.config.Property;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -30,6 +41,163 @@ import org.junit.jupiter.api.Test;
  */
 @SuppressWarnings("unchecked")
 class CoopStorageDriverBaseTest {
+
+	private static class CapturingAppender extends AbstractAppender {
+		private final List<LogEvent> events = Collections.synchronizedList(new ArrayList<>());
+
+		CapturingAppender() {
+			super("coop-driver-base-test-capture", null, null, true, Property.EMPTY_ARRAY);
+		}
+
+		@Override
+		public void append(final LogEvent event) {
+			events.add(event.toImmutable());
+		}
+
+		List<LogEvent> events() {
+			return List.copyOf(events);
+		}
+	}
+
+	private static Config storageConfigForMultipartLimits(final int mpuObjectLimit, final int mpuPartLimit) {
+		final var storageConfig = mock(Config.class);
+		final var driverConfig = mock(Config.class);
+		final var limitConfig = mock(Config.class);
+		final var authConfig = mock(Config.class);
+
+		when(storageConfig.configVal("driver")).thenReturn(driverConfig);
+		when(driverConfig.configVal("limit")).thenReturn(limitConfig);
+		when(storageConfig.stringVal("namespace")).thenReturn("test-ns");
+		when(storageConfig.configVal("auth")).thenReturn(authConfig);
+		when(authConfig.stringVal("uid")).thenReturn("user");
+		when(authConfig.stringVal("secret")).thenReturn("secret");
+		when(authConfig.stringVal("token")).thenReturn(null);
+		when(limitConfig.intVal("concurrency")).thenReturn(4);
+		when(driverConfig.intVal("threads")).thenReturn(0);
+		when(storageConfig.intVal("driver-limit-queue-input")).thenReturn(16);
+		when(storageConfig.intVal("driver-limit-multipart-objects")).thenReturn(mpuObjectLimit);
+		when(storageConfig.intVal("driver-limit-multipart-parts")).thenReturn(mpuPartLimit);
+
+		return storageConfig;
+	}
+
+	private static Config storageConfigWithMalformedMultipartLimit(final RuntimeException parseException) {
+		final var storageConfig = storageConfigForMultipartLimits(0, 0);
+		when(storageConfig.intVal("driver-limit-multipart-objects")).thenThrow(parseException);
+		return storageConfig;
+	}
+
+	private static Semaphore mpuObjectThrottleOf(final CoopStorageDriverBase<Item, Operation<Item>> driver) throws Exception {
+		final var field = CoopStorageDriverBase.class.getDeclaredField("mpuObjectThrottle");
+		field.setAccessible(true);
+		return (Semaphore) field.get(driver);
+	}
+
+	private static int mpuMaxPartsOf(final CoopStorageDriverBase<Item, Operation<Item>> driver) throws Exception {
+		final var field = CoopStorageDriverBase.class.getDeclaredField("mpuMaxParts");
+		field.setAccessible(true);
+		return field.getInt(driver);
+	}
+
+	private static void awaitCapturedEvents(
+					final CapturingAppender appender, final int minCount, final long timeoutMillis)
+					throws InterruptedException {
+		final long deadlineNanos = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(timeoutMillis);
+		while (appender.events().size() < minCount && System.nanoTime() < deadlineNanos) {
+			Thread.sleep(10);
+		}
+	}
+
+	@Test
+	void malformedMultipartLimitLogsWarningAndFallsBackToUnlimited() throws Exception {
+		final var storageConfig = storageConfigWithMalformedMultipartLimit(
+						new IllegalArgumentException("For input string: \"oops\""));
+		final var appender = new CapturingAppender();
+		appender.start();
+
+		final var loggerCtx = LoggerContext.getContext(false);
+		final var logger = loggerCtx.getLogger(Loggers.ERR.getName());
+		final var originalLevel = logger.getLevel();
+		logger.addAppender(appender);
+		logger.setLevel(Level.WARN);
+
+		final var dataInput = DataInput.instance(null, "7a42d9c483244167", new SizeInBytes("64KB"), 4, false, 0.0, true);
+		CoopStorageDriverMock<Item, Operation<Item>> driver = null;
+		try {
+			driver = new CoopStorageDriverMock<>("parse-warn-step", dataInput, storageConfig, false, 16);
+
+			assertNull(mpuObjectThrottleOf(driver), "malformed multipart limits should fall back to unlimited MPU objects");
+			assertEquals(0, mpuMaxPartsOf(driver), "malformed multipart limits should fall back to unlimited MPU parts");
+			awaitCapturedEvents(appender, 1, 2000);
+
+			final var parseWarnEvents = appender.events().stream()
+							.filter(e -> Level.WARN.equals(e.getLevel()))
+							.map(e -> e.getMessage().getFormattedMessage())
+							.filter(msg -> msg.contains("Failed to parse multipart limits"))
+							.toList();
+			assertEquals(1, parseWarnEvents.size(), "exactly one multipart parse warning should be logged");
+			assertTrue(parseWarnEvents.get(0).contains("For input string: \"oops\""),
+							"warning should include parse failure details");
+			assertTrue(parseWarnEvents.get(0).contains("Proceeding with unlimited"),
+							"warning should indicate fallback behavior");
+		} finally {
+			try {
+				if (driver != null) {
+					driver.close();
+				} else {
+					dataInput.close();
+				}
+			} finally {
+				logger.removeAppender(appender);
+				logger.setLevel(originalLevel);
+				appender.stop();
+			}
+		}
+	}
+
+	@Test
+	void validMultipartLimitsConfigureThrottleWithoutParseWarning() throws Exception {
+		final var storageConfig = storageConfigForMultipartLimits(3, 9);
+		final var appender = new CapturingAppender();
+		appender.start();
+
+		final var loggerCtx = LoggerContext.getContext(false);
+		final var logger = loggerCtx.getLogger(Loggers.ERR.getName());
+		final var originalLevel = logger.getLevel();
+		logger.addAppender(appender);
+		logger.setLevel(Level.WARN);
+
+		final var dataInput = DataInput.instance(null, "7a42d9c483244167", new SizeInBytes("64KB"), 4, false, 0.0, true);
+		CoopStorageDriverMock<Item, Operation<Item>> driver = null;
+		try {
+			driver = new CoopStorageDriverMock<>("parse-ok-step", dataInput, storageConfig, false, 16);
+
+			final var mpuThrottle = mpuObjectThrottleOf(driver);
+			assertNotNull(mpuThrottle, "valid multipart object limit should create MPU throttle");
+			assertEquals(3, mpuThrottle.availablePermits(),
+							"MPU throttle permits should match configured multipart object limit");
+			assertEquals(9, mpuMaxPartsOf(driver), "multipart part limit should match configured value");
+
+			final var parseWarnCount = appender.events().stream()
+							.filter(e -> Level.WARN.equals(e.getLevel()))
+							.map(e -> e.getMessage().getFormattedMessage())
+							.filter(msg -> msg.contains("Failed to parse multipart limits"))
+							.count();
+			assertEquals(0, parseWarnCount, "valid multipart limits should not produce parse warnings");
+		} finally {
+			try {
+				if (driver != null) {
+					driver.close();
+				} else {
+					dataInput.close();
+				}
+			} finally {
+				logger.removeAppender(appender);
+				logger.setLevel(originalLevel);
+				appender.stop();
+			}
+		}
+	}
 
 	@Test
 	void scheduledAndCompletedCountersAreIndependent() throws Exception {
@@ -676,5 +844,47 @@ class CoopStorageDriverBaseTest {
 
 		assertFalse(result, "handleCompleted should return false on overflow");
 		assertEquals(1, mpuThrottle.availablePermits(), "MPU object permit should be safely released on parent enqueue overflow");
+	}
+
+	@Test
+	void releaseMpuObjectPermitSignalsDispatchWaiter() throws Exception {
+		final var driver = newRetryTestDriver();
+
+		final Semaphore mpuThrottle = new Semaphore(1, true);
+		mpuThrottle.acquire(); // force available permits to 0 before release
+		final var mpuField = CoopStorageDriverBase.class.getDeclaredField("mpuObjectThrottle");
+		mpuField.setAccessible(true);
+		mpuField.set(driver, mpuThrottle);
+
+		final var lockField = CoopStorageDriverBase.class.getDeclaredField("dispatchLock");
+		lockField.setAccessible(true);
+		final ReentrantLock lock = (ReentrantLock) lockField.get(driver);
+
+		final var condField = CoopStorageDriverBase.class.getDeclaredField("dispatchReady");
+		condField.setAccessible(true);
+		final var condition = (java.util.concurrent.locks.Condition) condField.get(driver);
+
+		final var waiterReady = new CountDownLatch(1);
+		final var waiterDone = new CountDownLatch(1);
+		final boolean[] awakened = {false};
+
+		Thread.ofVirtual().start(() -> {
+			lock.lock();
+			try {
+				waiterReady.countDown();
+				awakened[0] = condition.await(2, TimeUnit.SECONDS);
+			} catch (final InterruptedException ignored) {} finally {
+				lock.unlock();
+				waiterDone.countDown();
+			}
+		});
+
+		assertTrue(waiterReady.await(5, TimeUnit.SECONDS), "waiter should be parked on dispatch condition");
+
+		driver.releaseMpuObjectPermit();
+
+		assertTrue(waiterDone.await(5, TimeUnit.SECONDS), "waiter should complete after permit release signal");
+		assertTrue(awakened[0], "permit release should signal the dispatch condition");
+		assertEquals(1, mpuThrottle.availablePermits(), "permit release should return one permit");
 	}
 }

--- a/engine/extensions/storage-drivers/primitives/coop/src/test/java/com/dell/spt/storage/driver/coop/OperationDispatchTaskTest.java
+++ b/engine/extensions/storage-drivers/primitives/coop/src/test/java/com/dell/spt/storage/driver/coop/OperationDispatchTaskTest.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.ReentrantLock;
 import org.junit.jupiter.api.AfterEach;
@@ -42,13 +43,40 @@ class OperationDispatchTaskTest {
 		dispatchReady = dispatchLock.newCondition();
 		task = new OperationDispatchTask<>(
 						executor, driverMock, inOpQueue, childOpQueue, STEP_ID, BATCH_SIZE,
-						dispatchLock, dispatchReady);
+						dispatchLock, dispatchReady, 16);
 	}
 
 	@AfterEach
 	void tearDown() {
 		task.close();
 		executor.close();
+	}
+
+	private void configurePermitGate(final AtomicInteger availableMpuPermits) {
+		when(driverMock.tryAcquireMpuObjectPermit()).thenAnswer(inv -> {
+			final int permits = availableMpuPermits.get();
+			if (permits > 0) {
+				availableMpuPermits.decrementAndGet();
+				return true;
+			}
+			return false;
+		});
+	}
+
+	private void captureSubmittedOps(final List<Operation<Item>> submitted) {
+		when(driverMock.submit(any(Operation.class))).thenAnswer(inv -> {
+			submitted.add(inv.getArgument(0));
+			return true;
+		});
+		when(driverMock.submit(anyList(), anyInt(), anyInt())).thenAnswer(inv -> {
+			final List<Operation<Item>> buff = inv.getArgument(0);
+			final int from = inv.getArgument(1);
+			final int to = inv.getArgument(2);
+			for (int i = from; i < to; i++) {
+				submitted.add(buff.get(i));
+			}
+			return to - from;
+		});
 	}
 
 	@Test
@@ -272,5 +300,189 @@ class OperationDispatchTaskTest {
 
 		task.stop();
 		assertTrue(task.await(5, TimeUnit.SECONDS), "task should stop within timeout");
+	}
+
+	@Test
+	void deferredMpuQueueCapacityPreservesInputBackpressure() throws Exception {
+		task = new OperationDispatchTask<>(
+						executor, driverMock, inOpQueue, childOpQueue, STEP_ID, BATCH_SIZE,
+						dispatchLock, dispatchReady, 2);
+		final Operation<Item> op1 = mock(Operation.class);
+		final Operation<Item> op2 = mock(Operation.class);
+		final Operation<Item> op3 = mock(Operation.class);
+		final Operation<Item> op4 = mock(Operation.class);
+		final Operation<Item> op5 = mock(Operation.class);
+		when(driverMock.isMpuInit(any(Operation.class))).thenReturn(true);
+		when(driverMock.tryAcquireMpuObjectPermit()).thenReturn(false);
+
+		inOpQueue.add(op1);
+		inOpQueue.add(op2);
+		inOpQueue.add(op3);
+		inOpQueue.add(op4);
+		inOpQueue.add(op5);
+		task.doWork();
+
+		assertEquals(3, inOpQueue.size(), "dispatcher should stop draining input once deferred MPU queue reaches capacity");
+		verify(driverMock, never()).submit(any(Operation.class));
+		verify(driverMock, never()).submit(anyList(), anyInt(), anyInt());
+	}
+
+	@Test
+	void deferredMpuOnlyWorkAwaitsWhenPermitsUnavailable() throws Exception {
+		final Operation<Item> mpuOp = mock(Operation.class);
+		when(driverMock.isMpuInit(any(Operation.class))).thenReturn(true);
+		when(driverMock.tryAcquireMpuObjectPermit()).thenReturn(false);
+
+		inOpQueue.add(mpuOp);
+		task.doWork();
+		assertTrue(inOpQueue.isEmpty(), "precondition: MPU init op should be deferred");
+
+		final var worker = Thread.ofVirtual().start(() -> {
+			try {
+				task.doWork();
+			} catch (Exception e) {
+				throw new RuntimeException(e);
+			}
+		});
+		Thread.sleep(50);
+		assertTrue(worker.isAlive(), "dispatcher should await when only deferred MPU ops exist and no permits are available");
+
+		dispatchLock.lock();
+		try {
+			dispatchReady.signal();
+		} finally {
+			dispatchLock.unlock();
+		}
+		worker.join(5000);
+		assertFalse(worker.isAlive(), "dispatcher should wake and finish iteration after signal");
+	}
+
+	@Test
+	void deferredQueueFullAndInputPendingAwaitsWithoutPermits() throws Exception {
+		task = new OperationDispatchTask<>(
+						executor, driverMock, inOpQueue, childOpQueue, STEP_ID, BATCH_SIZE,
+						dispatchLock, dispatchReady, 2);
+		final Operation<Item> op1 = mock(Operation.class);
+		final Operation<Item> op2 = mock(Operation.class);
+		final Operation<Item> op3 = mock(Operation.class);
+		when(driverMock.isMpuInit(any(Operation.class))).thenReturn(true);
+		when(driverMock.tryAcquireMpuObjectPermit()).thenReturn(false);
+
+		inOpQueue.add(op1);
+		inOpQueue.add(op2);
+		inOpQueue.add(op3);
+		task.doWork();
+		assertEquals(1, inOpQueue.size(), "precondition: one input op should remain when deferred queue is full");
+
+		final var worker = Thread.ofVirtual().start(() -> {
+			try {
+				task.doWork();
+			} catch (Exception e) {
+				throw new RuntimeException(e);
+			}
+		});
+		Thread.sleep(50);
+		assertTrue(worker.isAlive(), "dispatcher should await when deferred queue is full and MPU permits are unavailable");
+		assertEquals(1, inOpQueue.size(), "input queue should not be drained while deferred queue is full");
+
+		dispatchLock.lock();
+		try {
+			dispatchReady.signal();
+		} finally {
+			dispatchLock.unlock();
+		}
+		worker.join(5000);
+		assertFalse(worker.isAlive(), "dispatcher should wake and finish iteration after signal");
+	}
+
+	@Test
+	void deferredQueueFullResumesWithoutDroppingMpuOpsInFifoOrder() throws Exception {
+		task = new OperationDispatchTask<>(
+						executor, driverMock, inOpQueue, childOpQueue, STEP_ID, BATCH_SIZE,
+						dispatchLock, dispatchReady, 2);
+		final Operation<Item> op1 = mock(Operation.class);
+		final Operation<Item> op2 = mock(Operation.class);
+		final Operation<Item> op3 = mock(Operation.class);
+		final List<Operation<Item>> submitted = new ArrayList<>();
+		final AtomicInteger availableMpuPermits = new AtomicInteger(0);
+
+		when(driverMock.isMpuInit(any(Operation.class))).thenReturn(true);
+		configurePermitGate(availableMpuPermits);
+		captureSubmittedOps(submitted);
+
+		inOpQueue.add(op1);
+		inOpQueue.add(op2);
+		inOpQueue.add(op3);
+
+		task.doWork();
+		assertEquals(1, inOpQueue.size(), "input queue should preserve backpressure while deferred MPU queue is full");
+		assertTrue(submitted.isEmpty(), "no MPU op should be dispatched without permits");
+
+		availableMpuPermits.set(1);
+		task.doWork();
+		assertEquals(1, submitted.size(), "one permit should resume exactly one deferred MPU op");
+		assertSame(op1, submitted.get(0), "deferred MPU ops should resume in FIFO order");
+		assertTrue(inOpQueue.isEmpty(), "pending input should move only when deferred queue capacity reopens");
+
+		availableMpuPermits.set(1);
+		task.doWork();
+		assertEquals(2, submitted.size(), "second permit should dispatch the second deferred MPU op");
+		assertSame(op2, submitted.get(1), "second dispatched op should preserve FIFO order");
+
+		availableMpuPermits.set(1);
+		task.doWork();
+		assertEquals(3, submitted.size(), "third permit should dispatch the last preserved MPU op");
+		assertSame(op3, submitted.get(2), "all deferred/pending MPU ops should eventually dispatch without loss");
+	}
+
+	@Test
+	void deferredQueueFullPausesIntakeUntilPermitThenResumesMpuAndNonMpu() throws Exception {
+		task = new OperationDispatchTask<>(
+						executor, driverMock, inOpQueue, childOpQueue, STEP_ID, BATCH_SIZE,
+						dispatchLock, dispatchReady, 1);
+		final Operation<Item> mpuOp = mock(Operation.class);
+		final Operation<Item> simpleOp = mock(Operation.class);
+		final List<Operation<Item>> submitted = new ArrayList<>();
+		final AtomicInteger availableMpuPermits = new AtomicInteger(0);
+
+		when(driverMock.isMpuInit(any(Operation.class))).thenAnswer(inv -> inv.getArgument(0) == mpuOp);
+		configurePermitGate(availableMpuPermits);
+		captureSubmittedOps(submitted);
+
+		inOpQueue.add(mpuOp);
+		inOpQueue.add(simpleOp);
+
+		task.doWork();
+		assertEquals(1, inOpQueue.size(), "non-MPU input should remain queued while deferred MPU queue is full");
+		assertTrue(submitted.isEmpty(), "dispatcher should not submit work without MPU permits");
+
+		final var worker = Thread.ofVirtual().start(() -> {
+			try {
+				task.doWork();
+			} catch (Exception e) {
+				throw new RuntimeException(e);
+			}
+		});
+		Thread.sleep(50);
+		assertTrue(worker.isAlive(), "dispatcher should await when deferred MPU queue is full and permits are unavailable");
+		assertEquals(1, inOpQueue.size(), "input queue should remain paused while awaiting permits");
+
+		dispatchLock.lock();
+		try {
+			dispatchReady.signal();
+		} finally {
+			dispatchLock.unlock();
+		}
+		worker.join(5000);
+		assertFalse(worker.isAlive(), "dispatcher should wake and finish iteration after signal");
+		assertEquals(1, inOpQueue.size(), "signal without permits should not drain paused input");
+		assertTrue(submitted.isEmpty(), "signal without permits should not dispatch queued ops");
+
+		availableMpuPermits.set(1);
+		task.doWork();
+		assertTrue(inOpQueue.isEmpty(), "paused input should resume once deferred MPU capacity opens");
+		assertEquals(2, submitted.size(), "resume should dispatch both the deferred MPU op and queued non-MPU op");
+		assertSame(mpuOp, submitted.get(0), "deferred MPU op should dispatch first on resume");
+		assertSame(simpleOp, submitted.get(1), "queued non-MPU op should dispatch immediately after resume");
 	}
 }


### PR DESCRIPTION
## Summary
- bound deferred MPU intake in `OperationDispatchTask` using a dedicated deferred-queue capacity tied to input queue limits
- add a no-actionable-work await path when deferred MPU operations exist but permits are unavailable (or deferred queue is full), preventing busy-spin while preserving strict backpressure
- signal dispatch waiters when MPU object permits are released so deferred work resumes promptly
- log multipart-limit parse failures in `CoopStorageDriverBase` instead of silently falling back to unlimited behavior
- add behavior-focused tests for dispatcher backpressure/pause-resume semantics and multipart-limit warning/fallback behavior

