### PR TITLE
Fix mixed workload config key collision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Changed
+
+- **Mixed workload distribution config key** — renamed the mixed workload engine config from `load.op.weight.{get,put,delete,stat}` to `load.op.weights.{get,put,delete,stat}` to avoid colliding with `WeightedLoad`'s scalar `load.op.weight` key. CLI-generated `spt run mixed` scenarios use the new key automatically; hand-written `MixedLoad` scenarios should be updated.
+
 ## [5.9.2] - 2026-05-05
 
 ### Fixed

--- a/cli/internal/scenario/generator_mixed.go
+++ b/cli/internal/scenario/generator_mixed.go
@@ -103,7 +103,7 @@ MixedLoad
                 "id": "{{.StepIDMixed}}"
             },
             "op": {
-                "weight": {
+                "weights": {
                     "get": {{.GetDistrib}},
                     "put": {{.PutDistrib}},
                     "delete": {{.DeleteDistrib}},

--- a/cli/internal/scenario/generator_mixed_test.go
+++ b/cli/internal/scenario/generator_mixed_test.go
@@ -41,6 +41,7 @@ func TestGenerateMixedScenario(t *testing.T) {
 				`PreconditionLoad`,
 				`"count": seedCount`,
 				`MixedLoad`,
+				`"weights": {`,
 				`"get": 45`,
 				`"put": 30`,
 				`"delete": 15`,

--- a/engine/extensions/load-steps/mixed/src/main/java/com/dell/spt/load/step/mixed/MixedLoadStepClient.java
+++ b/engine/extensions/load-steps/mixed/src/main/java/com/dell/spt/load/step/mixed/MixedLoadStepClient.java
@@ -46,10 +46,10 @@ public final class MixedLoadStepClient extends LoadStepClientBase<MixedLoadStepC
 			stepConfig.val("id", autoStepId);
 		}
 
-		final int getWeight = config.intVal("load-op-weight-get");
-		final int putWeight = config.intVal("load-op-weight-put");
-		final int deleteWeight = config.intVal("load-op-weight-delete");
-		final int statWeight = config.intVal("load-op-weight-stat");
+		final int getWeight = config.intVal("load-op-weights-get");
+		final int putWeight = config.intVal("load-op-weights-put");
+		final int deleteWeight = config.intVal("load-op-weights-delete");
+		final int statWeight = config.intVal("load-op-weights-stat");
 
 		final int concurrencyLimit = config.intVal("storage-driver-limit-concurrency");
 		final Config outputConfig = config.configVal("output");

--- a/engine/extensions/load-steps/mixed/src/main/java/com/dell/spt/load/step/mixed/MixedLoadStepLocal.java
+++ b/engine/extensions/load-steps/mixed/src/main/java/com/dell/spt/load/step/mixed/MixedLoadStepLocal.java
@@ -149,10 +149,10 @@ public final class MixedLoadStepLocal extends LoadStepLocalBase {
 		final ItemFactory itemFactory = ItemType.getItemFactory(itemType);
 
 		// ── 4. Read weights → build OpSchedule ─────────────────────────────
-		final int getWeight = mergedConfig.intVal("load-op-weight-get");
-		final int putWeight = mergedConfig.intVal("load-op-weight-put");
-		final int deleteWeight = mergedConfig.intVal("load-op-weight-delete");
-		final int statWeight = mergedConfig.intVal("load-op-weight-stat");
+		final int getWeight = mergedConfig.intVal("load-op-weights-get");
+		final int putWeight = mergedConfig.intVal("load-op-weights-put");
+		final int deleteWeight = mergedConfig.intVal("load-op-weights-delete");
+		final int statWeight = mergedConfig.intVal("load-op-weights-stat");
 
 		final int nonZero = (getWeight > 0 ? 1 : 0) + (putWeight > 0 ? 1 : 0)
 						+ (deleteWeight > 0 ? 1 : 0) + (statWeight > 0 ? 1 : 0);

--- a/engine/extensions/load-steps/mixed/src/main/resources/config-schema-load-op-mixed.yaml
+++ b/engine/extensions/load-steps/mixed/src/main/resources/config-schema-load-op-mixed.yaml
@@ -3,7 +3,8 @@
 # Mixed workload operation weight distribution (must sum to 100).
 load:
   op:
-    weight:
+    # Plural to avoid colliding with WeightedLoad's scalar load.op.weight.
+    weights:
       get: int
       put: int
       delete: int

--- a/engine/extensions/load-steps/mixed/src/main/resources/config/defaults-load-op-mixed.yaml
+++ b/engine/extensions/load-steps/mixed/src/main/resources/config/defaults-load-op-mixed.yaml
@@ -3,7 +3,7 @@
 # the command line arguments or load step configurations in the scenario files instead.
 load:
   op:
-    weight:
+    weights:
       get: 45
       stat: 30
       put: 15

--- a/engine/extensions/load-steps/mixed/src/test/java/com/dell/spt/load/step/mixed/MixedLoadStepClientTest.java
+++ b/engine/extensions/load-steps/mixed/src/test/java/com/dell/spt/load/step/mixed/MixedLoadStepClientTest.java
@@ -52,11 +52,13 @@ class MixedLoadStepClientTest {
 		opLimit.put("fail", opLimitFail);
 		op.put("limit", opLimit);
 		op.put("type", String.class);
-		final Map<String, Object> weight = new HashMap<>();
-		weight.put("get", Integer.class);
-		weight.put("put", Integer.class);
-		weight.put("delete", Integer.class);
-		op.put("weight", weight);
+		op.put("weight", Integer.class); // WeightedLoad scalar key; MixedLoad uses weights below.
+		final Map<String, Object> weights = new HashMap<>();
+		weights.put("get", Integer.class);
+		weights.put("put", Integer.class);
+		weights.put("delete", Integer.class);
+		weights.put("stat", Integer.class);
+		op.put("weights", weights);
 		load.put("op", op);
 
 		final Map<String, Object> batch = new HashMap<>();
@@ -165,11 +167,13 @@ class MixedLoadStepClientTest {
 		opLimit.put("fail", opLimitFail);
 		op.put("limit", opLimit);
 		op.put("type", "create");
-		final Map<String, Object> weight = new HashMap<>();
-		weight.put("get", 60);
-		weight.put("put", 25);
-		weight.put("delete", 15);
-		op.put("weight", weight);
+		op.put("weight", 1); // WeightedLoad scalar key; MixedLoad uses weights below.
+		final Map<String, Object> weights = new HashMap<>();
+		weights.put("get", 60);
+		weights.put("put", 25);
+		weights.put("delete", 15);
+		weights.put("stat", 0);
+		op.put("weights", weights);
 		load.put("op", op);
 
 		final Map<String, Object> batch = new HashMap<>();
@@ -288,6 +292,30 @@ class MixedLoadStepClientTest {
 		assertEquals("base-step", client.loadStepId());
 		assertEquals("base-step", withCtx.loadStepId());
 		assertEquals(MixedLoadStepExtension.TYPE, withCtx.getTypeName());
+	}
+
+	@Test
+	@DisplayName("config(Map) accepts mixed weights when weighted scalar weight is present")
+	void testConfigAcceptsMixedWeightsWithWeightedScalarPresent() {
+		final Config cfg = newBaseConfig();
+		final MixedLoadStepClient client = new MixedLoadStepClient(
+						cfg, Collections.<Extension> emptyList(), null, null);
+
+		final MixedLoadStepClient copy = assertDoesNotThrow(
+						() -> client.config(
+										Map.of(
+														"load",
+														Map.of(
+																		"op",
+																		Map.of(
+																						"weights",
+																						Map.of(
+																										"get", 45,
+																										"put", 15,
+																										"delete", 10,
+																										"stat", 30))))));
+
+		assertDoesNotThrow(copy::init);
 	}
 
 	/** Minimal {@link com.dell.spt.base.item.Item} stub for queue tests. */

--- a/engine/tools/jartest.mixed.sh
+++ b/engine/tools/jartest.mixed.sh
@@ -200,7 +200,7 @@ MixedLoad
                 "id": "${STEP_MIXED}"
             },
             "op": {
-                "weight": {
+                "weights": {
                     "get": ${MIXED_GET},
                     "put": ${MIXED_PUT},
                     "delete": ${MIXED_DELETE},


### PR DESCRIPTION
## Summary
Fix `spt run mixed` scenario startup by moving mixed workload operation distribution from `load.op.weight.*` to `load.op.weights.*`.

`WeightedLoad` already uses `load.op.weight` as a scalar value, so the mixed workload's nested `load.op.weight.{get,put,delete,stat}` config collided with the merged confuse schema and failed during scenario validation with `Invalid value path: load-op-weight`.

## Changes
- Update mixed workload schema/defaults to use `load.op.weights.{get,put,delete,stat}`.
- Update `MixedLoadStepClient` and `MixedLoadStepLocal` to read the new config path.
- Update CLI-generated mixed scenarios and `engine/tools/jartest.mixed.sh`.
- Add regression coverage proving mixed weights coexist with the scalar weighted-load key.
- Document the slightly breaking hand-written scenario config change in `CHANGELOG.md`.

## Compatibility Note
CLI-generated mixed scenarios are updated automatically. Hand-written `MixedLoad` scenarios using `load.op.weight.{get,put,delete,stat}` must be changed to `load.op.weights.{get,put,delete,stat}`.
