### PR TITLE
Fix TUI trace capture and wire trace artifacts into results

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -614,6 +614,13 @@ Trace files include:
 - System metadata and command information
 - Execution timeline with precise timestamps
 
+When `--auto-results` is enabled and `--trace-file` is not set, spt now auto-creates a per-run trace file:
+- Path: `<results-root>/spt-<runTimestamp>.trace.log`
+- Applies to both headless and TUI runs
+- Auto traces always start fresh (no append)
+- If the results-root trace path cannot be initialized, spt falls back to `./spt-<runTimestamp>.trace.log` and prints a warning
+- The trace is recorded in the results bundle manifest (`index.json` → `runFiles`) and run metadata (`spt_run_params.json` → `traceFile`, `traceAuto`)
+
 ### Logging and Debugging
 
 `spt` provides multiple debugging approaches depending on your needs:

--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -382,22 +382,23 @@ func prepareTraceOptions(explicitPath string, explicitAppend bool, autoResults b
 
 	name := fmt.Sprintf("spt-%s.trace.log", runToken)
 	primaryPath := filepath.Join(plannedResultsRoot, name)
-	if err := ensureTracePathWritable(primaryPath, false); err == nil {
+	primaryErr := ensureTracePathWritable(primaryPath, false)
+	if primaryErr == nil {
 		return traceOptions{Path: primaryPath, Append: false, Auto: true}, nil
-	} else {
-		fallbackPath := filepath.Join(".", name)
-		if warnOut != nil {
-			_, _ = fmt.Fprintf(
-				warnOut,
-				"Warning: could not initialize auto trace file at %s (%v); falling back to %s\n",
-				primaryPath, err, fallbackPath,
-			)
-		}
-		if fallbackErr := ensureTracePathWritable(fallbackPath, false); fallbackErr != nil {
-			return traceOptions{}, fmt.Errorf("failed to initialize fallback trace file: %w", fallbackErr)
-		}
-		return traceOptions{Path: fallbackPath, Append: false, Auto: true}, nil
 	}
+
+	fallbackPath := filepath.Join(".", name)
+	if warnOut != nil {
+		_, _ = fmt.Fprintf(
+			warnOut,
+			"Warning: could not initialize auto trace file at %s (%v); falling back to %s\n",
+			primaryPath, primaryErr, fallbackPath,
+		)
+	}
+	if fallbackErr := ensureTracePathWritable(fallbackPath, false); fallbackErr != nil {
+		return traceOptions{}, fmt.Errorf("failed to initialize fallback trace file: %w", fallbackErr)
+	}
+	return traceOptions{Path: fallbackPath, Append: false, Auto: true}, nil
 }
 
 func ensureTracePathWritable(path string, appendMode bool) error {

--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -6,6 +6,7 @@ package cmd
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -116,7 +117,7 @@ func deriveBaseURL(apiPort string, hosts []*hostparse.HostInfo) string {
 
 // startAutoResults kicks off background completion tracking and artifact fetching.
 // After successful fetch, optionally requests /shutdown across all hosts and waits for API linger.
-func startAutoResults(baseURL, label, resultsDir string, expectedStepIDs []string, debug bool, allHosts []*hostparse.HostInfo, apiPort string, shutdownOn bool, lingerSec int, scenarioPath string, metadata *runMetadata, progressOut io.Writer, summaryOut io.Writer) chan struct{} {
+func startAutoResults(baseURL, label, resultsDir string, expectedStepIDs []string, debug bool, allHosts []*hostparse.HostInfo, apiPort string, shutdownOn bool, lingerSec int, scenarioPath string, metadata *runMetadata, progressOut io.Writer, summaryOut io.Writer, traceFile string) chan struct{} {
 	done := make(chan struct{}, 1)
 	go func() {
 		defer func() { done <- struct{}{} }()
@@ -133,8 +134,13 @@ func startAutoResults(baseURL, label, resultsDir string, expectedStepIDs []strin
 		}
 		writeProgress("Auto-results: monitoring %s for completion...\n", baseURL)
 		// Precompute output root and announce
-		ts := time.Now().UTC().Format("20060102.150405.000")
-		root := filepath.Join(resultsDir, fmt.Sprintf("%s-%s", label, ts))
+		root := ""
+		if metadata != nil && metadata.ResultsRoot != "" {
+			root = metadata.ResultsRoot
+		} else {
+			ts := time.Now().UTC().Format("20060102.150405.000")
+			root = filepath.Join(resultsDir, fmt.Sprintf("%s-%s", label, ts))
+		}
 		writeProgress("Auto-results: will save results under %s\n", root)
 		if metadata != nil {
 			metadata.ResultsRoot = root
@@ -294,6 +300,11 @@ func startAutoResults(baseURL, label, resultsDir string, expectedStepIDs []strin
 			writeProgress("Results fetch encountered errors; see log. Output: %s\n", root)
 			return
 		}
+		if traceFile != "" {
+			if err := appendTraceToResultsManifest(root, traceFile); err != nil {
+				logging.LogError("auto-results", "trace artifact append failed", err, "trace_file", traceFile, "out", root)
+			}
+		}
 		writeProgress("Auto-results: results saved to %s\n", root)
 		writer := summaryOut
 		if writer == nil {
@@ -349,6 +360,170 @@ func uniqueStepIDs(lists ...[]string) []string {
 		}
 	}
 	return out
+}
+
+type traceOptions struct {
+	Path   string
+	Append bool
+	Auto   bool
+}
+
+func prepareTraceOptions(explicitPath string, explicitAppend bool, autoResults bool, plannedResultsRoot string, runToken string, warnOut io.Writer) (traceOptions, error) {
+	path := strings.TrimSpace(explicitPath)
+	if path != "" {
+		if err := ensureTracePathWritable(path, explicitAppend); err != nil {
+			return traceOptions{}, fmt.Errorf("failed to initialize trace file: %w", err)
+		}
+		return traceOptions{Path: path, Append: explicitAppend, Auto: false}, nil
+	}
+	if !autoResults || plannedResultsRoot == "" {
+		return traceOptions{}, nil
+	}
+
+	name := fmt.Sprintf("spt-%s.trace.log", runToken)
+	primaryPath := filepath.Join(plannedResultsRoot, name)
+	if err := ensureTracePathWritable(primaryPath, false); err == nil {
+		return traceOptions{Path: primaryPath, Append: false, Auto: true}, nil
+	} else {
+		fallbackPath := filepath.Join(".", name)
+		if warnOut != nil {
+			_, _ = fmt.Fprintf(
+				warnOut,
+				"Warning: could not initialize auto trace file at %s (%v); falling back to %s\n",
+				primaryPath, err, fallbackPath,
+			)
+		}
+		if fallbackErr := ensureTracePathWritable(fallbackPath, false); fallbackErr != nil {
+			return traceOptions{}, fmt.Errorf("failed to initialize fallback trace file: %w", fallbackErr)
+		}
+		return traceOptions{Path: fallbackPath, Append: false, Auto: true}, nil
+	}
+}
+
+func ensureTracePathWritable(path string, appendMode bool) error {
+	if path == "" {
+		return nil
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		return err
+	}
+	flags := os.O_CREATE | os.O_WRONLY
+	if appendMode {
+		flags |= os.O_APPEND
+	} else {
+		flags |= os.O_TRUNC
+	}
+	f, err := os.OpenFile(path, flags, 0o600) // #nosec G304 -- validated local output path
+	if err != nil {
+		return err
+	}
+	return f.Close()
+}
+
+func appendTraceToResultsManifest(resultsRoot string, tracePath string) error {
+	if resultsRoot == "" || tracePath == "" {
+		return nil
+	}
+	manifestPath := filepath.Join(resultsRoot, constants.ResultsManifestFileName)
+	content, err := os.ReadFile(manifestPath) // #nosec G304 -- path derived from local results root
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("read results manifest: %w", err)
+	}
+	manifest := &results.Manifest{}
+	if err := json.Unmarshal(content, manifest); err != nil {
+		return fmt.Errorf("decode results manifest: %w", err)
+	}
+
+	destName := filepath.Base(tracePath)
+	destPath := filepath.Join(resultsRoot, destName)
+	srcAbs, _ := filepath.Abs(tracePath)
+	destAbs, _ := filepath.Abs(destPath)
+	if srcAbs != destAbs {
+		if err := copyFileAtomic(tracePath, destPath); err != nil {
+			return fmt.Errorf("copy trace file into results root: %w", err)
+		}
+	}
+
+	stat, err := os.Stat(destPath)
+	if err != nil {
+		return fmt.Errorf("stat results trace file: %w", err)
+	}
+	traceStatus := results.FileStatus{
+		Name:        destName,
+		Size:        stat.Size(),
+		Status:      "ok",
+		Modified:    stat.ModTime().UTC().Format(time.RFC3339),
+		ContentType: "text/plain",
+	}
+	replaced := false
+	for i := range manifest.RunFiles {
+		if manifest.RunFiles[i].Name == destName {
+			manifest.RunFiles[i] = traceStatus
+			replaced = true
+			break
+		}
+	}
+	if !replaced {
+		manifest.RunFiles = append(manifest.RunFiles, traceStatus)
+	}
+
+	updated, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal updated results manifest: %w", err)
+	}
+	tmp, err := os.CreateTemp(resultsRoot, ".index.json.trace-*")
+	if err != nil {
+		return fmt.Errorf("create temp manifest: %w", err)
+	}
+	tmpPath := tmp.Name()
+	if _, err = tmp.Write(updated); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("write temp manifest: %w", err)
+	}
+	if err = tmp.Close(); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("close temp manifest: %w", err)
+	}
+	if err = os.Rename(tmpPath, manifestPath); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("replace results manifest: %w", err)
+	}
+	return nil
+}
+
+func copyFileAtomic(srcPath string, destPath string) error {
+	src, err := os.Open(srcPath) // #nosec G304 -- validated local trace path
+	if err != nil {
+		return err
+	}
+	defer func() { _ = src.Close() }()
+
+	if err := os.MkdirAll(filepath.Dir(destPath), 0o750); err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(destPath), ".trace-*")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	if _, err = io.Copy(tmp, src); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpPath)
+		return err
+	}
+	if err = tmp.Close(); err != nil {
+		_ = os.Remove(tmpPath)
+		return err
+	}
+	if err = os.Rename(tmpPath, destPath); err != nil {
+		_ = os.Remove(tmpPath)
+		return err
+	}
+	return nil
 }
 
 // requestShutdownAll posts /shutdown to all provided hosts and waits for linger.
