### PR TITLE
Fix mixed mode concurrency accounting and Prometheus collector collisions

### DIFF
--- a/engine/core/spt-base/src/main/java/com/dell/spt/base/load/step/local/LoadStepLocalBase.java
+++ b/engine/core/spt-base/src/main/java/com/dell/spt/base/load/step/local/LoadStepLocalBase.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
+import java.util.function.IntSupplier;
 import org.apache.logging.log4j.Level;
 
 public abstract class LoadStepLocalBase extends LoadStepBase {
@@ -31,6 +32,10 @@ public abstract class LoadStepLocalBase extends LoadStepBase {
 	private static final long STEP_CONTEXT_POLL_NANOS = 10_000_000L; // 10ms
 
 	protected final List<LoadStepContext> stepContexts = new ArrayList<>();
+
+	protected IntSupplier actualConcurrencyGauge(final int index, final OpType opType) {
+		return () -> stepContexts.get(index).activeOpCount();
+	}
 
 	protected LoadStepLocalBase(
 					final Config baseConfig,
@@ -76,7 +81,7 @@ public abstract class LoadStepLocalBase extends LoadStepBase {
 		final var metricsCtx = MetricsContextImpl.builder()
 						.loadStepId(loadStepId())
 						.opType(opType)
-						.actualConcurrencyGauge(() -> stepContexts.get(index).activeOpCount())
+						.actualConcurrencyGauge(actualConcurrencyGauge(index, opType))
 						.concurrencyLimit(concurrency)
 						.concurrencyThreshold((int) (concurrency * metricsConfig.doubleVal("threshold")))
 						.itemDataSize(itemDataSize)

--- a/engine/core/spt-base/src/main/java/com/dell/spt/base/metrics/util/PrometheusMetricsExporterImpl.java
+++ b/engine/core/spt-base/src/main/java/com/dell/spt/base/metrics/util/PrometheusMetricsExporterImpl.java
@@ -17,14 +17,17 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
 
 /** Prometheus collector that exports SPT distributed metrics snapshots. */
 public class PrometheusMetricsExporterImpl extends Collector implements PrometheusMetricsExporter {
 
+	private static final AtomicLong COLLECTOR_IDS = new AtomicLong(0);
 	private final List<String> labelValues = new ArrayList<>();
 	private final List<String> labelNames = new ArrayList<>();
 	private final DistributedMetricsContext metricsContext;
 	private final List<Double> quantileValues = new ArrayList<>();
+	private final long collectorId = COLLECTOR_IDS.incrementAndGet();
 	private String help = "";
 
 	public PrometheusMetricsExporterImpl(final DistributedMetricsContext context) {
@@ -117,7 +120,7 @@ public class PrometheusMetricsExporterImpl extends Collector implements Promethe
 		final double timeSeconds = (double) timeMillis / Constants.K;
 		mfsList.add(
 						new MetricFamilySamples(
-										String.format(METRIC_FORMAT, METRIC_NAME_TIME + System.currentTimeMillis()),
+										metricFamilyName(METRIC_NAME_TIME),
 										Type.GAUGE,
 										help,
 										Collections.singletonList(
@@ -158,8 +161,7 @@ public class PrometheusMetricsExporterImpl extends Collector implements Promethe
 
 		mfsList.add(
 						new MetricFamilySamples(
-										String.format(MetricsConstants.METRIC_FORMAT,
-														MetricsConstants.METRIC_NAME_COMPLETION + System.currentTimeMillis()),
+										metricFamilyName(MetricsConstants.METRIC_NAME_COMPLETION),
 										Type.GAUGE,
 										help,
 										Collections.singletonList(
@@ -194,7 +196,7 @@ public class PrometheusMetricsExporterImpl extends Collector implements Promethe
 
 		mfsList.add(
 						new MetricFamilySamples(
-										String.format(METRIC_FORMAT, METRIC_NAME_TEST_STATE + System.currentTimeMillis()),
+										metricFamilyName(METRIC_NAME_TEST_STATE),
 										Type.GAUGE,
 										help,
 										Collections.singletonList(
@@ -213,7 +215,7 @@ public class PrometheusMetricsExporterImpl extends Collector implements Promethe
 		} else {
 			Loggers.ERR.warn("Unexpected metric snapshot type: {}", snapshot.getClass());
 		}
-		final MetricFamilySamples mfs = new MetricFamilySamples(String.format(METRIC_FORMAT, snapshot.name() + snapshot.hashCode()), Type.GAUGE, help, samples);
+		final MetricFamilySamples mfs = new MetricFamilySamples(metricFamilyName(snapshot.name()), Type.GAUGE, help, samples);
 		mfsList.add(mfs);
 	}
 
@@ -265,6 +267,10 @@ public class PrometheusMetricsExporterImpl extends Collector implements Promethe
 					final String metricName, final String aggregationType, final double value) {
 		return new Sample(
 						String.format(METRIC_FORMAT, metricName) + "_" + aggregationType, labelNames, labelValues, value);
+	}
+
+	private String metricFamilyName(final String metricName) {
+		return String.format(METRIC_FORMAT, metricName + collectorId);
 	}
 
 	private static Long toLong(final Object raw, final String key) {

--- a/engine/core/spt-base/src/test/java/com/dell/spt/base/metrics/util/PrometheusMetricsExporterImplTest.java
+++ b/engine/core/spt-base/src/test/java/com/dell/spt/base/metrics/util/PrometheusMetricsExporterImplTest.java
@@ -175,6 +175,34 @@ class PrometheusMetricsExporterImplTest {
 						"Malformed metadata should be ignored and completion should remain at default");
 	}
 
+	@Test
+	void metricFamilyNamesRemainStableAcrossCollectCalls() throws Exception {
+		setupMockSnapshot(10, 1, 1.0);
+		when(mockMetricsContext.lastSnapshot()).thenReturn(mockSnapshot);
+
+		List<MetricFamilySamples> first = exporter.collect();
+		Thread.sleep(2L);
+		List<MetricFamilySamples> second = exporter.collect();
+
+		MetricFamilySamples firstElapsed = findMetricByName(first, MetricsConstants.METRIC_NAME_TIME);
+		MetricFamilySamples secondElapsed = findMetricByName(second, MetricsConstants.METRIC_NAME_TIME);
+		assertNotNull(firstElapsed);
+		assertNotNull(secondElapsed);
+		assertEquals(firstElapsed.name, secondElapsed.name, "Elapsed metric family name should be stable");
+
+		MetricFamilySamples firstCompletion = findMetricByName(first, MetricsConstants.METRIC_NAME_COMPLETION);
+		MetricFamilySamples secondCompletion = findMetricByName(second, MetricsConstants.METRIC_NAME_COMPLETION);
+		assertNotNull(firstCompletion);
+		assertNotNull(secondCompletion);
+		assertEquals(firstCompletion.name, secondCompletion.name, "Completion metric family name should be stable");
+
+		MetricFamilySamples firstTestState = findMetricByName(first, MetricsConstants.METRIC_NAME_TEST_STATE);
+		MetricFamilySamples secondTestState = findMetricByName(second, MetricsConstants.METRIC_NAME_TEST_STATE);
+		assertNotNull(firstTestState);
+		assertNotNull(secondTestState);
+		assertEquals(firstTestState.name, secondTestState.name, "Test-state metric family name should be stable");
+	}
+
 	private void setupMockSnapshot(long successCount, long failsCount, double concurrency) {
 		// Setup success snapshot
 		when(mockSuccessSnapshot.name()).thenReturn("spt_success");

--- a/engine/extensions/load-steps/mixed/src/main/java/com/dell/spt/load/step/mixed/MixedLoadGenerator.java
+++ b/engine/extensions/load-steps/mixed/src/main/java/com/dell/spt/load/step/mixed/MixedLoadGenerator.java
@@ -15,11 +15,13 @@ import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.ThreadContext;
 
 import java.io.IOException;
+import java.util.EnumMap;
 import java.util.Map;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.LongAdder;
 
 /**
@@ -50,9 +52,8 @@ public final class MixedLoadGenerator<I extends Item, O extends Operation<I>>
 	private final Map<OpType, OperationsBuilder<I, O>> builders;
 	private final Output<O> opOutput;
 	private final Input<I> newItemInput;
-	private final Output<O> putResultsOutput;
-	private final Output<O> operationsResultsOutput;
 	private final Semaphore concurrencyThrottle;
+	private final Map<OpType, AtomicInteger> inFlightByOpType;
 
 	private final Queue<O> recycleQueue = new ConcurrentLinkedQueue<>();
 	private final LongAdder generatedCount = new LongAdder();
@@ -60,6 +61,8 @@ public final class MixedLoadGenerator<I extends Item, O extends Operation<I>>
 
 	// Active op types excluding DELETE (for re-roll)
 	private final OpType[] rerollTargets;
+	private final int[] rerollCumulativeWeights;
+	private final int rerollTotalWeight;
 
 	/**
 	 * @param executor         VT executor for the generation task
@@ -69,8 +72,6 @@ public final class MixedLoadGenerator<I extends Item, O extends Operation<I>>
 	 * @param opOutput         driver to submit operations to
 	 * @param concurrencyLimit max in-flight operations (matches driver concurrency)
 	 * @param newItemInput     item source for CREATE operations (generates new items)
-	 * @param putResultsOutput optional output for successful PUT results (put-remaining.csv + queue feed)
-	 * @param operationsResultsOutput optional output for all operation results
 	 */
 	public MixedLoadGenerator(
 					final VirtualThreadExecutor executor,
@@ -79,9 +80,7 @@ public final class MixedLoadGenerator<I extends Item, O extends Operation<I>>
 					final Map<OpType, OperationsBuilder<I, O>> builders,
 					final Output<O> opOutput,
 					final int concurrencyLimit,
-					final Input<I> newItemInput,
-					final Output<O> putResultsOutput,
-					final Output<O> operationsResultsOutput) {
+					final Input<I> newItemInput) {
 		super(executor);
 		this.schedule = schedule;
 		this.pool = pool;
@@ -90,18 +89,25 @@ public final class MixedLoadGenerator<I extends Item, O extends Operation<I>>
 		this.concurrencyThrottle = new Semaphore(
 						concurrencyLimit > 0 ? concurrencyLimit : Integer.MAX_VALUE, true);
 		this.newItemInput = newItemInput;
-		this.putResultsOutput = putResultsOutput;
-		this.operationsResultsOutput = operationsResultsOutput;
+		this.inFlightByOpType = new EnumMap<>(OpType.class);
 
 		// Build the re-roll target list: all active ops except DELETE
 		final OpType[] active = schedule.activeOpTypes();
 		final java.util.List<OpType> targets = new java.util.ArrayList<>(active.length);
 		for (final OpType op : active) {
+			inFlightByOpType.put(op, new AtomicInteger());
 			if (op != OpType.DELETE) {
 				targets.add(op);
 			}
 		}
 		this.rerollTargets = targets.toArray(new OpType[0]);
+		this.rerollCumulativeWeights = new int[this.rerollTargets.length];
+		int cumulative = 0;
+		for (int i = 0; i < this.rerollTargets.length; i++) {
+			cumulative += schedule.weight(this.rerollTargets[i]);
+			this.rerollCumulativeWeights[i] = cumulative;
+		}
+		this.rerollTotalWeight = cumulative;
 	}
 
 	@Override
@@ -115,6 +121,7 @@ public final class MixedLoadGenerator<I extends Item, O extends Operation<I>>
 		// This prevents the generator from flooding the driver's input queue
 		// faster than the driver can process operations.
 		concurrencyThrottle.acquire();
+		boolean permitTransferred = false;
 
 		try {
 			OpType opType = schedule.next();
@@ -124,29 +131,28 @@ public final class MixedLoadGenerator<I extends Item, O extends Operation<I>>
 				final I deleteItem = pool.pollDelete();
 				if (deleteItem == null) {
 					opType = reroll();
-					dispatchNonDelete(opType);
+					permitTransferred = dispatchNonDelete(opType);
 				} else {
-					dispatchDelete(deleteItem);
+					permitTransferred = dispatchDelete(deleteItem);
 				}
 			} else {
-				dispatchNonDelete(opType);
+				permitTransferred = dispatchNonDelete(opType);
 			}
-		} catch (final Exception e) {
-			// Release permit on any error to avoid leaking
-			concurrencyThrottle.release();
-			throw e;
+		} finally {
+			if (!permitTransferred) {
+				concurrencyThrottle.release();
+			}
 		}
 	}
 
-	private void dispatchNonDelete(final OpType opType) throws IOException {
+	private boolean dispatchNonDelete(final OpType opType) throws IOException {
 		final I item;
 		if (opType == OpType.CREATE) {
 			item = newItemInput.get();
 			if (item == null) {
 				itemInputFinished = true;
-				concurrencyThrottle.release();
 				Thread.yield();
-				return;
+				return false;
 			}
 		} else {
 			// READ or STAT — random item from static pool
@@ -155,31 +161,45 @@ public final class MixedLoadGenerator<I extends Item, O extends Operation<I>>
 
 		final O op = builders.get(opType).buildOp(item);
 		if (!opOutput.put(op)) {
-			concurrencyThrottle.release();
 			Thread.yield();
-			return;
+			return false;
+		}
+		final AtomicInteger counter = inFlightByOpType.get(opType);
+		if (counter != null) {
+			counter.incrementAndGet();
 		}
 		generatedCount.increment();
+		return true;
 	}
 
-	private void dispatchDelete(final I item) throws IOException {
+	private boolean dispatchDelete(final I item) throws IOException {
 		final O op = builders.get(OpType.DELETE).buildOp(item);
 		if (!opOutput.put(op)) {
 			// Put item back if driver rejected — avoid item loss
 			pool.addDeleteItem(item);
-			concurrencyThrottle.release();
 			Thread.yield();
-			return;
+			return false;
+		}
+		final AtomicInteger counter = inFlightByOpType.get(OpType.DELETE);
+		if (counter != null) {
+			counter.incrementAndGet();
 		}
 		generatedCount.increment();
+		return true;
 	}
 
-	/** Re-roll DELETE to another active op type (uniform random among non-DELETE ops). */
+	/** Re-roll DELETE to another active op type (weighted by configured non-DELETE weights). */
 	private OpType reroll() {
 		if (rerollTargets.length == 1) {
 			return rerollTargets[0];
 		}
-		return rerollTargets[ThreadLocalRandom.current().nextInt(rerollTargets.length)];
+		final int draw = ThreadLocalRandom.current().nextInt(rerollTotalWeight);
+		for (int i = 0; i < rerollCumulativeWeights.length; i++) {
+			if (draw < rerollCumulativeWeights[i]) {
+				return rerollTargets[i];
+			}
+		}
+		return rerollTargets[rerollTargets.length - 1];
 	}
 
 	@Override
@@ -239,16 +259,18 @@ public final class MixedLoadGenerator<I extends Item, O extends Operation<I>>
 		concurrencyThrottle.release();
 	}
 
-	/**
-	 * Called by the step context when a PUT operation completes successfully.
-	 * Feeds the item into the delete queue and optionally writes to put-remaining.csv.
-	 */
-	public void handlePutCompletion(final O op) {
-		if (op.item() != null) {
-			pool.addDeleteItem(op.item());
+	public void onOperationCompleted(final O op) {
+		if (op == null) {
+			return;
 		}
-		if (putResultsOutput != null) {
-			putResultsOutput.put(op);
+		final AtomicInteger counter = inFlightByOpType.get(op.type());
+		if (counter != null) {
+			counter.getAndUpdate(v -> v > 0 ? v - 1 : 0);
 		}
+	}
+
+	public int inFlightCount(final OpType opType) {
+		final AtomicInteger counter = inFlightByOpType.get(opType);
+		return counter != null ? counter.get() : 0;
 	}
 }

--- a/engine/extensions/load-steps/mixed/src/main/java/com/dell/spt/load/step/mixed/MixedLoadStepLocal.java
+++ b/engine/extensions/load-steps/mixed/src/main/java/com/dell/spt/load/step/mixed/MixedLoadStepLocal.java
@@ -47,6 +47,7 @@ import java.util.EnumMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.function.IntSupplier;
 
 import static com.github.akurilov.commons.collection.TreeUtil.reduceForest;
 import static com.github.akurilov.commons.lang.Exceptions.throwUnchecked;
@@ -70,12 +71,25 @@ import static com.github.akurilov.confuse.Config.deepToMap;
 })
 public final class MixedLoadStepLocal extends LoadStepLocalBase {
 
+	private volatile MixedLoadGenerator mixedGenerator;
+
 	public MixedLoadStepLocal(
 					final Config baseConfig,
 					final List<Extension> extensions,
 					final List<Config> contextConfigs,
 					final MetricsManager metricsManager) {
 		super(baseConfig, extensions, contextConfigs, metricsManager);
+	}
+
+	@Override
+	protected IntSupplier actualConcurrencyGauge(final int index, final OpType opType) {
+		return () -> {
+			final MixedLoadGenerator generator = mixedGenerator;
+			if (generator != null) {
+				return generator.inFlightCount(opType);
+			}
+			return stepContexts.get(index).activeOpCount();
+		};
 	}
 
 	@Override
@@ -269,7 +283,25 @@ public final class MixedLoadStepLocal extends LoadStepLocalBase {
 			newItemInput = null;
 		}
 
-		// ── 11. Register metrics ───────────────────────────────────────────
+		// ── 11. Wire put-remaining.csv output for PUT completions ──────────
+		final ItemInfoFileOutput putRemainingFileOut;
+		if (putWeight > 0) {
+			try {
+				putRemainingFileOut = new ItemInfoFileOutput<>(putRemainingFilePath);
+			} catch (final IOException e) {
+				throw new IllegalStateException("Failed to open put-remaining.csv: " + putRemainingFilePath, e);
+			}
+		} else {
+			putRemainingFileOut = null;
+		}
+
+		// ── 12. Create MixedLoadGenerator ──────────────────────────────────
+		final MixedLoadGenerator generator = new MixedLoadGenerator(
+						ServiceTaskExecutor.VT_EXECUTOR, schedule, pool, builders,
+						driver, concurrencyLimit, newItemInput);
+		this.mixedGenerator = generator;
+
+		// ── 13. Register metrics ───────────────────────────────────────────
 		originIdx = 0;
 		if (getWeight > 0)
 			initMetrics(originIdx++, OpType.READ, concurrencyLimit, metricsConfig, itemDataSize, colorFlag);
@@ -292,73 +324,6 @@ public final class MixedLoadStepLocal extends LoadStepLocalBase {
 		if (statWeight > 0)
 			metricsCtxByOpType.put(OpType.STAT, metricsContexts.get(originIdx++));
 
-		// ── 12. Wire put-remaining.csv output for PUT completions ──────────
-		final ItemInfoFileOutput putRemainingFileOut;
-		if (putWeight > 0) {
-			try {
-				putRemainingFileOut = new ItemInfoFileOutput<>(putRemainingFilePath);
-			} catch (final IOException e) {
-				throw new IllegalStateException("Failed to open put-remaining.csv: " + putRemainingFilePath, e);
-			}
-		} else {
-			putRemainingFileOut = null;
-		}
-
-		// PUT results output: feeds delete queue + writes to put-remaining.csv
-		final Output putResultsOutput;
-		if (putWeight > 0) {
-			putResultsOutput = new Output() {
-				@Override
-				public boolean put(final Object op) {
-					if (op instanceof Operation) {
-						final Operation o = (Operation) op;
-						if (Operation.Status.SUCC.equals(o.status())) {
-							// Feed the delete queue
-							pool.addDeleteItem((Item) o.item());
-							// Write to put-remaining.csv — pass the Operation, not the Item,
-							// because ItemInfoFileOutput<O extends Operation> expects an Operation
-							if (putRemainingFileOut != null) {
-								putRemainingFileOut.put(o);
-							}
-						}
-					}
-					return true;
-				}
-
-				@Override
-				public int put(final List ops, final int from, final int to) {
-					for (int i = from; i < to; i++)
-						put(ops.get(i));
-					return to - from;
-				}
-
-				@Override
-				public int put(final List ops) {
-					for (final Object op : ops)
-						put(op);
-					return ops.size();
-				}
-
-				@Override
-				public Input getInput() {
-					return null;
-				}
-
-				@Override
-				public void close() throws Exception {
-					if (putRemainingFileOut != null)
-						putRemainingFileOut.close();
-				}
-			};
-		} else {
-			putResultsOutput = null;
-		}
-
-		// ── 13. Create MixedLoadGenerator ──────────────────────────────────
-		final MixedLoadGenerator generator = new MixedLoadGenerator(
-						ServiceTaskExecutor.VT_EXECUTOR, schedule, pool, builders,
-						driver, concurrencyLimit, newItemInput, putResultsOutput, null);
-
 		// ── 14. Create single LoadStepContextImpl with per-op metrics map ──
 		// Use the first MetricsContext as the primary (for isDone checks).
 		// The metricsCtxByOpType map handles per-op routing in put().
@@ -378,6 +343,7 @@ public final class MixedLoadStepLocal extends LoadStepLocalBase {
 		driver.operationResultOutput(new Output() {
 			@Override
 			public boolean put(final Object op) {
+				generator.onOperationCompleted((Operation) op);
 				generator.releasePermit();
 				return stepCtx.put((Operation) op);
 			}
@@ -385,6 +351,7 @@ public final class MixedLoadStepLocal extends LoadStepLocalBase {
 			@Override
 			public int put(final List ops, final int from, final int to) {
 				for (int i = from; i < to; i++) {
+					generator.onOperationCompleted((Operation) ops.get(i));
 					generator.releasePermit();
 				}
 				return stepCtx.put((List) ops, from, to);
@@ -405,12 +372,6 @@ public final class MixedLoadStepLocal extends LoadStepLocalBase {
 		});
 
 		stepContexts.add(stepCtx);
-		// Pad stepContexts so all metrics context indices resolve to the same context.
-		// initMetrics() captures stepContexts.get(i) in a closure for the concurrency gauge;
-		// without padding, indices 1+ throw IndexOutOfBoundsException.
-		for (int i = 1; i < nonZero; i++) {
-			stepContexts.add(stepCtx);
-		}
 
 		// ── 15. Wire operation results output (for put-remaining routing) ──
 		stepCtx.operationsResultsOutput(new Output() {

--- a/engine/extensions/load-steps/mixed/src/main/java/com/dell/spt/load/step/mixed/OpSchedule.java
+++ b/engine/extensions/load-steps/mixed/src/main/java/com/dell/spt/load/step/mixed/OpSchedule.java
@@ -27,6 +27,7 @@ public final class OpSchedule {
 	private final AtomicInteger index = new AtomicInteger(0);
 	private final OpType[] activeOps;
 	private final Map<OpType, Integer> originIndices;
+	private final Map<OpType, Integer> weights;
 
 	/**
 	 * @param weights non-empty map of op types to positive integer weights;
@@ -39,12 +40,14 @@ public final class OpSchedule {
 
 		int totalWeight = 0;
 		int nonZeroCount = 0;
+		this.weights = new EnumMap<>(OpType.class);
 		for (final var entry : weights.entrySet()) {
 			final int w = entry.getValue();
 			if (w < 0) {
 				throw new IllegalArgumentException("Negative weight for " + entry.getKey() + ": " + w);
 			}
 			if (w > 0) {
+				this.weights.put(entry.getKey(), w);
 				totalWeight += w;
 				nonZeroCount++;
 			}
@@ -118,5 +121,10 @@ public final class OpSchedule {
 	/** Returns the active (non-zero weight) op types in enum ordinal order. */
 	public OpType[] activeOpTypes() {
 		return activeOps.clone();
+	}
+
+	public int weight(final OpType opType) {
+		final Integer w = weights.get(opType);
+		return w != null ? w : 0;
 	}
 }

--- a/engine/extensions/load-steps/mixed/src/main/java/com/dell/spt/load/step/mixed/PoolItemInput.java
+++ b/engine/extensions/load-steps/mixed/src/main/java/com/dell/spt/load/step/mixed/PoolItemInput.java
@@ -1,5 +1,6 @@
 package com.dell.spt.load.step.mixed;
 
+import com.dell.spt.base.item.DataItemImpl;
 import com.dell.spt.base.item.Item;
 
 import java.util.Collection;
@@ -56,7 +57,24 @@ public final class PoolItemInput<I extends Item> {
 
 	/** Returns a random item from the read pool. Thread-safe, never returns null. */
 	public I randomItem() {
-		return readPool[ThreadLocalRandom.current().nextInt(readPool.length)];
+		final I item = readPool[ThreadLocalRandom.current().nextInt(readPool.length)];
+		if (item instanceof DataItemImpl) {
+			final DataItemImpl dataItem = (DataItemImpl) item;
+			final DataItemImpl independentItem;
+			if (dataItem.isUpdated()) {
+				independentItem = new DataItemImpl(dataItem.toString());
+			} else {
+				independentItem = new DataItemImpl(dataItem.name(), dataItem.offset(), dataItem.size(), dataItem.layer());
+			}
+			final var dataInput = dataItem.dataInput();
+			if (dataInput != null) {
+				independentItem.dataInput(dataInput);
+			}
+			@SuppressWarnings("unchecked")
+			final I typedItem = (I) independentItem;
+			return typedItem;
+		}
+		return item;
 	}
 
 	/** Number of items in the read pool. */

--- a/engine/extensions/load-steps/mixed/src/test/java/com/dell/spt/load/step/mixed/MixedLoadGeneratorTest.java
+++ b/engine/extensions/load-steps/mixed/src/test/java/com/dell/spt/load/step/mixed/MixedLoadGeneratorTest.java
@@ -21,6 +21,8 @@ import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -286,7 +288,7 @@ class MixedLoadGeneratorTest {
 
 		// Concurrency limit of 2 — no permits are ever released, so only 2 ops should be generated
 		final MixedLoadGenerator gen = new MixedLoadGenerator(executor, schedule, pool, builders,
-						mockDriver, 2, mockNewItemSupplier(), null, null);
+						mockDriver, 2, mockNewItemSupplier());
 
 		gen.start();
 		Thread.sleep(200);
@@ -313,7 +315,7 @@ class MixedLoadGeneratorTest {
 		final Output<Operation> mockDriver = noopOutput();
 
 		final MixedLoadGenerator gen = new MixedLoadGenerator(executor, schedule, pool, builders,
-						mockDriver, 1, mockNewItemSupplier(), null, null);
+						mockDriver, 1, mockNewItemSupplier());
 
 		gen.start();
 		Thread.sleep(50);
@@ -328,6 +330,137 @@ class MixedLoadGeneratorTest {
 		gen.await(5, TimeUnit.SECONDS);
 	}
 
+	@Test
+	@DisplayName("Builder Error path releases acquired permit")
+	void builderErrorReleasesPermit() throws Exception {
+		final Map<OpType, Integer> weights = new EnumMap<>(OpType.class);
+		weights.put(OpType.READ, 50);
+		weights.put(OpType.CREATE, 50);
+		final OpSchedule schedule = new OpSchedule(weights);
+		final PoolItemInput<Item> pool = new PoolItemInput<>(makeItems(10));
+
+		final Map<OpType, OperationsBuilder> builders = new EnumMap<>(OpType.class);
+		builders.put(OpType.READ, errorBuilder(OpType.READ));
+		builders.put(OpType.CREATE, errorBuilder(OpType.CREATE));
+
+		final MixedLoadGenerator gen = new MixedLoadGenerator(
+						executor, schedule, pool, builders, noopOutput(), 1, mockNewItemSupplier());
+
+		assertThrows(AssertionError.class, gen::doWork,
+						"precondition: builder must fail with Error to exercise throwable path");
+		assertEquals(1, availablePermits(gen),
+						"generator must release permit even when builder throws Error");
+	}
+
+	@Test
+	@DisplayName("Per-op in-flight counters increment on dispatch and decrement on completion")
+	void perOpInFlightCountersTrackDispatchAndCompletion() throws Exception {
+		final Map<OpType, Integer> weights = new EnumMap<>(OpType.class);
+		weights.put(OpType.READ, 70);
+		weights.put(OpType.CREATE, 30);
+		final OpSchedule schedule = new OpSchedule(weights);
+		final PoolItemInput<Item> pool = new PoolItemInput<>(makeItems(20));
+		final Map<OpType, OperationsBuilder> builders = new EnumMap<>(OpType.class);
+		builders.put(OpType.READ, testBuilder(OpType.READ, null));
+		builders.put(OpType.CREATE, testBuilder(OpType.CREATE, null));
+		final List<Operation<Item>> dispatched = new CopyOnWriteArrayList<>();
+		final Output<Operation> captureOutput = new Output<>() {
+			@Override
+			public boolean put(final Operation op) {
+				dispatched.add(op);
+				return true;
+			}
+
+			@Override
+			public int put(final List<Operation> ops, final int from, final int to) {
+				for (int i = from; i < to; i++) {
+					dispatched.add(ops.get(i));
+				}
+				return to - from;
+			}
+
+			@Override
+			public int put(final List<Operation> ops) {
+				for (final Operation op : ops) {
+					dispatched.add(op);
+				}
+				return ops.size();
+			}
+
+			@Override
+			public Input<Operation> getInput() {
+				return null;
+			}
+
+			@Override
+			public void close() {}
+		};
+
+		final MixedLoadGenerator gen = new MixedLoadGenerator(
+						executor, schedule, pool, builders, captureOutput, 10_000, mockNewItemSupplier());
+
+		for (int i = 0; i < 200; i++) {
+			gen.doWork();
+		}
+		assertFalse(dispatched.isEmpty(), "sanity: generator should dispatch operations");
+
+		final long dispatchedRead = dispatched.stream().filter(o -> OpType.READ.equals(o.type())).count();
+		final long dispatchedCreate = dispatched.stream().filter(o -> OpType.CREATE.equals(o.type())).count();
+		assertEquals(dispatchedRead, gen.inFlightCount(OpType.READ),
+						"READ in-flight count should match dispatched READ ops");
+		assertEquals(dispatchedCreate, gen.inFlightCount(OpType.CREATE),
+						"CREATE in-flight count should match dispatched CREATE ops");
+
+		for (final Operation<Item> op : dispatched) {
+			gen.onOperationCompleted(op);
+			gen.releasePermit();
+		}
+		assertEquals(0, gen.inFlightCount(OpType.READ), "READ in-flight count should return to zero after completion");
+		assertEquals(0, gen.inFlightCount(OpType.CREATE), "CREATE in-flight count should return to zero after completion");
+	}
+
+	@Test
+	@DisplayName("DELETE reroll follows configured non-DELETE weights when delete queue is empty")
+	void rerollDeleteHonorsConfiguredWeights() throws Exception {
+		final Map<OpType, Integer> weights = new EnumMap<>(OpType.class);
+		weights.put(OpType.READ, 10);
+		weights.put(OpType.CREATE, 90);
+		weights.put(OpType.DELETE, 900);
+		final OpSchedule schedule = new OpSchedule(weights);
+
+		final PoolItemInput<Item> pool = new PoolItemInput<>(makeItems(20));
+		final ConcurrentLinkedQueue<OpType> dispatched = new ConcurrentLinkedQueue<>();
+		final Map<OpType, OperationsBuilder> builders = new EnumMap<>(OpType.class);
+		builders.put(OpType.READ, testBuilder(OpType.READ, dispatched));
+		builders.put(OpType.CREATE, testBuilder(OpType.CREATE, dispatched));
+		builders.put(OpType.DELETE, testBuilder(OpType.DELETE, dispatched));
+
+		final MixedLoadGenerator gen = new MixedLoadGenerator(
+						executor, schedule, pool, builders, noopOutput(), Integer.MAX_VALUE, mockNewItemSupplier());
+
+		for (int i = 0; i < 20_000; i++) {
+			gen.doWork();
+		}
+
+		final long readCount = dispatched.stream().filter(t -> t == OpType.READ).count();
+		final long createCount = dispatched.stream().filter(t -> t == OpType.CREATE).count();
+		final long deleteCount = dispatched.stream().filter(t -> t == OpType.DELETE).count();
+		final long nonDeleteCount = readCount + createCount;
+
+		assertEquals(0, deleteCount, "DELETE queue is empty, so DELETE ops must reroll");
+		assertTrue(nonDeleteCount > 0, "sanity: test must dispatch non-delete operations");
+		final double readRatio = (double) readCount / nonDeleteCount;
+		assertEquals(0.10, readRatio, 0.08,
+						"reroll should preserve configured READ:CREATE weight ratio (10:90)");
+	}
+
+	@Test
+	@DisplayName("Legacy PUT completion hook is removed from MixedLoadGenerator")
+	void legacyPutCompletionHookRemoved() {
+		assertThrows(NoSuchMethodException.class,
+						() -> MixedLoadGenerator.class.getDeclaredMethod("handlePutCompletion", Operation.class));
+	}
+
 	// ── Helpers ───────────────────────────────────────────────────────────
 
 	/** Helper to create a MixedLoadGenerator with raw types (avoids generic inference issues in tests). */
@@ -337,7 +470,7 @@ class MixedLoadGeneratorTest {
 					final Map builders,
 					final Output driver) {
 		return new MixedLoadGenerator(executor, schedule, pool, builders, driver,
-						Integer.MAX_VALUE, mockNewItemSupplier(), null, null);
+						Integer.MAX_VALUE, mockNewItemSupplier());
 	}
 
 	/** Creates a simple Output that accepts all put() calls (avoids Mockito raw-type issues). */
@@ -445,6 +578,67 @@ class MixedLoadGeneratorTest {
 			@Override
 			public void close() {}
 		};
+	}
+
+	private static OperationsBuilder<Item, Operation<Item>> errorBuilder(final OpType opType) {
+		return new OperationsBuilder<>() {
+			@Override
+			public int originIndex() {
+				return 0;
+			}
+
+			@Override
+			public OpType opType() {
+				return opType;
+			}
+
+			@Override
+			public OperationsBuilder<Item, Operation<Item>> opType(final OpType t) {
+				return this;
+			}
+
+			@Override
+			public String inputPath() {
+				return "";
+			}
+
+			@Override
+			public OperationsBuilder<Item, Operation<Item>> inputPath(final String p) {
+				return this;
+			}
+
+			@Override
+			public OperationsBuilder<Item, Operation<Item>> outputPathInput(final Input<String> i) {
+				return this;
+			}
+
+			@Override
+			public OperationsBuilder<Item, Operation<Item>> credentialInput(final Input i) {
+				return this;
+			}
+
+			@Override
+			public OperationsBuilder<Item, Operation<Item>> credentialsByPath(final Map m) {
+				return this;
+			}
+
+			@Override
+			public Operation<Item> buildOp(final Item item) {
+				throw new AssertionError("synthetic builder error");
+			}
+
+			@Override
+			public void buildOps(final List<Item> items, final List<Operation<Item>> buff) {}
+
+			@Override
+			public void close() {}
+		};
+	}
+
+	private static int availablePermits(final MixedLoadGenerator gen) throws Exception {
+		final var throttleField = MixedLoadGenerator.class.getDeclaredField("concurrencyThrottle");
+		throttleField.setAccessible(true);
+		return ((Semaphore) throttleField.get(gen)).availablePermits();
 	}
 
 	/** Creates a supplier of new items for CREATE operations. */

--- a/engine/extensions/load-steps/mixed/src/test/java/com/dell/spt/load/step/mixed/PoolItemInputTest.java
+++ b/engine/extensions/load-steps/mixed/src/test/java/com/dell/spt/load/step/mixed/PoolItemInputTest.java
@@ -2,10 +2,13 @@ package com.dell.spt.load.step.mixed;
 
 import com.dell.spt.base.item.Item;
 import com.dell.spt.base.item.ItemImpl;
+import com.dell.spt.base.item.DataItem;
+import com.dell.spt.base.item.DataItemImpl;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
+import java.util.BitSet;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -109,6 +112,46 @@ class PoolItemInputTest {
 		for (final Thread t : threads)
 			t.join();
 		assertFalse(errors[0], "randomItem returned null during concurrent access");
+	}
+
+	@Test
+	@DisplayName("randomItem returns independent DataItem instances")
+	void randomItemReturnsIndependentDataItemInstances() {
+		final DataItemImpl seed = new DataItemImpl("obj-a", 0, 4096);
+		final PoolItemInput<Item> pool = new PoolItemInput<>(List.of(seed));
+
+		final DataItem first = (DataItem) pool.randomItem();
+		final DataItem second = (DataItem) pool.randomItem();
+
+		assertNotSame(seed, first, "first random item should be an independent instance");
+		assertNotSame(seed, second, "second random item should be an independent instance");
+		assertNotSame(first, second, "each random read should get its own DataItem instance");
+
+		first.position(128);
+		assertEquals(0, seed.position(), "mutating returned item position must not mutate seed item");
+		assertEquals(0, second.position(), "mutating one returned item must not mutate another");
+	}
+
+	@Test
+	@DisplayName("randomItem preserves updated DataItem state when cloning")
+	void randomItemPreservesUpdatedDataItemState() {
+		final DataItemImpl seed = new DataItemImpl("obj-b", 0, 8192);
+		final BitSet[] updateMask = new BitSet[]{new BitSet(Long.SIZE), new BitSet(Long.SIZE)
+		};
+		updateMask[0].set(2);
+		updateMask[0].set(5);
+		seed.commitUpdatedRanges(updateMask);
+		assertTrue(seed.isUpdated(), "precondition: seed must be updated");
+		assertTrue(seed.isRangeUpdated(2), "precondition: range 2 must be marked updated");
+		assertTrue(seed.isRangeUpdated(5), "precondition: range 5 must be marked updated");
+
+		final PoolItemInput<Item> pool = new PoolItemInput<>(List.of(seed));
+		final DataItem copy = (DataItem) pool.randomItem();
+
+		assertNotSame(seed, copy, "updated DataItem must still be cloned");
+		assertTrue(copy.isUpdated(), "updated state should be preserved");
+		assertTrue(copy.isRangeUpdated(2), "range update mask should be preserved");
+		assertTrue(copy.isRangeUpdated(5), "range update mask should be preserved");
 	}
 
 	// ── Delete queue ──────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- fix mixed-step generator permit ownership so failed/short-circuit dispatch paths always release capacity
- switch mixed metrics concurrency gauge to per-op in-flight counts from `MixedLoadGenerator` and remove fragile step-context index padding
- preserve configured non-DELETE weights when rerolling DELETE with an empty delete queue
- return independent `DataItem` instances from `PoolItemInput.randomItem()` to avoid shared mutable state across concurrent operations
- remove legacy/dead mixed PUT completion hook wiring and keep completion routing in the step context output path
- fix Prometheus exporter collector registration collisions by replacing timestamp-based metric family names with per-exporter unique IDs; add stability regression coverage

