### PR TITLE
trim confusing load.op weight keys from config.yaml dumps

### DIFF
--- a/engine/core/spt-base/src/main/java/com/dell/spt/base/config/ConfigUtil.java
+++ b/engine/core/spt-base/src/main/java/com/dell/spt/base/config/ConfigUtil.java
@@ -24,6 +24,8 @@ import static com.dell.spt.base.config.ConfigFormat.YAML;
 
 public interface ConfigUtil {
 
+	String MIXED_LOAD_STEP_TYPE = "MixedLoad";
+
 	static ObjectMapper readConfigMapper(final ConfigFormat format, final Map<String, Object> schema)
 					throws NoSuchMethodException {
 		final ObjectMapper mapper;
@@ -80,12 +82,57 @@ public interface ConfigUtil {
 	}
 
 	static String toString(final Config config, final ConfigFormat format) {
+		return toString(config, format, null);
+	}
+
+	static String toString(final Config config, final ConfigFormat format, final String stepTypeName) {
 		try {
 			final var configTree = configTree(config);
+			trimLoadOpNoise(configTree, stepTypeName);
 			return configWriter(format).writeValueAsString(configTree);
 		} catch (final JsonProcessingException e) {
 			throw new RuntimeException(e);
 		}
+	}
+
+	@SuppressWarnings("unchecked")
+	static void trimLoadOpNoise(final Map<String, Object> configTree, final String stepTypeName) {
+		if (configTree == null || stepTypeName == null || stepTypeName.isEmpty()) {
+			return;
+		}
+		final Object loadRaw = configTree.get("load");
+		if (!(loadRaw instanceof Map)) {
+			return;
+		}
+		final var load = (Map<String, Object>) loadRaw;
+		final Object opRaw = load.get("op");
+		if (!(opRaw instanceof Map)) {
+			return;
+		}
+		final var op = (Map<String, Object>) opRaw;
+		if (MIXED_LOAD_STEP_TYPE.equals(stepTypeName)) {
+			final Object weightRaw = op.get("weight");
+			if (weightRaw != null && !(weightRaw instanceof Map)) {
+				op.remove("weight");
+			}
+		} else {
+			op.remove("weights");
+			final Object weightRaw = op.get("weight");
+			if (isLegacyMixedWeightMap(weightRaw)) {
+				op.remove("weight");
+			}
+		}
+	}
+
+	static boolean isLegacyMixedWeightMap(final Object weightRaw) {
+		if (!(weightRaw instanceof Map<?, ?>)) {
+			return false;
+		}
+		final var weightMap = (Map<?, ?>) weightRaw;
+		return weightMap.containsKey("get")
+						|| weightMap.containsKey("put")
+						|| weightMap.containsKey("delete")
+						|| weightMap.containsKey("stat");
 	}
 
 	static Config loadConfig(final File file, final Map<String, Object> schema)

--- a/engine/core/spt-base/src/main/java/com/dell/spt/base/load/step/LoadStepBase.java
+++ b/engine/core/spt-base/src/main/java/com/dell/spt/base/load/step/LoadStepBase.java
@@ -48,7 +48,15 @@ public abstract class LoadStepBase extends DaemonBase implements LoadStep, Runna
 		this.extensions = extensions;
 		this.ctxConfigs = ctxConfigs;
 		this.metricsMgr = metricsMgr;
-		Loggers.CONFIG.info(ConfigUtil.toString(config, ConfigFormat.YAML));
+		Loggers.CONFIG.info(ConfigUtil.toString(config, ConfigFormat.YAML, resolveStepTypeName()));
+	}
+
+	private String resolveStepTypeName() {
+		try {
+			return getTypeName();
+		} catch (final Exception e) {
+			return null;
+		}
 	}
 
 	@Override

--- a/engine/core/spt-base/src/test/java/com/dell/spt/base/config/ConfigUtilTest.java
+++ b/engine/core/spt-base/src/test/java/com/dell/spt/base/config/ConfigUtilTest.java
@@ -2,6 +2,8 @@ package com.dell.spt.base.config;
 
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.util.HashMap;
@@ -30,5 +32,94 @@ public class ConfigUtilTest {
 		assertEquals("123", dstMap.get("a-bb"));
 		assertEquals("yohoho", dstMap.get("b-aa"));
 		assertEquals("true", dstMap.get("b-bb"));
+	}
+
+	@Test
+	public void testTrimLoadOpNoiseMixedRemovesScalarWeightOnly() {
+		final Map<String, Object> configTree = new HashMap<>();
+		final Map<String, Object> load = new HashMap<>();
+		final Map<String, Object> op = new HashMap<>();
+		final Map<String, Object> weights = new HashMap<>();
+		weights.put("get", 50);
+		weights.put("put", 50);
+		weights.put("delete", 0);
+		weights.put("stat", 0);
+		op.put("weight", 1);
+		op.put("weights", weights);
+		load.put("op", op);
+		configTree.put("load", load);
+
+		ConfigUtil.trimLoadOpNoise(configTree, ConfigUtil.MIXED_LOAD_STEP_TYPE);
+
+		assertNull(op.get("weight"));
+		assertNotNull(op.get("weights"));
+	}
+
+	@Test
+	public void testTrimLoadOpNoiseNonMixedRemovesWeightsAndLegacyWeightMap() {
+		final Map<String, Object> configTree = new HashMap<>();
+		final Map<String, Object> load = new HashMap<>();
+		final Map<String, Object> op = new HashMap<>();
+		final Map<String, Object> legacyWeightMap = new HashMap<>();
+		legacyWeightMap.put("get", 45);
+		legacyWeightMap.put("put", 15);
+		legacyWeightMap.put("delete", 10);
+		legacyWeightMap.put("stat", 30);
+		final Map<String, Object> weights = new HashMap<>();
+		weights.put("get", 45);
+		weights.put("put", 15);
+		weights.put("delete", 10);
+		weights.put("stat", 30);
+		op.put("weight", legacyWeightMap);
+		op.put("weights", weights);
+		load.put("op", op);
+		configTree.put("load", load);
+
+		ConfigUtil.trimLoadOpNoise(configTree, "Load");
+
+		assertNull(op.get("weight"));
+		assertNull(op.get("weights"));
+	}
+
+	@Test
+	public void testTrimLoadOpNoiseNonMixedKeepsScalarWeight() {
+		final Map<String, Object> configTree = new HashMap<>();
+		final Map<String, Object> load = new HashMap<>();
+		final Map<String, Object> op = new HashMap<>();
+		final Map<String, Object> weights = new HashMap<>();
+		weights.put("get", 45);
+		weights.put("put", 15);
+		weights.put("delete", 10);
+		weights.put("stat", 30);
+		op.put("weight", 1);
+		op.put("weights", weights);
+		load.put("op", op);
+		configTree.put("load", load);
+
+		ConfigUtil.trimLoadOpNoise(configTree, "Load");
+
+		assertEquals(1, op.get("weight"));
+		assertNull(op.get("weights"));
+	}
+
+	@Test
+	public void testTrimLoadOpNoiseGuardReturns() {
+		assertDoesNotThrow(() -> ConfigUtil.trimLoadOpNoise(null, "Load"));
+		assertDoesNotThrow(() -> ConfigUtil.trimLoadOpNoise(new HashMap<>(), null));
+		assertDoesNotThrow(() -> ConfigUtil.trimLoadOpNoise(new HashMap<>(), ""));
+
+		final Map<String, Object> configTreeWithNonMapLoad = new HashMap<>();
+		configTreeWithNonMapLoad.put("load", 1);
+		assertDoesNotThrow(() -> ConfigUtil.trimLoadOpNoise(configTreeWithNonMapLoad, "Load"));
+
+		final Map<String, Object> configTreeWithoutOp = new HashMap<>();
+		configTreeWithoutOp.put("load", new HashMap<>());
+		assertDoesNotThrow(() -> ConfigUtil.trimLoadOpNoise(configTreeWithoutOp, "Load"));
+
+		final Map<String, Object> configTreeWithNonMapOp = new HashMap<>();
+		final Map<String, Object> load = new HashMap<>();
+		load.put("op", 1);
+		configTreeWithNonMapOp.put("load", load);
+		assertDoesNotThrow(() -> ConfigUtil.trimLoadOpNoise(configTreeWithNonMapOp, "Load"));
 	}
 }