@@ -647,6 +822,22 @@ Available workload types:
 		autoTerminate, _ := cmd.Flags().GetInt("auto-terminate-seconds")
 		apiPort := getAPIPort(cmd)
 		baseURL := deriveBaseURL(apiPort, hostInfos)
+		traceFileFlag, _ := cmd.Flags().GetString("trace-file")
+		traceAppendFlag, _ := cmd.Flags().GetBool("trace-append")
+		runToken := time.Now().UTC().Format("20060102.150405.000")
+		plannedResultsRoot := ""
+		if resultsOpts.AutoResults {
+			plannedResultsRoot = filepath.Join(resultsOpts.ResultsDir, fmt.Sprintf("%s-%s", resultsOpts.Label, runToken))
+		}
+		traceOpts, err := prepareTraceOptions(traceFileFlag, traceAppendFlag, resultsOpts.AutoResults, plannedResultsRoot, runToken, os.Stdout)
+		if err != nil {
+			if removeErr := os.Remove(scenarioPath); removeErr != nil {
+				logger.Debug("Failed to clean up scenario file after trace initialization error",
+					"file", scenarioPath,
+					"error", removeErr.Error())
+			}
+			return err
+		}
 		metadata := buildRunMetadata(runMetadataInput{
 			WorkloadType:         workloadType,
 			Params:               params,
@@ -666,6 +857,11 @@ Available workload types:
 			Command:              cmd,
 			AutoTerminateSeconds: autoTerminate,
 		})
+		metadata.TraceFile = traceOpts.Path
+		metadata.TraceAuto = traceOpts.Auto
+		if plannedResultsRoot != "" {
+			metadata.ResultsRoot = plannedResultsRoot
+		}
 
 		headlessMode := shouldRunHeadless(cmd)
 
@@ -687,7 +883,23 @@ Available workload types:
 		// Start background auto-results tracker/fetcher if enabled
 		var autoResultsDone chan struct{}
 		if resultsOpts.AutoResults {
-			autoResultsDone = startAutoResults(baseURL, resultsOpts.Label, resultsOpts.ResultsDir, expectedStepIDs, resultsOpts.Debug, hostInfos, apiPort, resultsOpts.ShutdownOnComplete, resultsOpts.ShutdownLingerSec, scenarioPath, metadata, progressOut, summaryWriter)
+			autoResultsDone = startAutoResults(baseURL, resultsOpts.Label, resultsOpts.ResultsDir, expectedStepIDs, resultsOpts.Debug, hostInfos, apiPort, resultsOpts.ShutdownOnComplete, resultsOpts.ShutdownLingerSec, scenarioPath, metadata, progressOut, summaryWriter, traceOpts.Path)
+		}
+		waitForAutoResults := func() {
+			if autoResultsDone != nil {
+				select {
+				case <-autoResultsDone:
+				case <-time.After(2 * time.Second):
+				}
+			}
+		}
+		finalizeTraceArtifact := func() {
+			if err := appendTraceToResultsManifest(plannedResultsRoot, traceOpts.Path); err != nil {
+				logger.Debug("Failed to finalize trace artifact in results manifest",
+					"results_root", plannedResultsRoot,
+					"trace_file", traceOpts.Path,
+					"error", err.Error())
+			}
 		}
 
 		// Get endpoint for display
@@ -744,14 +956,11 @@ Available workload types:
 
 			// Check if we should run in headless mode
 			if headlessMode {
-				// Get headless options from flags
-				traceFile, _ := cmd.Flags().GetString("trace-file")
-				traceAppend, _ := cmd.Flags().GetBool("trace-append")
 				verbose, _ := cmd.Flags().GetBool("verbose")
 
 				options := headless.HeadlessOptions{
-					TraceFile:            traceFile,
-					TraceAppend:          traceAppend,
+					TraceFile:            traceOpts.Path,
+					TraceAppend:          traceOpts.Append,
 					Verbose:              verbose,
 					AutoTerminateSeconds: autoTerminate,
 				}
@@ -761,34 +970,33 @@ Available workload types:
 				}
 
 				err := headless.StartHeadlessModeWithOrchestrator(orchestrator, sptImage, scenarioPath, params, options)
-				if autoResultsDone != nil {
-					select {
-					case <-autoResultsDone:
-					case <-time.After(2 * time.Second):
-					}
-				}
+				waitForAutoResults()
+				finalizeTraceArtifact()
 				return err
 			}
 
 			fmt.Printf("Starting multi-host TUI...\n\n")
 			if autoTerminate > 0 {
 				fmt.Printf("Auto-terminate: will stop after %d seconds\n", autoTerminate)
-				return tui.StartTUIWithMultiHostOrchestratorTimeout(orchestrator, sptImage, scenarioPath, params, autoTerminate, setSummarySink)
+				err = tui.StartTUIWithMultiHostOrchestratorTimeoutWithTrace(orchestrator, sptImage, scenarioPath, params, autoTerminate, setSummarySink, traceOpts.Path, traceOpts.Append)
+				waitForAutoResults()
+				finalizeTraceArtifact()
+				return err
 			}
-			return tui.StartTUIWithMultiHostOrchestrator(orchestrator, sptImage, scenarioPath, params, setSummarySink)
+			err = tui.StartTUIWithMultiHostOrchestratorWithTrace(orchestrator, sptImage, scenarioPath, params, setSummarySink, traceOpts.Path, traceOpts.Append)
+			waitForAutoResults()
+			finalizeTraceArtifact()
+			return err
 		}
 
 		// Single host mode (existing logic)
 		// Check if we should run in headless mode
 		if headlessMode {
-			// Get headless options from flags
-			traceFile, _ := cmd.Flags().GetString("trace-file")
-			traceAppend, _ := cmd.Flags().GetBool("trace-append")
 			verbose, _ := cmd.Flags().GetBool("verbose")
 
 			options := headless.HeadlessOptions{
-				TraceFile:            traceFile,
-				TraceAppend:          traceAppend,
+				TraceFile:            traceOpts.Path,
+				TraceAppend:          traceOpts.Append,
 				Verbose:              verbose,
 				APIPort:              apiPort,
 				AutoTerminateSeconds: autoTerminate,
@@ -799,12 +1007,8 @@ Available workload types:
 			}
 
 			err := headless.StartHeadlessModeWithParams(sptImage, scenarioPath, params, options)
-			if autoResultsDone != nil {
-				select {
-				case <-autoResultsDone:
-				case <-time.After(2 * time.Second):
-				}
-			}
+			waitForAutoResults()
+			finalizeTraceArtifact()
 			return err
 		}
 
@@ -812,16 +1016,12 @@ Available workload types:
 		// Launch TUI with the scenario file
 		if autoTerminate > 0 {
 			fmt.Printf("Auto-terminate: will stop after %d seconds\n", autoTerminate)
-			err = tui.StartTUIWithScenarioAndParamsTimeout(sptImage, scenarioPath, params, apiPort, autoTerminate, setSummarySink)
+			err = tui.StartTUIWithScenarioAndParamsTimeoutWithTrace(sptImage, scenarioPath, params, apiPort, autoTerminate, setSummarySink, traceOpts.Path, traceOpts.Append)
 		} else {
-			err = tui.StartTUIWithScenarioAndParams(sptImage, scenarioPath, params, apiPort, setSummarySink)
+			err = tui.StartTUIWithScenarioAndParamsWithTrace(sptImage, scenarioPath, params, apiPort, setSummarySink, traceOpts.Path, traceOpts.Append)
 		}
-		if autoResultsDone != nil {
-			select {
-			case <-autoResultsDone:
-			case <-time.After(2 * time.Second):
-			}
-		}
+		waitForAutoResults()
+		finalizeTraceArtifact()
 		return err
 	},
 }

--- a/cli/cmd/run_auto_results_test.go
+++ b/cli/cmd/run_auto_results_test.go
@@ -2,13 +2,16 @@ package cmd
 
 import (
 	"context"
+	"encoding/json"
 	"io"
+	"os"
 	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/dell/storage-performance-tool/cli/internal/constants"
 	"github.com/dell/storage-performance-tool/cli/internal/portcheck"
 	"github.com/dell/storage-performance-tool/cli/internal/results"
 )
