### PR TITLE
make cli args artifact optional in auto-results

### DIFF
--- a/cli/internal/results/fetcher.go
+++ b/cli/internal/results/fetcher.go
@@ -28,7 +28,7 @@ type ArtifactSpec struct {
 var DefaultArtifacts = []ArtifactSpec{
 	{Loggers: []string{"metrics.FileTotal"}, Suffix: constants.ResultsArtifactSuffixMetricsTotal, Required: true},
 	{Loggers: []string{"Config"}, Suffix: constants.ResultsArtifactSuffixConfig, Required: true},
-	{Loggers: []string{"Cli"}, Suffix: constants.ResultsArtifactSuffixCLIArgs, Required: true},
+	{Loggers: []string{"Cli"}, Suffix: constants.ResultsArtifactSuffixCLIArgs, Required: false},
 	{Loggers: []string{"Messages"}, Suffix: constants.ResultsArtifactSuffixMessages, Required: true},
 	{Loggers: []string{"Errors"}, Suffix: constants.ResultsArtifactSuffixErrors, Required: true},
 	// Optional below


### PR DESCRIPTION
## Summary
- mark `cli.args.log` as optional in CLI auto-results artifact specs
- remove false-positive artifact health warnings for API-driven runs where engine does not emit per-step `Cli` entries
- keep required artifact gating focused on performance-critical outputs (for example, `metrics.total.csv`)
