### PR TITLE
Polish mixed docs and S3 LIST timing

### DIFF
--- a/cli/docs/SPT_SYNTAX.md
+++ b/cli/docs/SPT_SYNTAX.md
@@ -636,7 +636,7 @@ spt run mixed \
 **How it works:**
 
 1. **Seed phase** — writes `--seed-objects` objects to populate the read/delete pools. Skipped when `--read-items-file` is provided.
-2. **Mixed benchmark** — runs for `--duration`, issuing operations at the specified weights. The engine's `MixedLoad` step draws from the item set for GETs, STATs, and DELETEs while PUTs create new objects. Objects created by PUT that are not consumed by DELETE during the benchmark are tracked in a `put-remaining.csv` artifact (fetched to the results directory), giving you an exact inventory of objects left behind.
+2. **Mixed benchmark** — runs for `--duration`, issuing operations at the specified weights. The engine's `MixedLoad` step draws from the item set for GETs, STATs, and DELETEs while PUTs create new objects. PUT-created objects are eligible for DELETE during the benchmark. Exact final reporting of PUT-created objects that remain after mixed DELETEs is deferred.
 3. **Cleanup** (optional, `--cleanup`) — deletes the seed objects and any objects created by PUT operations during the benchmark.
 
 ### Distributed / Attach Mode

--- a/cli/internal/results/fetcher.go
+++ b/cli/internal/results/fetcher.go
@@ -42,7 +42,7 @@ var DefaultArtifacts = []ArtifactSpec{
 	{Loggers: []string{"TablesMetrics"}, Suffix: constants.ResultsArtifactSuffixTablesMetrics, Required: false},
 	// Items CSV (only present when --save-items is used on write workloads)
 	{Loggers: []string{"items.csv"}, Suffix: constants.ResultsArtifactSuffixItems, Required: false},
-	// PUT-remaining CSV (only present on mixed workloads; lists objects created by PUT that may need cleanup)
+	// PUT-created CSV (only present on mixed workloads; exact remaining-set generation is deferred)
 	{Loggers: []string{"put-remaining.csv"}, Suffix: constants.ResultsArtifactSuffixPutRemaining, Required: false},
 	// Ext results XML (Mongoose 3.6 compatible result.xml)
 	{Loggers: []string{"metrics.ExtResultsFile"}, Suffix: constants.ResultsArtifactSuffixExtResults, Required: false},

--- a/engine/extensions/load-steps/mixed/src/main/java/com/dell/spt/load/step/mixed/MixedLoadStepLocal.java
+++ b/engine/extensions/load-steps/mixed/src/main/java/com/dell/spt/load/step/mixed/MixedLoadStepLocal.java
@@ -62,7 +62,8 @@ import static com.github.akurilov.confuse.Config.deepToMap;
  *
  * <p>PUT-created items are:
  * <ol>
- *   <li>Written to {@code put-remaining.csv} so the cleanup phase can delete them.
+ *   <li>Written to {@code put-remaining.csv} for post-run cleanup. Exact remaining-set
+ *       generation is deferred.
  *   <li>Pushed into the {@link PoolItemInput} delete queue so freshly-written objects
  *       are eligible for deletion in the same run.
  * </ol>

--- a/engine/extensions/storage-drivers/implementations/s3-aws/src/main/java/com/dell/spt/storage/driver/coop/aws/s3/S3AwsStorageDriver.java
+++ b/engine/extensions/storage-drivers/implementations/s3-aws/src/main/java/com/dell/spt/storage/driver/coop/aws/s3/S3AwsStorageDriver.java
@@ -780,6 +780,7 @@ public class S3AwsStorageDriver<I extends Item, O extends Operation<I>> extends 
 
 		return s3AsyncClient.listObjectsV2(reqBuilder.build())
 						.thenAccept(resp -> {
+							markListDataResponseStart(listOp);
 							int objectCount = 0;
 							long bytesTotal = 0;
 							String firstKey = null;
@@ -817,6 +818,16 @@ public class S3AwsStorageDriver<I extends Item, O extends Operation<I>> extends 
 							}
 							listOp.countBytesDone(listOp.bytesListed());
 						});