@@ -48,12 +51,18 @@ type fakeFetcher struct {
 	output   string
 	manifest *results.Manifest
 	err      error
+	onFetch  func(output string, stepIDs []string) error
 }
 
 func (f *fakeFetcher) FetchArtifactsForSteps(ctx context.Context, stepIDs []string) (*results.Manifest, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.stepIDs = append([]string(nil), stepIDs...)
+	if f.onFetch != nil {
+		if err := f.onFetch(f.output, stepIDs); err != nil {
+			return nil, err
+		}
+	}
 	if f.manifest != nil || f.err != nil {
 		return f.manifest, f.err
 	}
@@ -129,7 +138,7 @@ func TestStartAutoResults_StaleDiscoveredIDsFromPriorRun(t *testing.T) {
 	generateRunSummaryFunc = func(ctx context.Context, runDir string, out io.Writer) error { return nil }
 
 	tmpDir := t.TempDir()
-	done := startAutoResults("http://example", "mt", tmpDir, currentIDs, false, nil, "", false, 0, "", nil, io.Discard, io.Discard)
+	done := startAutoResults("http://example", "mt", tmpDir, currentIDs, false, nil, "", false, 0, "", nil, io.Discard, io.Discard, "")
 
 	select {
 	case <-done:
@@ -211,7 +220,7 @@ func TestStartAutoResults_DiscoveredIDsFilteredToExpectedSet(t *testing.T) {
 	}
 
 	tmpDir := t.TempDir()
-	done := startAutoResults("http://example", "mt", tmpDir, []string{"expected-create"}, false, nil, "", false, 0, "", nil, io.Discard, io.Discard)
+	done := startAutoResults("http://example", "mt", tmpDir, []string{"expected-create"}, false, nil, "", false, 0, "", nil, io.Discard, io.Discard, "")
 
 	select {
 	case <-done:
@@ -298,7 +307,7 @@ func TestStartAutoResults_FleetDiscoveryPreferred(t *testing.T) {
 	generateRunSummaryFunc = func(ctx context.Context, runDir string, out io.Writer) error { return nil }
 
 	tmpDir := t.TempDir()
-	done := startAutoResults("http://example", "mt", tmpDir, expectedIDs, false, nil, "", false, 0, "", nil, io.Discard, io.Discard)
+	done := startAutoResults("http://example", "mt", tmpDir, expectedIDs, false, nil, "", false, 0, "", nil, io.Discard, io.Discard, "")
 
 	select {
 	case <-done:
@@ -366,7 +375,7 @@ func TestStartAutoResults_FleetUnavailableFallback(t *testing.T) {
 	generateRunSummaryFunc = func(ctx context.Context, runDir string, out io.Writer) error { return nil }
 
 	tmpDir := t.TempDir()
-	done := startAutoResults("http://example", "mt", tmpDir, expectedIDs, false, nil, "", false, 0, "", nil, io.Discard, io.Discard)
+	done := startAutoResults("http://example", "mt", tmpDir, expectedIDs, false, nil, "", false, 0, "", nil, io.Discard, io.Discard, "")
 
 	select {
 	case <-done:
@@ -389,5 +398,99 @@ func TestStartAutoResults_FleetUnavailableFallback(t *testing.T) {
 		if !expectedSet[id] {
 			t.Fatalf("unexpected step ID %q in fetcher.stepIDs; got %v", id, fetcher.stepIDs)
 		}
+	}
+}
+
+func TestStartAutoResults_AppendsTraceArtifactToManifest(t *testing.T) {
+	origRunTracker := newRunTrackerFunc
+	origDiscover := discoverStepIDsFunc
+	origFleetDiscover := discoverFleetStepIDsFunc
+	origFetcher := newResultsFetcherFunc
+	origSummary := generateRunSummaryFunc
+	defer func() {
+		newRunTrackerFunc = origRunTracker
+		discoverStepIDsFunc = origDiscover
+		discoverFleetStepIDsFunc = origFleetDiscover
+		newResultsFetcherFunc = origFetcher
+		generateRunSummaryFunc = origSummary
+	}()
+
+	tracker := &fakeRunTracker{}
+	newRunTrackerFunc = func(baseURL string) autoResultsRunTracker { return tracker }
+
+	stepID := "mt-001-20260506.204108.064-write"
+	discoverStepIDsFunc = func(baseURL string) ([]string, error) {
+		return []string{stepID}, nil
+	}
+	discoverFleetStepIDsFunc = func(baseURL string) ([]string, error) { return nil, nil }
+
+	traceSrcDir := t.TempDir()
+	traceFile := filepath.Join(traceSrcDir, "spt-20260506.204108.064.trace.log")
+	if err := os.WriteFile(traceFile, []byte("trace-data\n"), 0o600); err != nil {
+		t.Fatalf("write trace file: %v", err)
+	}
+
+	fetcher := &fakeFetcher{
+		onFetch: func(output string, stepIDs []string) error {
+			if err := os.MkdirAll(output, 0o755); err != nil {
+				return err
+			}
+			manifest := &results.Manifest{
+				BaseURL:   "http://example",
+				OutputDir: output,
+				Steps: []results.StepManifest{
+					{
+						StepID: stepID,
+						Files: []results.FileStatus{
+							{Name: stepID + ".metrics.total.csv", Status: "ok"},
+						},
+					},
+				},
+			}
+			data, err := json.MarshalIndent(manifest, "", "  ")
+			if err != nil {
+				return err
+			}
+			return os.WriteFile(filepath.Join(output, constants.ResultsManifestFileName), data, 0o600)
+		},
+	}
+	newResultsFetcherFunc = func(baseURL, outputDir string) autoResultsFetcher {
+		fetcher.baseURL = baseURL
+		fetcher.output = outputDir
+		return fetcher
+	}
+	generateRunSummaryFunc = func(ctx context.Context, runDir string, out io.Writer) error { return nil }
+
+	tmpDir := t.TempDir()
+	done := startAutoResults("http://example", "mt", tmpDir, []string{stepID}, false, nil, "", false, 0, "", nil, io.Discard, io.Discard, traceFile)
+
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("startAutoResults did not complete in time")
+	}
+
+	manifestPath := filepath.Join(fetcher.output, constants.ResultsManifestFileName)
+	content, err := os.ReadFile(manifestPath)
+	if err != nil {
+		t.Fatalf("read manifest: %v", err)
+	}
+	var got results.Manifest
+	if err := json.Unmarshal(content, &got); err != nil {
+		t.Fatalf("unmarshal manifest: %v", err)
+	}
+	if len(got.RunFiles) != 1 {
+		t.Fatalf("RunFiles length = %d, want 1", len(got.RunFiles))
+	}
+	if got.RunFiles[0].Name != filepath.Base(traceFile) {
+		t.Fatalf("RunFiles[0].Name = %q, want %q", got.RunFiles[0].Name, filepath.Base(traceFile))
+	}
+	if got.RunFiles[0].Status != "ok" {
+		t.Fatalf("RunFiles[0].Status = %q, want ok", got.RunFiles[0].Status)
+	}
+
+	traceCopyPath := filepath.Join(fetcher.output, filepath.Base(traceFile))
+	if _, err := os.Stat(traceCopyPath); err != nil {
+		t.Fatalf("expected trace file copied to results root: %v", err)
 	}
 }

--- a/cli/cmd/run_metadata.go
+++ b/cli/cmd/run_metadata.go
@@ -23,6 +23,8 @@ type runMetadata struct {
 	SptImage             string                 `json:"sptImage"`
 	APIPort              string                 `json:"apiPort"`
 	BaseURL              string                 `json:"baseUrl"`
+	TraceFile            string                 `json:"traceFile,omitempty"`
+	TraceAuto            bool                   `json:"traceAuto,omitempty"`
 	Label                string                 `json:"label"`
 	ResultsDir           string                 `json:"resultsDir"`
 	ResultsRoot          string                 `json:"resultsRoot"`

--- a/cli/cmd/run_metadata.go
+++ b/cli/cmd/run_metadata.go
@@ -6,9 +6,9 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"strings"
 	"time"
 
+	"github.com/dell/storage-performance-tool/cli/internal/cmdline"
 	"github.com/dell/storage-performance-tool/cli/internal/constants"
 	"github.com/dell/storage-performance-tool/cli/internal/hostparse"
 	"github.com/dell/storage-performance-tool/cli/internal/scenario"
@@ -208,90 +208,7 @@ func isSensitiveFlag(name string) bool {
 }
 
 func sanitizeCommandArgs(args []string) []string {
-	out := make([]string, len(args))
-	for i := 0; i < len(args); i++ {
-		arg := args[i]
-		if strings.HasPrefix(arg, "--") {
-			flag, hasValue := splitLongArg(arg)
-			if isSensitiveLongFlag(flag) {
-				if hasValue {
-					out[i] = flag + "=" + maskedPlaceholder
-				} else {
-					out[i] = flag
-					if i+1 < len(args) {
-						out[i+1] = maskedPlaceholder
-						i++
-					}
-				}
-				continue
-			}
-			out[i] = arg
-			continue
-		}
-		if isSensitiveShortFlag(arg) {
-			out[i] = arg
-			if strings.Contains(arg, "=") {
-				out[i] = sensitiveShortPrefix(arg)
-			} else if i+1 < len(args) {
-				out[i+1] = maskedPlaceholder
-				i++
-			}
-			continue
-		}
-		out[i] = arg
-	}
-	return fillUnsetArgs(out, args)
-}
-
-func fillUnsetArgs(out, original []string) []string {
-	for i := range out {
-		if out[i] == "" {
-			out[i] = original[i]
-		}
-	}
-	return out
-}
-
-func splitLongArg(arg string) (flag string, hasValue bool) {
-	if !strings.HasPrefix(arg, "--") {
-		return "", false
-	}
-	if idx := strings.Index(arg, "="); idx != -1 {
-		return arg[:idx], true
-	}
-	return arg, false
-}
-
-func isSensitiveLongFlag(flag string) bool {
-	switch flag {
-	case "--secret-key", "--access-key":
-		return true
-	default:
-		return false
-	}
-}
-
-func isSensitiveShortFlag(arg string) bool {
-	if !strings.HasPrefix(arg, "-") || strings.HasPrefix(arg, "--") {
-		return false
-	}
-	base := arg
-	if strings.Contains(arg, "=") {
-		base = arg[:strings.Index(arg, "=")]
-	}
-	switch base {
-	case "-s", "-a":
-		return true
-	default:
-		return false
-	}
-}
-
-func sensitiveShortPrefix(arg string) string {
-	if idx := strings.Index(arg, "="); idx != -1 {
-		return arg[:idx+1] + maskedPlaceholder
-	}
-	return arg
+	return cmdline.SanitizeArgs(args)
 }
 
 func copyScenarioForResults(srcPath, destDir string) (string, error) {

--- a/cli/cmd/run_metadata_test.go
+++ b/cli/cmd/run_metadata_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/dell/storage-performance-tool/cli/internal/constants"
@@ -52,6 +53,35 @@ func TestSanitizeCommandArgsMasksSensitiveFlags(t *testing.T) {
 		if got[i] != want[i] {
 			t.Fatalf("sanitized args[%d] = %q, want %q", i, got[i], want[i])
 		}
+	}
+}
+
+func TestBuildRunMetadata_CommandIsSanitized(t *testing.T) {
+	oldArgs := os.Args
+	os.Args = []string{"spt", "run", "write", "--secret-key", "verysecret", "--access-key=OPENKEY"}
+	defer func() { os.Args = oldArgs }()
+
+	meta := buildRunMetadata(runMetadataInput{
+		WorkloadType: "write",
+		Params:       scenario.Params{},
+		ScenarioPath: "./tmp/scenario.js",
+		ResultsOptions: ResultsOptions{
+			AutoResults: false,
+			ResultsDir:  "./results",
+			Label:       "mt",
+		},
+		SptImage: "repo/spt:latest",
+	})
+
+	if len(meta.CLI.Command) == 0 {
+		t.Fatalf("CLI command should not be empty")
+	}
+	joined := strings.Join(meta.CLI.Command, " ")
+	if strings.Contains(joined, "verysecret") || strings.Contains(joined, "OPENKEY") {
+		t.Fatalf("metadata command leaked credentials: %q", joined)
+	}
+	if !strings.Contains(joined, "--secret-key ***") || !strings.Contains(joined, "--access-key=***") {
+		t.Fatalf("metadata command missing masked values: %q", joined)
 	}
 }
 

--- a/cli/cmd/run_metadata_test.go
+++ b/cli/cmd/run_metadata_test.go
@@ -149,6 +149,8 @@ func TestBuildRunMetadataPopulatesCoreFields(t *testing.T) {
 		SptImage:        "repo/spt:latest",
 		Command:         cmd,
 	})
+	meta.TraceFile = "results/mt-20260506.204108.064/spt-20260506.204108.064.trace.log"
+	meta.TraceAuto = true
 
 	if meta.ScenarioFile != "scenario.js" {
 		t.Fatalf("ScenarioFile = %q, want scenario.js", meta.ScenarioFile)
@@ -164,5 +166,11 @@ func TestBuildRunMetadataPopulatesCoreFields(t *testing.T) {
 	}
 	if len(meta.ExpectedStepIDs) != 1 || meta.ExpectedStepIDs[0] != "step-001" {
 		t.Fatalf("ExpectedStepIDs = %+v, want [step-001]", meta.ExpectedStepIDs)
+	}
+	if meta.TraceFile == "" {
+		t.Fatalf("TraceFile should be populated")
+	}
+	if !meta.TraceAuto {
+		t.Fatalf("TraceAuto should be true")
 	}
 }

--- a/cli/cmd/run_results_flags_test.go
+++ b/cli/cmd/run_results_flags_test.go
@@ -1,8 +1,14 @@
 package cmd
 
 import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/dell/storage-performance-tool/cli/internal/constants"
+	"github.com/dell/storage-performance-tool/cli/internal/results"
 	"github.com/spf13/cobra"
 )
 
@@ -75,5 +81,147 @@ func TestSanitizeLabel_InvalidCharsAndLength(t *testing.T) {
 	got := sanitizeLabel(long)
 	if len(got) != 64 {
 		t.Fatalf("sanitizeLabel length = %d, want 64 (got %q)", len(got), got)
+	}
+}
+
+func TestPrepareTraceOptions_ExplicitPathPrecedence(t *testing.T) {
+	tmpDir := t.TempDir()
+	explicit := filepath.Join(tmpDir, "explicit.log")
+	got, err := prepareTraceOptions(explicit, true, true, filepath.Join(tmpDir, "results-root"), "20260506.204108.064", nil)
+	if err != nil {
+		t.Fatalf("prepareTraceOptions returned error: %v", err)
+	}
+	if got.Path != explicit {
+		t.Fatalf("Path = %q, want %q", got.Path, explicit)
+	}
+	if !got.Append {
+		t.Fatalf("Append = false, want true")
+	}
+	if got.Auto {
+		t.Fatalf("Auto = true, want false")
+	}
+}
+
+func TestPrepareTraceOptions_AutoDefaultsFreshFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	resultsRoot := filepath.Join(tmpDir, "results", "mt-20260506.204108.064")
+	runToken := "20260506.204108.064"
+	got, err := prepareTraceOptions("", true, true, resultsRoot, runToken, nil)
+	if err != nil {
+		t.Fatalf("prepareTraceOptions returned error: %v", err)
+	}
+	wantPath := filepath.Join(resultsRoot, "spt-"+runToken+".trace.log")
+	if got.Path != wantPath {
+		t.Fatalf("Path = %q, want %q", got.Path, wantPath)
+	}
+	if got.Append {
+		t.Fatalf("Append = true, want false for auto trace")
+	}
+	if !got.Auto {
+		t.Fatalf("Auto = false, want true")
+	}
+}
+
+func TestPrepareTraceOptions_AutoFallbackToCWD(t *testing.T) {
+	tmpDir := t.TempDir()
+	resultsRoot := filepath.Join(tmpDir, "as-file")
+	if err := os.WriteFile(resultsRoot, []byte("file-blocking-dir-create"), 0o600); err != nil {
+		t.Fatalf("write sentinel file: %v", err)
+	}
+	oldWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("chdir tempdir: %v", err)
+	}
+	defer func() { _ = os.Chdir(oldWD) }()
+
+	var sb strings.Builder
+	runToken := "20260506.204108.064"
+	got, err := prepareTraceOptions("", false, true, resultsRoot, runToken, &sb)
+	if err != nil {
+		t.Fatalf("prepareTraceOptions returned error: %v", err)
+	}
+	wantFallback := filepath.Join(".", "spt-"+runToken+".trace.log")
+	if got.Path != wantFallback {
+		t.Fatalf("Path = %q, want %q", got.Path, wantFallback)
+	}
+	if got.Append {
+		t.Fatalf("Append = true, want false for fallback auto trace")
+	}
+	if !got.Auto {
+		t.Fatalf("Auto = false, want true")
+	}
+	if !strings.Contains(sb.String(), "falling back") {
+		t.Fatalf("expected fallback warning, got %q", sb.String())
+	}
+}
+
+func TestAppendTraceToResultsManifest_AddsRunFileAndCopies(t *testing.T) {
+	tmpDir := t.TempDir()
+	resultsRoot := filepath.Join(tmpDir, "results", "mt-20260506.204108.064")
+	if err := os.MkdirAll(resultsRoot, 0o755); err != nil {
+		t.Fatalf("mkdir results root: %v", err)
+	}
+
+	manifest := &results.Manifest{
+		BaseURL:   "http://example",
+		OutputDir: resultsRoot,
+	}
+	data, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal manifest: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(resultsRoot, constants.ResultsManifestFileName), data, 0o600); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+
+	traceSrc := filepath.Join(tmpDir, "trace.log")
+	traceContent := "hello trace\n"
+	if err := os.WriteFile(traceSrc, []byte(traceContent), 0o600); err != nil {
+		t.Fatalf("write trace source: %v", err)
+	}
+
+	if err := appendTraceToResultsManifest(resultsRoot, traceSrc); err != nil {
+		t.Fatalf("appendTraceToResultsManifest error: %v", err)
+	}
+
+	traceDest := filepath.Join(resultsRoot, filepath.Base(traceSrc))
+	gotTrace, err := os.ReadFile(traceDest)
+	if err != nil {
+		t.Fatalf("read copied trace: %v", err)
+	}
+	if string(gotTrace) != traceContent {
+		t.Fatalf("copied trace content = %q, want %q", string(gotTrace), traceContent)
+	}
+
+	updatedBytes, err := os.ReadFile(filepath.Join(resultsRoot, constants.ResultsManifestFileName))
+	if err != nil {
+		t.Fatalf("read updated manifest: %v", err)
+	}
+	var updated results.Manifest
+	if err := json.Unmarshal(updatedBytes, &updated); err != nil {
+		t.Fatalf("unmarshal updated manifest: %v", err)
+	}
+	if len(updated.RunFiles) != 1 {
+		t.Fatalf("RunFiles length = %d, want 1", len(updated.RunFiles))
+	}
+	if updated.RunFiles[0].Name != filepath.Base(traceSrc) {
+		t.Fatalf("RunFiles[0].Name = %q, want %q", updated.RunFiles[0].Name, filepath.Base(traceSrc))
+	}
+	if updated.RunFiles[0].Status != "ok" {
+		t.Fatalf("RunFiles[0].Status = %q, want ok", updated.RunFiles[0].Status)
+	}
+}
+
+func TestAppendTraceToResultsManifest_NoManifestNoError(t *testing.T) {
+	tmpDir := t.TempDir()
+	traceSrc := filepath.Join(tmpDir, "trace.log")
+	if err := os.WriteFile(traceSrc, []byte("x"), 0o600); err != nil {
+		t.Fatalf("write trace source: %v", err)
+	}
+	if err := appendTraceToResultsManifest(filepath.Join(tmpDir, "missing-root"), traceSrc); err != nil {
+		t.Fatalf("appendTraceToResultsManifest should ignore missing manifest, got: %v", err)
 	}
 }

--- a/cli/internal/cmdline/cmdline.go
+++ b/cli/internal/cmdline/cmdline.go
@@ -1,0 +1,109 @@
+package cmdline
+
+import (
+	"strconv"
+	"strings"
+)
+
+const redactedValue = "***"
+
+// SanitizeArgs masks sensitive credential arguments in argv-style input.
+func SanitizeArgs(args []string) []string {
+	out := make([]string, len(args))
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		if strings.HasPrefix(arg, "--") {
+			flag, hasValue := splitLongArg(arg)
+			if isSensitiveLongFlag(flag) {
+				if hasValue {
+					out[i] = flag + "=" + redactedValue
+				} else {
+					out[i] = flag
+					if i+1 < len(args) {
+						out[i+1] = redactedValue
+						i++
+					}
+				}
+				continue
+			}
+			out[i] = arg
+			continue
+		}
+		if isSensitiveShortFlag(arg) {
+			out[i] = arg
+			if strings.Contains(arg, "=") {
+				out[i] = sensitiveShortPrefix(arg)
+			} else if i+1 < len(args) {
+				out[i+1] = redactedValue
+				i++
+			}
+			continue
+		}
+		out[i] = arg
+	}
+	for i := range out {
+		if out[i] == "" {
+			out[i] = args[i]
+		}
+	}
+	return out
+}
+
+// FormatForArtifact renders sanitized args as a command line for logs/artifacts.
+func FormatForArtifact(args []string) string {
+	sanitized := SanitizeArgs(args)
+	if len(sanitized) == 0 {
+		return ""
+	}
+	parts := make([]string, len(sanitized))
+	for i, arg := range sanitized {
+		if arg == "" || strings.ContainsAny(arg, " \t\n\"'\\") {
+			parts[i] = strconv.Quote(arg)
+			continue
+		}
+		parts[i] = arg
+	}
+	return strings.Join(parts, " ")
+}
+
+func splitLongArg(arg string) (flag string, hasValue bool) {
+	if !strings.HasPrefix(arg, "--") {
+		return "", false
+	}
+	if idx := strings.Index(arg, "="); idx != -1 {
+		return arg[:idx], true
+	}
+	return arg, false
+}
+
+func isSensitiveLongFlag(flag string) bool {
+	switch flag {
+	case "--secret-key", "--access-key":
+		return true
+	default:
+		return false
+	}
+}
+
+func isSensitiveShortFlag(arg string) bool {
+	if !strings.HasPrefix(arg, "-") || strings.HasPrefix(arg, "--") {
+		return false
+	}
+	base := arg
+	if strings.Contains(arg, "=") {
+		base = arg[:strings.Index(arg, "=")]
+	}
+	switch base {
+	case "-s", "-a":
+		return true
+	default:
+		return false
+	}
+}
+
+func sensitiveShortPrefix(arg string) string {
+	if idx := strings.Index(arg, "="); idx != -1 {
+		return arg[:idx+1] + redactedValue
+	}
+	return arg
+}

--- a/cli/internal/cmdline/cmdline.go
+++ b/cli/internal/cmdline/cmdline.go
@@ -1,3 +1,4 @@
+// Package cmdline provides helpers to sanitize and render CLI args for logs/artifacts.
 package cmdline
 
 import (

--- a/cli/internal/cmdline/cmdline_test.go
+++ b/cli/internal/cmdline/cmdline_test.go
@@ -1,0 +1,37 @@
+package cmdline
+
+import "testing"
+
+func TestSanitizeArgsMasksSensitiveFlags(t *testing.T) {
+	args := []string{
+		"spt", "run", "write",
+		"--secret-key=verysecret",
+		"--access-key", "OPENKEY",
+		"-s", "short",
+		"-a=value",
+	}
+	got := SanitizeArgs(args)
+	want := []string{
+		"spt", "run", "write",
+		"--secret-key=***",
+		"--access-key", "***",
+		"-s", "***",
+		"-a=***",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("sanitized args length %d, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("sanitized args[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestFormatForArtifactMasksAndQuotes(t *testing.T) {
+	got := FormatForArtifact([]string{"spt", "run", "--secret-key", "top secret", "--name", "my run", "-a=AKIA"})
+	want := `spt run --secret-key *** --name "my run" -a=***`
+	if got != want {
+		t.Fatalf("FormatForArtifact mismatch\nwant: %s\ngot:  %s", want, got)
+	}
+}

--- a/cli/internal/results/fetcher.go
+++ b/cli/internal/results/fetcher.go
@@ -72,6 +72,7 @@ type Manifest struct {
 	OutputDir   string         `json:"outputDir"`
 	GeneratedAt time.Time      `json:"generatedAt"`
 	Steps       []StepManifest `json:"steps"`
+	RunFiles    []FileStatus   `json:"runFiles,omitempty"`
 }
 
 // Fetcher downloads artifacts for steps via the /logs endpoints.

--- a/cli/internal/results/summary/loader.go
+++ b/cli/internal/results/summary/loader.go
@@ -267,6 +267,8 @@ type RunParams struct {
 	SptImage           string            `json:"sptImage"`
 	APIPort            string            `json:"apiPort"`
 	BaseURL            string            `json:"baseUrl"`
+	TraceFile          string            `json:"traceFile"`
+	TraceAuto          bool              `json:"traceAuto"`
 	Label              string            `json:"label"`
 	ResultsDir         string            `json:"resultsDir"`
 	ResultsRoot        string            `json:"resultsRoot"`

--- a/cli/tui/headless/runner.go
+++ b/cli/tui/headless/runner.go
@@ -12,11 +12,11 @@ import (
 	"os"
 	"os/signal"
 	"runtime"
-	"strconv"
 	"strings"
 	"syscall"
 	"time"
 
+	"github.com/dell/storage-performance-tool/cli/internal/cmdline"
 	"github.com/dell/storage-performance-tool/cli/internal/constants"
 	"github.com/dell/storage-performance-tool/cli/internal/logging"
 	"github.com/dell/storage-performance-tool/cli/internal/scenario"
@@ -37,21 +37,6 @@ type HeadlessRunner struct {
 	keepScenario  bool
 	scenarioPath  string
 	apiPort       string
-}
-
-func formatCommandLine(args []string) string {
-	if len(args) == 0 {
-		return ""
-	}
-	parts := make([]string, len(args))
-	for i, arg := range args {
-		if arg == "" || strings.ContainsAny(arg, " \t\n\"'\\") {
-			parts[i] = strconv.Quote(arg)
-			continue
-		}
-		parts[i] = arg
-	}
-	return strings.Join(parts, " ")
 }
 
 // HeadlessOptions holds configuration for headless mode
@@ -243,7 +228,7 @@ func (r *MultiHostHeadlessRunner) writeTraceHeader(filename string, hostCount in
 	header += fmt.Sprintf("Started: %s\n", time.Now().Format("2006-01-02 15:04:05"))
 	header += fmt.Sprintf("Runtime: %s %s\n", runtime.GOOS, runtime.GOARCH)
 	header += fmt.Sprintf("Trace File: %s\n", filename)
-	header += fmt.Sprintf("Command: %s\n", formatCommandLine(os.Args))
+	header += fmt.Sprintf("Command: %s\n", cmdline.FormatForArtifact(os.Args))
 	header += strings.Repeat("=", 50) + "\n"
 
 	fmt.Print(header)
@@ -498,7 +483,7 @@ func (r *HeadlessRunner) writeTraceHeader(filename string) {
 		return
 	}
 
-	command := formatCommandLine(os.Args)
+	command := cmdline.FormatForArtifact(os.Args)
 	if command == "" {
 		command = "<unknown>"
 	}

--- a/cli/tui/headless/runner.go
+++ b/cli/tui/headless/runner.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"os/signal"
 	"runtime"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -36,6 +37,21 @@ type HeadlessRunner struct {
 	keepScenario  bool
 	scenarioPath  string
 	apiPort       string
+}
+
+func formatCommandLine(args []string) string {
+	if len(args) == 0 {
+		return ""
+	}
+	parts := make([]string, len(args))
+	for i, arg := range args {
+		if arg == "" || strings.ContainsAny(arg, " \t\n\"'\\") {
+			parts[i] = strconv.Quote(arg)
+			continue
+		}
+		parts[i] = arg
+	}
+	return strings.Join(parts, " ")
 }
 
 // HeadlessOptions holds configuration for headless mode
@@ -227,6 +243,7 @@ func (r *MultiHostHeadlessRunner) writeTraceHeader(filename string, hostCount in
 	header += fmt.Sprintf("Started: %s\n", time.Now().Format("2006-01-02 15:04:05"))
 	header += fmt.Sprintf("Runtime: %s %s\n", runtime.GOOS, runtime.GOARCH)
 	header += fmt.Sprintf("Trace File: %s\n", filename)
+	header += fmt.Sprintf("Command: %s\n", formatCommandLine(os.Args))
 	header += strings.Repeat("=", 50) + "\n"
 
 	fmt.Print(header)
@@ -481,11 +498,16 @@ func (r *HeadlessRunner) writeTraceHeader(filename string) {
 		return
 	}
 
+	command := formatCommandLine(os.Args)
+	if command == "" {
+		command = "<unknown>"
+	}
 	header := fmt.Sprintf(`# Trace file: %s
 # Generated: %s
+# Command: %s
 # System: %s/%s
 #
-`, filename, time.Now().Format("2006-01-02 15:04:05"), runtime.GOOS, runtime.GOARCH)
+`, filename, time.Now().Format("2006-01-02 15:04:05"), command, runtime.GOOS, runtime.GOARCH)
 
 	_, _ = r.traceFile.WriteString(header) //nolint:errcheck
 }

--- a/cli/tui/headless/runner_multihost_test.go
+++ b/cli/tui/headless/runner_multihost_test.go
@@ -53,6 +53,10 @@ func TestNewMultiHostHeadlessRunner_Success(t *testing.T) {
 }
 
 func TestNewMultiHostHeadlessRunner_WithTraceFile(t *testing.T) {
+	oldArgs := os.Args
+	os.Args = []string{"spt", "run", "mixed", "-s", "secret", "-a=ACCESS"}
+	defer func() { os.Args = oldArgs }()
+
 	hostInfos := []*hostparse.HostInfo{
 		{Host: "host1", IsLocal: false, Original: "host1"},
 	}
@@ -102,6 +106,12 @@ func TestNewMultiHostHeadlessRunner_WithTraceFile(t *testing.T) {
 	}
 	if !strings.Contains(contentStr, "Command:") {
 		t.Errorf("Trace file should contain command line, got: %s", contentStr)
+	}
+	if strings.Contains(contentStr, "secret") || strings.Contains(contentStr, "ACCESS") {
+		t.Errorf("Trace file header leaked credentials, got: %s", contentStr)
+	}
+	if !strings.Contains(contentStr, "-s ***") || !strings.Contains(contentStr, "-a=***") {
+		t.Errorf("Trace file should mask command credentials in header, got: %s", contentStr)
 	}
 }
 

--- a/cli/tui/headless/runner_multihost_test.go
+++ b/cli/tui/headless/runner_multihost_test.go
@@ -100,6 +100,9 @@ func TestNewMultiHostHeadlessRunner_WithTraceFile(t *testing.T) {
 	if !strings.Contains(contentStr, "1 hosts") {
 		t.Errorf("Trace file should contain host count, got: %s", contentStr)
 	}
+	if !strings.Contains(contentStr, "Command:") {
+		t.Errorf("Trace file should contain command line, got: %s", contentStr)
+	}
 }
 
 func TestNewMultiHostHeadlessRunner_TraceFileAppend(t *testing.T) {
@@ -152,6 +155,9 @@ func TestNewMultiHostHeadlessRunner_TraceFileAppend(t *testing.T) {
 
 	if !strings.Contains(contentStr, "Multi-Host") {
 		t.Errorf("Trace file should contain new multi-host header when appending, got: %s", contentStr)
+	}
+	if !strings.Contains(contentStr, "Command:") {
+		t.Errorf("Trace file should contain command line in header when appending, got: %s", contentStr)
 	}
 }
 

--- a/cli/tui/headless/runner_test.go
+++ b/cli/tui/headless/runner_test.go
@@ -196,6 +196,9 @@ func TestHeadlessRunner_TraceFile(t *testing.T) {
 	if !strings.Contains(traceContent, "# Trace file:") {
 		t.Errorf("Trace file missing header")
 	}
+	if !strings.Contains(traceContent, "# Command:") {
+		t.Errorf("Trace file missing command header")
+	}
 
 	// Check for some expected log entries
 	if !strings.Contains(traceContent, "[INIT]") {

--- a/cli/tui/headless/runner_test.go
+++ b/cli/tui/headless/runner_test.go
@@ -143,6 +143,10 @@ func TestHeadlessRunner_DryRun(t *testing.T) {
 }
 
 func TestHeadlessRunner_TraceFile(t *testing.T) {
+	oldArgs := os.Args
+	os.Args = []string{"spt", "run", "write", "--secret-key", "verysecret", "--access-key=OPENKEY"}
+	defer func() { os.Args = oldArgs }()
+
 	tempDir := t.TempDir()
 	traceFile := filepath.Join(tempDir, "trace.log")
 
@@ -198,6 +202,12 @@ func TestHeadlessRunner_TraceFile(t *testing.T) {
 	}
 	if !strings.Contains(traceContent, "# Command:") {
 		t.Errorf("Trace file missing command header")
+	}
+	if strings.Contains(traceContent, "verysecret") || strings.Contains(traceContent, "OPENKEY") {
+		t.Errorf("Trace file leaked credential in header")
+	}
+	if !strings.Contains(traceContent, "--secret-key ***") || !strings.Contains(traceContent, "--access-key=***") {
+		t.Errorf("Trace file should mask command credentials in header")
 	}
 
 	// Check for some expected log entries

--- a/cli/tui/model.go
+++ b/cli/tui/model.go
@@ -21,6 +21,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/dell/storage-performance-tool/cli/internal/cmdline"
 	"github.com/dell/storage-performance-tool/cli/internal/constants"
 	"github.com/dell/storage-performance-tool/cli/internal/logging"
 	"github.com/dell/storage-performance-tool/cli/internal/mathutil"
@@ -1455,7 +1456,7 @@ func newProgramWithTrace(model Model, tracePath string, traceAppend bool) (*tea.
 		return nil, nil, fmt.Errorf("failed to open trace file: %w", err)
 	}
 	if !traceAppend {
-		command := formatCommandLine(os.Args)
+		command := cmdline.FormatForArtifact(os.Args)
 		if command == "" {
 			command = "<unknown>"
 		}
@@ -1469,21 +1470,6 @@ func newProgramWithTrace(model Model, tracePath string, traceAppend bool) (*tea.
 	}
 	model.traceSink = newTUITraceSink(traceFile)
 	return tea.NewProgram(model, opts...), traceFile, nil
-}
-
-func formatCommandLine(args []string) string {
-	if len(args) == 0 {
-		return ""
-	}
-	parts := make([]string, len(args))
-	for i, arg := range args {
-		if arg == "" || strings.ContainsAny(arg, " \t\n\"'\\") {
-			parts[i] = strconv.Quote(arg)
-			continue
-		}
-		parts[i] = arg
-	}
-	return strings.Join(parts, " ")
 }
 
 // StartTUIWithContainer starts the TUI and immediately launches a container

--- a/cli/tui/model.go
+++ b/cli/tui/model.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
@@ -868,11 +869,16 @@ func StartTUI() error {
 func StartTUIWithScenario(image string, scenarioPath string) error {
 	// Create empty params for backward compatibility - endpoint args will be empty
 	params := scenario.ScenarioParams{}
-	return StartTUIWithScenarioAndParams(image, scenarioPath, params, "", nil)
+	return StartTUIWithScenarioAndParamsWithTrace(image, scenarioPath, params, "", nil, "", false)
 }
 
 // StartTUIWithScenarioAndParams starts the TUI with a scenario file and scenario parameters
 func StartTUIWithScenarioAndParams(image string, scenarioPath string, params scenario.ScenarioParams, apiPort string, setSummarySink func(func(string))) error {
+	return StartTUIWithScenarioAndParamsWithTrace(image, scenarioPath, params, apiPort, setSummarySink, "", false)
+}
+
+// StartTUIWithScenarioAndParamsWithTrace starts the TUI with optional full-output trace capture.
+func StartTUIWithScenarioAndParamsWithTrace(image string, scenarioPath string, params scenario.ScenarioParams, apiPort string, setSummarySink func(func(string)), tracePath string, traceAppend bool) error {
 	model := InitialModel()
 	if params.MinimalTUI {
 		model.processOutputHidden = true
@@ -899,7 +905,13 @@ func StartTUIWithScenarioAndParams(image string, scenarioPath string, params sce
 
 	model.dockerManager = dm
 
-	p := tea.NewProgram(model, tea.WithAltScreen())
+	p, traceFile, err := newProgramWithTrace(model, tracePath, traceAppend)
+	if err != nil {
+		return err
+	}
+	if traceFile != nil {
+		defer func() { _ = traceFile.Close() }()
+	}
 
 	if setSummarySink != nil {
 		setSummarySink(func(line string) {
@@ -988,6 +1000,11 @@ func StartTUIWithScenarioAndParams(image string, scenarioPath string, params sce
 
 // StartTUIWithMultiHostOrchestrator starts the TUI with a pre-configured multi-host orchestrator
 func StartTUIWithMultiHostOrchestrator(orchestrator *MultiHostOrchestrator, image string, scenarioPath string, params scenario.ScenarioParams, setSummarySink func(func(string))) error {
+	return StartTUIWithMultiHostOrchestratorWithTrace(orchestrator, image, scenarioPath, params, setSummarySink, "", false)
+}
+
+// StartTUIWithMultiHostOrchestratorWithTrace starts the multi-host TUI with optional full-output trace capture.
+func StartTUIWithMultiHostOrchestratorWithTrace(orchestrator *MultiHostOrchestrator, image string, scenarioPath string, params scenario.ScenarioParams, setSummarySink func(func(string)), tracePath string, traceAppend bool) error {
 	model := InitialModel()
 	if params.MinimalTUI {
 		model.processOutputHidden = true
@@ -1017,7 +1034,13 @@ func StartTUIWithMultiHostOrchestrator(orchestrator *MultiHostOrchestrator, imag
 	// Provide baseline generator so Model.Init can emit it safely at startup
 	model.baselineFn = multiOrchestrator.BuildBaselineUpdate
 
-	p := tea.NewProgram(model, tea.WithAltScreen())
+	p, traceFile, err := newProgramWithTrace(model, tracePath, traceAppend)
+	if err != nil {
+		return err
+	}
+	if traceFile != nil {
+		defer func() { _ = traceFile.Close() }()
+	}
 
 	if setSummarySink != nil {
 		setSummarySink(func(line string) {
@@ -1124,8 +1147,13 @@ func StartTUIWithMultiHostOrchestrator(orchestrator *MultiHostOrchestrator, imag
 
 // StartTUIWithScenarioAndParamsTimeout starts the TUI (single host) and exits after autoTerminateSeconds (>0).
 func StartTUIWithScenarioAndParamsTimeout(image string, scenarioPath string, params scenario.ScenarioParams, apiPort string, autoTerminateSeconds int, setSummarySink func(func(string))) error {
+	return StartTUIWithScenarioAndParamsTimeoutWithTrace(image, scenarioPath, params, apiPort, autoTerminateSeconds, setSummarySink, "", false)
+}
+
+// StartTUIWithScenarioAndParamsTimeoutWithTrace starts the TUI (single host), exits after timeout, and can capture full output.
+func StartTUIWithScenarioAndParamsTimeoutWithTrace(image string, scenarioPath string, params scenario.ScenarioParams, apiPort string, autoTerminateSeconds int, setSummarySink func(func(string)), tracePath string, traceAppend bool) error {
 	if autoTerminateSeconds <= 0 {
-		return StartTUIWithScenarioAndParams(image, scenarioPath, params, apiPort, setSummarySink)
+		return StartTUIWithScenarioAndParamsWithTrace(image, scenarioPath, params, apiPort, setSummarySink, tracePath, traceAppend)
 	}
 	model := InitialModel()
 	if params.MinimalTUI {
@@ -1148,7 +1176,19 @@ func StartTUIWithScenarioAndParamsTimeout(image string, scenarioPath string, par
 	model.orchestrator = orchestrator
 	model.dockerManager = dm
 
-	p := tea.NewProgram(model, tea.WithAltScreen())
+	p, traceFile, err := newProgramWithTrace(model, tracePath, traceAppend)
+	if err != nil {
+		return err
+	}
+	if traceFile != nil {
+		defer func() { _ = traceFile.Close() }()
+	}
+
+	if setSummarySink != nil {
+		setSummarySink(func(line string) {
+			p.Send(sptMessageMsg(line))
+		})
+	}
 
 	orchestrator.SetCallbacks(
 		func(status *TestStatus) {
@@ -1216,8 +1256,13 @@ func StartTUIWithScenarioAndParamsTimeout(image string, scenarioPath string, par
 
 // StartTUIWithMultiHostOrchestratorTimeout starts the TUI (multi-host) and exits after autoTerminateSeconds (>0).
 func StartTUIWithMultiHostOrchestratorTimeout(orchestrator *MultiHostOrchestrator, image string, scenarioPath string, params scenario.ScenarioParams, autoTerminateSeconds int, setSummarySink func(func(string))) error {
+	return StartTUIWithMultiHostOrchestratorTimeoutWithTrace(orchestrator, image, scenarioPath, params, autoTerminateSeconds, setSummarySink, "", false)
+}
+
+// StartTUIWithMultiHostOrchestratorTimeoutWithTrace starts the multi-host TUI with timeout and optional full-output trace capture.
+func StartTUIWithMultiHostOrchestratorTimeoutWithTrace(orchestrator *MultiHostOrchestrator, image string, scenarioPath string, params scenario.ScenarioParams, autoTerminateSeconds int, setSummarySink func(func(string)), tracePath string, traceAppend bool) error {
 	if autoTerminateSeconds <= 0 {
-		return StartTUIWithMultiHostOrchestrator(orchestrator, image, scenarioPath, params, setSummarySink)
+		return StartTUIWithMultiHostOrchestratorWithTrace(orchestrator, image, scenarioPath, params, setSummarySink, tracePath, traceAppend)
 	}
 	model := InitialModel()
 	if params.MinimalTUI {
@@ -1239,7 +1284,19 @@ func StartTUIWithMultiHostOrchestratorTimeout(orchestrator *MultiHostOrchestrato
 	model.orchestrator = multiOrchestrator
 	model.baselineFn = multiOrchestrator.BuildBaselineUpdate
 
-	p := tea.NewProgram(model, tea.WithAltScreen())
+	p, traceFile, err := newProgramWithTrace(model, tracePath, traceAppend)
+	if err != nil {
+		return err
+	}
+	if traceFile != nil {
+		defer func() { _ = traceFile.Close() }()
+	}
+
+	if setSummarySink != nil {
+		setSummarySink(func(line string) {
+			p.Send(sptMessageMsg(line))
+		})
+	}
 
 	orchestrator.SetNotifier(func(msg string) { p.Send(sptMessageMsg(msg)) })
 	multiOrchestrator.SetMessageSink(func(msg string) {
@@ -1309,6 +1366,30 @@ func StartTUIWithMultiHostOrchestratorTimeout(orchestrator *MultiHostOrchestrato
 		}
 	}
 	return err
+}
+
+func newProgramWithTrace(model Model, tracePath string, traceAppend bool) (*tea.Program, *os.File, error) {
+	opts := []tea.ProgramOption{tea.WithAltScreen()}
+	if tracePath == "" {
+		return tea.NewProgram(model, opts...), nil, nil
+	}
+	if err := os.MkdirAll(filepath.Dir(tracePath), 0o750); err != nil {
+		return nil, nil, fmt.Errorf("failed to create trace file directory: %w", err)
+	}
+	flags := os.O_CREATE | os.O_WRONLY
+	if traceAppend {
+		flags |= os.O_APPEND
+	} else {
+		flags |= os.O_TRUNC
+	}
+	traceFile, err := os.OpenFile(tracePath, flags, 0600) // #nosec G304 -- path validated by caller and kept local
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to open trace file: %w", err)
+	}
+	if !traceAppend {
+		_, _ = fmt.Fprintf(traceFile, "# TUI trace file: %s\n# Generated: %s\n#\n", tracePath, time.Now().Format("2006-01-02 15:04:05"))
+	}
+	return tea.NewProgram(model, opts...), traceFile, nil
 }
 
 // StartTUIWithContainer starts the TUI and immediately launches a container

--- a/cli/tui/model.go
+++ b/cli/tui/model.go
@@ -15,7 +15,9 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
+	"unicode"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
@@ -36,6 +38,7 @@ const (
 
 // Compiled regex for stripping ANSI escape sequences
 var ansiEscapeRegex = regexp.MustCompile(`\x1b\[[0-9;]*m`)
+var traceEscapeRegex = regexp.MustCompile(`\x1b\[[0-9;?]*[ -/]*[@-~]`)
 
 // Model represents the TUI state
 type Model struct {
@@ -98,6 +101,47 @@ type Model struct {
 	frameDumpCount       *int
 	frameDumpMinInterval time.Duration
 	frameDumpLast        *time.Time
+	traceSink            *tuiTraceSink
+}
+
+type tuiTraceSink struct {
+	mu   sync.Mutex
+	file *os.File
+}
+
+func newTUITraceSink(file *os.File) *tuiTraceSink {
+	if file == nil {
+		return nil
+	}
+	return &tuiTraceSink{file: file}
+}
+
+func sanitizeTUITraceLine(line string) string {
+	if line == "" {
+		return ""
+	}
+	line = traceEscapeRegex.ReplaceAllString(line, "")
+	var b strings.Builder
+	b.Grow(len(line))
+	for _, r := range line {
+		if r == '\t' || !unicode.IsControl(r) {
+			b.WriteRune(r)
+		}
+	}
+	return strings.TrimSpace(b.String())
+}
+
+func (s *tuiTraceSink) writeLine(line string) {
+	if s == nil || s.file == nil {
+		return
+	}
+	clean := sanitizeTUITraceLine(line)
+	if clean == "" {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	_, _ = fmt.Fprintln(s.file, clean)
 }
 
 // Messages
@@ -139,6 +183,7 @@ func InitialModel() Model {
 		frameDumpStrip:       false,
 		frameDumpLiveOnly:    false,
 		frameDumpCount:       nil,
+		traceSink:            nil,
 	}
 
 	// Optional frame dump configuration via env vars
@@ -176,6 +221,30 @@ func InitialModel() Model {
 	}
 
 	return m
+}
+
+func (m *Model) traceContainerOutput(line string) {
+	if m.traceSink != nil {
+		m.traceSink.writeLine(line)
+	}
+}
+
+func (m *Model) traceStderr(msg string) {
+	if m.traceSink != nil {
+		m.traceSink.writeLine("[stderr] " + msg)
+	}
+}
+
+func (m *Model) traceSptMessage(msg string) {
+	if m.traceSink != nil {
+		m.traceSink.writeLine("[spt] " + msg)
+	}
+}
+
+func (m *Model) traceStatus(status string) {
+	if m.traceSink != nil {
+		m.traceSink.writeLine("[status] " + status)
+	}
 }
 
 // Init initializes the model
@@ -219,18 +288,22 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return mm, nil
 	case containerOutputMsg:
 		mm := m
+		mm.traceContainerOutput(string(mt))
 		mm.handleContainerOutput(string(mt))
 		return mm, nil
 	case containerStderrMsg:
 		mm := m
+		mm.traceStderr(string(mt))
 		mm.addStderrMessage(string(mt))
 		return mm, nil
 	case sptMessageMsg:
 		mm := m
+		mm.traceSptMessage(string(mt))
 		mm.addSptMessage(string(mt))
 		return mm, nil
 	case containerStatusMsg:
 		mm := m
+		mm.traceStatus(string(mt))
 		mm.containerStatus = string(mt)
 		return mm, nil
 	case autoTerminateMsg:
@@ -1053,11 +1126,6 @@ func StartTUIWithMultiHostOrchestratorWithTrace(orchestrator *MultiHostOrchestra
 		p.Send(sptMessageMsg(msg))
 	})
 
-	// Route orchestrator progress messages into the TUI messages pane
-	orchestrator.SetNotifier(func(msg string) {
-		p.Send(sptMessageMsg(msg))
-	})
-
 	// Provide a message sink for other orchestrator-driven components (e.g., entry log relay)
 	// Route Spt log lines without the [spt] tag to avoid double-tagging.
 	multiOrchestrator.SetMessageSink(func(msg string) {
@@ -1389,6 +1457,7 @@ func newProgramWithTrace(model Model, tracePath string, traceAppend bool) (*tea.
 	if !traceAppend {
 		_, _ = fmt.Fprintf(traceFile, "# TUI trace file: %s\n# Generated: %s\n#\n", tracePath, time.Now().Format("2006-01-02 15:04:05"))
 	}
+	model.traceSink = newTUITraceSink(traceFile)
 	return tea.NewProgram(model, opts...), traceFile, nil
 }
 

--- a/cli/tui/model.go
+++ b/cli/tui/model.go
@@ -1455,10 +1455,35 @@ func newProgramWithTrace(model Model, tracePath string, traceAppend bool) (*tea.
 		return nil, nil, fmt.Errorf("failed to open trace file: %w", err)
 	}
 	if !traceAppend {
-		_, _ = fmt.Fprintf(traceFile, "# TUI trace file: %s\n# Generated: %s\n#\n", tracePath, time.Now().Format("2006-01-02 15:04:05"))
+		command := formatCommandLine(os.Args)
+		if command == "" {
+			command = "<unknown>"
+		}
+		_, _ = fmt.Fprintf(
+			traceFile,
+			"# TUI trace file: %s\n# Generated: %s\n# Command: %s\n#\n",
+			tracePath,
+			time.Now().Format("2006-01-02 15:04:05"),
+			command,
+		)
 	}
 	model.traceSink = newTUITraceSink(traceFile)
 	return tea.NewProgram(model, opts...), traceFile, nil
+}
+
+func formatCommandLine(args []string) string {
+	if len(args) == 0 {
+		return ""
+	}
+	parts := make([]string, len(args))
+	for i, arg := range args {
+		if arg == "" || strings.ContainsAny(arg, " \t\n\"'\\") {
+			parts[i] = strconv.Quote(arg)
+			continue
+		}
+		parts[i] = arg
+	}
+	return strings.Join(parts, " ")
 }
 
 // StartTUIWithContainer starts the TUI and immediately launches a container

--- a/cli/tui/model_test.go
+++ b/cli/tui/model_test.go
@@ -20,6 +20,9 @@ func TestNewProgramWithTrace_CreatesHeaderAndSupportsAppend(t *testing.T) {
 	tmpDir := t.TempDir()
 	tracePath := filepath.Join(tmpDir, "tui.trace.log")
 	model := InitialModel()
+	oldArgs := os.Args
+	os.Args = []string{"spt", "run", "read", "--trace-file", tracePath}
+	defer func() { os.Args = oldArgs }()
 
 	_, f, err := newProgramWithTrace(model, tracePath, false)
 	if err != nil {
@@ -38,6 +41,9 @@ func TestNewProgramWithTrace_CreatesHeaderAndSupportsAppend(t *testing.T) {
 	s := string(content)
 	if !strings.Contains(s, "# TUI trace file:") {
 		t.Fatalf("trace header missing: %q", s)
+	}
+	if !strings.Contains(s, "# Command: spt run read --trace-file") {
+		t.Fatalf("trace command header missing: %q", s)
 	}
 	if !strings.Contains(s, "first") {
 		t.Fatalf("trace content missing first marker: %q", s)
@@ -63,6 +69,14 @@ func TestNewProgramWithTrace_CreatesHeaderAndSupportsAppend(t *testing.T) {
 	}
 	if !strings.Contains(s2, "first") || !strings.Contains(s2, "second") {
 		t.Fatalf("append content missing markers: %q", s2)
+	}
+}
+
+func TestFormatCommandLine_QuotesWhitespaceAndSpecialChars(t *testing.T) {
+	got := formatCommandLine([]string{"spt", "run", "--name", "my run", "--note", `a"b`})
+	want := `spt run --name "my run" --note "a\"b"`
+	if got != want {
+		t.Fatalf("formatCommandLine mismatch\nwant: %s\ngot:  %s", want, got)
 	}
 }
 

--- a/cli/tui/model_test.go
+++ b/cli/tui/model_test.go
@@ -66,6 +66,64 @@ func TestNewProgramWithTrace_CreatesHeaderAndSupportsAppend(t *testing.T) {
 	}
 }
 
+func TestSanitizeTUITraceLine_StripsANSIAndControls(t *testing.T) {
+	got := sanitizeTUITraceLine("\x1b[33mhello\x1b[0m \x02x\tok\r\n")
+	if strings.Contains(got, "\x1b[") {
+		t.Fatalf("sanitizeTUITraceLine should strip ANSI escapes, got %q", got)
+	}
+	if strings.Contains(got, "\x02") {
+		t.Fatalf("sanitizeTUITraceLine should strip control chars, got %q", got)
+	}
+	if got != "hello x\tok" {
+		t.Fatalf("unexpected sanitized value: %q", got)
+	}
+}
+
+func TestModelUpdate_WritesTraceForMessageTypes(t *testing.T) {
+	tmpDir := t.TempDir()
+	tracePath := filepath.Join(tmpDir, "events.trace.log")
+	f, err := os.OpenFile(tracePath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0600) // #nosec G304 -- test temp file
+	if err != nil {
+		t.Fatalf("open trace file: %v", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	m := InitialModel()
+	m.traceSink = newTUITraceSink(f)
+
+	var updated tea.Model
+	updated, _ = m.Update(containerOutputMsg("plain output"))
+	m = updated.(Model)
+	updated, _ = m.Update(containerStderrMsg("oops"))
+	m = updated.(Model)
+	updated, _ = m.Update(sptMessageMsg("starting"))
+	m = updated.(Model)
+	updated, _ = m.Update(containerStatusMsg("API Running"))
+	m = updated.(Model)
+	_ = f.Sync()
+
+	content, err := os.ReadFile(tracePath)
+	if err != nil {
+		t.Fatalf("read trace file: %v", err)
+	}
+	lines := string(content)
+	if !strings.Contains(lines, "plain output\n") {
+		t.Fatalf("missing container output trace line: %q", lines)
+	}
+	if !strings.Contains(lines, "[stderr] oops\n") {
+		t.Fatalf("missing stderr trace line: %q", lines)
+	}
+	if !strings.Contains(lines, "[spt] starting\n") {
+		t.Fatalf("missing spt trace line: %q", lines)
+	}
+	if !strings.Contains(lines, "[status] API Running\n") {
+		t.Fatalf("missing status trace line: %q", lines)
+	}
+	if strings.Contains(lines, "┌") || strings.Contains(lines, "│") {
+		t.Fatalf("trace should not contain tui frame glyphs: %q", lines)
+	}
+}
+
 func TestInitialModel(t *testing.T) {
 	m := InitialModel()
 

--- a/cli/tui/model_test.go
+++ b/cli/tui/model_test.go
@@ -72,11 +72,33 @@ func TestNewProgramWithTrace_CreatesHeaderAndSupportsAppend(t *testing.T) {
 	}
 }
 
-func TestFormatCommandLine_QuotesWhitespaceAndSpecialChars(t *testing.T) {
-	got := formatCommandLine([]string{"spt", "run", "--name", "my run", "--note", `a"b`})
-	want := `spt run --name "my run" --note "a\"b"`
-	if got != want {
-		t.Fatalf("formatCommandLine mismatch\nwant: %s\ngot:  %s", want, got)
+func TestNewProgramWithTrace_HeaderMasksCredentials(t *testing.T) {
+	tmpDir := t.TempDir()
+	tracePath := filepath.Join(tmpDir, "tui.trace.log")
+	oldArgs := os.Args
+	os.Args = []string{"spt", "run", "write", "--secret-key", "supersecret", "-a=AKIA"}
+	defer func() { os.Args = oldArgs }()
+
+	_, f, err := newProgramWithTrace(InitialModel(), tracePath, false)
+	if err != nil {
+		t.Fatalf("newProgramWithTrace error: %v", err)
+	}
+	if f != nil {
+		_ = f.Close()
+	}
+	content, err := os.ReadFile(tracePath)
+	if err != nil {
+		t.Fatalf("read trace file: %v", err)
+	}
+	s := string(content)
+	if !strings.Contains(s, "# Command:") {
+		t.Fatalf("missing command header: %q", s)
+	}
+	if strings.Contains(s, "supersecret") || strings.Contains(s, "AKIA") {
+		t.Fatalf("trace header leaked credential: %q", s)
+	}
+	if !strings.Contains(s, "--secret-key ***") || !strings.Contains(s, "-a=***") {
+		t.Fatalf("trace header missing masked values: %q", s)
 	}
 }
 

--- a/cli/tui/model_test.go
+++ b/cli/tui/model_test.go
@@ -6,6 +6,8 @@ package tui
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -13,6 +15,56 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/dell/storage-performance-tool/cli/internal/textutil"
 )
+
+func TestNewProgramWithTrace_CreatesHeaderAndSupportsAppend(t *testing.T) {
+	tmpDir := t.TempDir()
+	tracePath := filepath.Join(tmpDir, "tui.trace.log")
+	model := InitialModel()
+
+	_, f, err := newProgramWithTrace(model, tracePath, false)
+	if err != nil {
+		t.Fatalf("newProgramWithTrace create error: %v", err)
+	}
+	if f == nil {
+		t.Fatalf("expected trace file handle")
+	}
+	_, _ = f.WriteString("first\n")
+	_ = f.Close()
+
+	content, err := os.ReadFile(tracePath)
+	if err != nil {
+		t.Fatalf("read trace file: %v", err)
+	}
+	s := string(content)
+	if !strings.Contains(s, "# TUI trace file:") {
+		t.Fatalf("trace header missing: %q", s)
+	}
+	if !strings.Contains(s, "first") {
+		t.Fatalf("trace content missing first marker: %q", s)
+	}
+
+	_, f2, err := newProgramWithTrace(model, tracePath, true)
+	if err != nil {
+		t.Fatalf("newProgramWithTrace append error: %v", err)
+	}
+	if f2 == nil {
+		t.Fatalf("expected trace file handle on append")
+	}
+	_, _ = f2.WriteString("second\n")
+	_ = f2.Close()
+
+	content2, err := os.ReadFile(tracePath)
+	if err != nil {
+		t.Fatalf("read trace file after append: %v", err)
+	}
+	s2 := string(content2)
+	if strings.Count(s2, "# TUI trace file:") != 1 {
+		t.Fatalf("expected single header after append, got content: %q", s2)
+	}
+	if !strings.Contains(s2, "first") || !strings.Contains(s2, "second") {
+		t.Fatalf("append content missing markers: %q", s2)
+	}
+}
 
 func TestInitialModel(t *testing.T) {
 	m := InitialModel()


### PR DESCRIPTION
## Summary
- ensure `--trace-file` / `--trace-append` are applied consistently across headless and interactive TUI run paths
- add auto-trace behavior for `--auto-results` runs when no explicit trace file is provided, with fallback-to-CWD warning if results-root trace init fails
- include trace artifacts in auto-results output (`index.json` runFiles) and persist trace metadata fields (`traceFile`, `traceAuto`) in run metadata
- replace TUI frame-output trace behavior with centralized event/message trace capture in the model update pipeline
- include invocation command in trace headers and mask credential flags (`--secret-key`, `--access-key`, `-s`, `-a`) via shared command-line sanitization helpers
- update tests for trace option resolution, manifest wiring, metadata sanitization, TUI/headless trace headers, and centralized TUI trace behavior