--- a/engine/extensions/load-steps/weighted/src/main/java/com/dell/spt/load/step/weighted/WeightedLoadStepLocal.java
+++ b/engine/extensions/load-steps/weighted/src/main/java/com/dell/spt/load/step/weighted/WeightedLoadStepLocal.java
@@ -204,7 +204,7 @@ public class WeightedLoadStepLocal extends LoadStepLocalBase {
 
 						// Overwrite step config with sub step config
 						ThreadContext.put(Constants.KEY_STEP_ID, testStepId);
-						Loggers.CONFIG.info(ConfigUtil.toString(subConfig, ConfigFormat.YAML));
+						Loggers.CONFIG.info(ConfigUtil.toString(subConfig, ConfigFormat.YAML, getTypeName()));
 					} catch (final IllegalConfigurationException e) {
 						throw new IllegalStateException("Failed to initialize the load generator", e);
 					}


### PR DESCRIPTION
## Summary
- apply step-type-aware config dump trimming in `ConfigUtil` to reduce confusing `load.op` keys in `config.yaml`
  - `MixedLoad` keeps `load.op.weights` and drops scalar `load.op.weight`
  - non-`MixedLoad` keeps scalar `load.op.weight`, drops `load.op.weights`, and removes legacy mixed-style map values under `load.op.weight`
- pass step type through `LoadStepBase` when serializing config dumps
- update weighted sub-step config serialization to use the same step-type-aware serializer
- add `ConfigUtilTest` coverage for mixed/non-mixed behavior plus guard-return paths