+	}
+
+	private void markListDataResponseStart(final ListOperation<? extends PathItem> op) {
+		if (op.respDataTimeStart() == 0) {
+			try {
+				op.startDataResponse();
+			} catch (final IllegalStateException e) {
+				LOG.debug("{}: failed to mark LIST data response start", op, e);
+			}
+		}
 	}
 
 	/**

--- a/engine/extensions/storage-drivers/implementations/s3-aws/src/test/java/com/dell/spt/storage/driver/coop/aws/s3/S3AwsStorageDriverTest.java
+++ b/engine/extensions/storage-drivers/implementations/s3-aws/src/test/java/com/dell/spt/storage/driver/coop/aws/s3/S3AwsStorageDriverTest.java
@@ -889,6 +889,28 @@ public class S3AwsStorageDriverTest {
 
 		@SuppressWarnings("unchecked")
 		@Test
+		void listStartsDataResponseTimingWhenResponseArrives() throws Exception {
+			ListOperation<PathItem> op = mock(ListOperation.class);
+			PathItem item = mock(PathItem.class);
+			when(op.type()).thenReturn(OpType.LIST);
+			when(op.srcPath()).thenReturn("/mybucket");
+			when(item.name()).thenReturn("");
+			when(op.item()).thenReturn(item);
+			when(op.options()).thenReturn(ListOptions.DEFAULT);
+			when(op.respDataTimeStart()).thenReturn(0L);
+
+			when(mockS3Client.listObjectsV2(any(ListObjectsV2Request.class)))
+							.thenReturn(CompletableFuture.completedFuture(buildListResponse(
+											List.of(S3Object.builder().key("obj1").size(100L).build()),
+											false, null)));
+
+			drv.execute((Operation<Item>) (Operation<?>) op).join();
+
+			verify(op).startDataResponse();
+		}
+
+		@SuppressWarnings("unchecked")
+		@Test
 		void listsWithPrefixFromItemName() throws Exception {
 			ListOperation<PathItem> op = mock(ListOperation.class);
 			PathItem item = mock(PathItem.class);

--- a/engine/extensions/storage-drivers/implementations/s3/src/main/java/com/dell/spt/storage/driver/coop/netty/http/s3/S3ResponseHandler.java
+++ b/engine/extensions/storage-drivers/implementations/s3/src/main/java/com/dell/spt/storage/driver/coop/netty/http/s3/S3ResponseHandler.java
@@ -87,9 +87,21 @@ public final class S3ResponseHandler<I extends Item, O extends Operation<I>>
 		if (op instanceof CompositeDataOperation) {
 			handleInitMultipartUploadResponseContentChunk(channel, contentChunk);
 		} else if (op instanceof ListOperation) {
+			final ListOperation<?> listOp = (ListOperation<?>) op;
+			markListDataResponseStart(listOp, contentChunk.readableBytes());
 			bufferListContent(channel, contentChunk);
 		} else {
 			super.handleResponseContentChunk(channel, op, contentChunk);
+		}
+	}
+
+	private void markListDataResponseStart(final ListOperation<?> op, final int chunkSize) {
+		if (chunkSize > 0 && op.respDataTimeStart() == 0) {
+			try {
+				op.startDataResponse();
+			} catch (final IllegalStateException e) {
+				LogUtil.exception(Level.DEBUG, e, "{}", op.toString());
+			}
 		}
 	}
 

--- a/engine/extensions/storage-drivers/implementations/s3/src/main/java/com/dell/spt/storage/driver/coop/netty/http/s3/S3StorageDriver.java
+++ b/engine/extensions/storage-drivers/implementations/s3/src/main/java/com/dell/spt/storage/driver/coop/netty/http/s3/S3StorageDriver.java
@@ -96,6 +96,8 @@ public class S3StorageDriver<I extends Item, O extends Operation<I>>
 				extends HttpStorageDriverBase<I, O>
 				implements com.dell.spt.base.storage.driver.ListDiscoveryProbe {
 
+	private static final String REDACTED_HEADER_VALUE = "<redacted>";
+
 	protected static final Base64.Encoder BASE64_ENCODER = Base64.getEncoder();
 	protected static final ThreadLocal<SAXParser> THREAD_LOCAL_XML_PARSER = new ThreadLocal<>();
 	protected static final ThreadLocal<StringBuilder> BUFF_CANONICAL = ThreadLocal.withInitial(StringBuilder::new),
@@ -445,7 +447,7 @@ public class S3StorageDriver<I extends Item, O extends Operation<I>>
 		final var bucketPath = SLASH + (slashPos > 0 ? relPath.substring(0, slashPos) : relPath);
 		final var uriQuery = uriQuery();
 		final var uri = uriQuery == null || uriQuery.isEmpty() ? bucketPath : bucketPath + uriQuery;
-		Loggers.MSG.info(
+		Loggers.MSG.debug(
 						"requestNewPath: path={}, relPath={}, bucketPath={}, uri={}",
 						path,
 						relPath,
@@ -460,8 +462,13 @@ public class S3StorageDriver<I extends Item, O extends Operation<I>>
 		applySharedHeaders(reqHeaders);
 		final var credential = pathToCredMap.getOrDefault(uri, this.credential);
 		applyAuthHeaders(reqHeaders, HttpMethod.HEAD, uri, credential);
-		for (final var header : reqHeaders) {
-			Loggers.MSG.info("requestNewPath HEAD header {}: {}", header.getKey(), header.getValue());
+		if (Loggers.MSG.isDebugEnabled()) {
+			for (final var header : reqHeaders) {
+				Loggers.MSG.debug(
+								"requestNewPath HEAD header {}: {}",
+								header.getKey(),
+								safeHeaderValueForLogging(header.getKey(), header.getValue()));
+			}
 		}
 		final FullHttpRequest checkBucketReq = new DefaultFullHttpRequest(
 						HttpVersion.HTTP_1_1,
@@ -561,6 +568,16 @@ public class S3StorageDriver<I extends Item, O extends Operation<I>>
 			}
 		}
 		return path;
+	}
+
+	static String safeHeaderValueForLogging(final String headerName, final String headerValue) {
+		final String normalizedHeaderName = headerName.toLowerCase(Locale.ROOT);
+		if (HttpHeaderNames.AUTHORIZATION.contentEqualsIgnoreCase(headerName) ||
+						HttpHeaderNames.COOKIE.contentEqualsIgnoreCase(headerName) ||
+						"x-amz-security-token".equals(normalizedHeaderName)) {
+			return REDACTED_HEADER_VALUE;
+		}
+		return headerValue;
 	}
 
 	protected void handleCheckBucketVersioningResponse(

--- a/engine/extensions/storage-drivers/implementations/s3/src/test/java/com/dell/spt/storage/driver/coop/netty/http/s3/S3ResponseHandlerListTest.java
+++ b/engine/extensions/storage-drivers/implementations/s3/src/test/java/com/dell/spt/storage/driver/coop/netty/http/s3/S3ResponseHandlerListTest.java
@@ -11,6 +11,7 @@ import com.dell.spt.base.storage.Credential;
 import com.dell.spt.base.storage.driver.ListOptions;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
+import io.netty.channel.embedded.EmbeddedChannel;
 import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.AfterEach;
@@ -57,6 +58,24 @@ final class S3ResponseHandlerListTest {
 		assertTrue(op.truncated());
 		assertEquals("token-123", op.options().continuationToken());
 		assertEquals("token-123", op.continuationToken());
+	}
+
+	@Test
+	void firstListContentChunkStartsDataResponseTiming() throws Exception {
+		final var op = new ListOperationImpl<PathItemImpl>(0, OpType.LIST, new PathItemImpl("prefix"), Credential.NONE);
+
+		final ByteBuf payload = content.retainedDuplicate();
+		final var channel = new EmbeddedChannel();
+		try {
+			assertEquals(0L, op.respDataTimeStart());
+
+			handler.handleResponseContentChunk(channel, op, payload);
+
+			assertTrue(op.respDataTimeStart() > 0, "LIST first-byte timestamp should be captured");
+		} finally {
+			channel.close();
+			payload.release();
+		}
 	}
 
 	private static final String LIST_V2_RESPONSE = "<ListBucketResult>"

--- a/engine/extensions/storage-drivers/implementations/s3/src/test/java/com/dell/spt/storage/driver/coop/netty/http/s3/S3StorageDriverTest.java
+++ b/engine/extensions/storage-drivers/implementations/s3/src/test/java/com/dell/spt/storage/driver/coop/netty/http/s3/S3StorageDriverTest.java
@@ -308,6 +308,26 @@ public class S3StorageDriverTest {
 
 	// ---------- requestNewPath ----------
 	@Test
+	void requestNewPathLogHeaderValue_redactsSensitiveHeaders() {
+		assertEquals(
+						"<redacted>",
+						S3StorageDriver.safeHeaderValueForLogging(
+										HttpHeaderNames.AUTHORIZATION.toString(), "AWS access:signature"));
+		assertEquals(
+						"<redacted>",
+						S3StorageDriver.safeHeaderValueForLogging(
+										HttpHeaderNames.COOKIE.toString(), "session=secret"));
+		assertEquals(
+						"<redacted>",
+						S3StorageDriver.safeHeaderValueForLogging(
+										"x-amz-security-token", "temporary-token"));
+		assertEquals(
+						"bucket.example.com",
+						S3StorageDriver.safeHeaderValueForLogging(
+										HttpHeaderNames.HOST.toString(), "bucket.example.com"));
+	}
+
+	@Test
 	void requestNewPath_createsBucketWhenMissing() throws Exception {
 		Config cfg = baseConfig(false, 2, false, null, "127.0.0.1");
 		TestS3Driver drv = new TestS3Driver(cfg);


### PR DESCRIPTION
## Summary
- Clarify that mixed `put-remaining.csv` is not an exact remaining-object inventory yet
- Demote Netty S3 request path/header diagnostics to DEBUG and redact sensitive header values
- Track LIST first-byte timing in both Netty S3 and AWS SDK S3 drivers
