### PR TITLE
Fix headless premature completion detection

### DIFF
--- a/cli/internal/constants/limits.go
+++ b/cli/internal/constants/limits.go
@@ -1,0 +1,16 @@
+/*
+Copyright © 2025 Dell Technologies
+*/
+
+package constants
+
+// Limit types reported by Spt node metrics payloads (the `limit.type` field of
+// the JSON metrics API). These govern how a load step decides it is complete.
+const (
+	// LimitTypeNone indicates an unbounded run (no time or op-count limit).
+	LimitTypeNone = "none"
+	// LimitTypeTime indicates a duration-bounded run (limit.time_sec).
+	LimitTypeTime = "time"
+	// LimitTypeOpCount indicates an operation-count-bounded run (limit.op_count).
+	LimitTypeOpCount = "op_count"
+)

--- a/cli/tui/completion_detection_test.go
+++ b/cli/tui/completion_detection_test.go
@@ -1,0 +1,98 @@
+package tui
+
+import (
+	"testing"
+
+	"github.com/dell/storage-performance-tool/cli/internal/constants"
+)
+
+// timeBoundedNode builds a per-node metric for a time-bounded run.
+func timeBoundedNode(nodeID string, state int, stepTime float64, limitSec int64) *PerformanceMetric {
+	m := newNodeMetric(nodeID, 100.0, 1000, 1000, 0, 0, 5.0, state)
+	m.HasLimit = true
+	m.LimitType = constants.LimitTypeTime
+	m.LimitTimeSec = limitSec
+	m.StepTime = stepTime
+	return m
+}
+
+// opCountBoundedNode builds a per-node metric for an op-count-bounded run.
+func opCountBoundedNode(nodeID string, state int, completionPercent float64, limitOps int64) *PerformanceMetric {
+	m := newNodeMetric(nodeID, 100.0, 500, 500, 0, 0, 5.0, state)
+	m.HasLimit = true
+	m.LimitType = constants.LimitTypeOpCount
+	m.LimitOpCount = limitOps
+	m.CompletionPercent = completionPercent
+	return m
+}
+
+// Finding 1 regression: a genuinely-completed, time-bounded run must be
+// detected as complete after running through the real aggregator. Before the
+// aggregator propagated StepTime/limit fields, the aggregate had StepTime=0 and
+// HasLimit=false, so this hung (or never required the time guard at all).
+func TestShouldSignalCompletion_TimeBounded_GenuineThroughAggregate(t *testing.T) {
+	agg := NewMetricsAggregator()
+	agg.AddNodeMetrics("node1", timeBoundedNode("node1", constants.TestStateCompleted, 120, 120))
+	agg.AddNodeMetrics("node2", timeBoundedNode("node2", constants.TestStateCompleted, 121, 120))
+
+	result := agg.Aggregate()
+	if result == nil {
+		t.Fatal("expected non-nil aggregate")
+	}
+	if !shouldSignalCompletion(result) {
+		t.Errorf("expected completion to be signalled for genuine time-bounded run; aggregate StepTime=%v HasLimit=%v LimitType=%q LimitTimeSec=%d",
+			result.StepTime, result.HasLimit, result.LimitType, result.LimitTimeSec)
+	}
+}
+
+// Finding 1: a transient Completed state before the duration elapses must NOT
+// signal completion, through the real aggregator.
+func TestShouldSignalCompletion_TimeBounded_TransientThroughAggregate(t *testing.T) {
+	agg := NewMetricsAggregator()
+	agg.AddNodeMetrics("node1", timeBoundedNode("node1", constants.TestStateCompleted, 5, 120))
+	agg.AddNodeMetrics("node2", timeBoundedNode("node2", constants.TestStateCompleted, 4, 120))
+
+	result := agg.Aggregate()
+	if result == nil {
+		t.Fatal("expected non-nil aggregate")
+	}
+	if shouldSignalCompletion(result) {
+		t.Errorf("expected completion NOT to be signalled for transient time-bounded run; aggregate StepTime=%v (limit %d)",
+			result.StepTime, result.LimitTimeSec)
+	}
+}
+
+// Finding 2 (CLI defense-in-depth): an op-count run that reports Completed but
+// has not reached 100% across the fleet must NOT signal completion.
+func TestShouldSignalCompletion_OpCount_TransientThroughAggregate(t *testing.T) {
+	agg := NewMetricsAggregator()
+	// node1 fully done, node2 lagging -> fleet completion is the MIN.
+	agg.AddNodeMetrics("node1", opCountBoundedNode("node1", constants.TestStateCompleted, 100, 1000))
+	agg.AddNodeMetrics("node2", opCountBoundedNode("node2", constants.TestStateCompleted, 40, 1000))
+
+	result := agg.Aggregate()
+	if result == nil {
+		t.Fatal("expected non-nil aggregate")
+	}
+	if shouldSignalCompletion(result) {
+		t.Errorf("expected completion NOT to be signalled for transient op-count run; aggregate CompletionPercent=%v",
+			result.CompletionPercent)
+	}
+}
+
+// Finding 2 (CLI defense-in-depth): a genuinely-complete op-count run (every
+// node at 100%) must signal completion.
+func TestShouldSignalCompletion_OpCount_GenuineThroughAggregate(t *testing.T) {
+	agg := NewMetricsAggregator()
+	agg.AddNodeMetrics("node1", opCountBoundedNode("node1", constants.TestStateCompleted, 100, 1000))
+	agg.AddNodeMetrics("node2", opCountBoundedNode("node2", constants.TestStateCompleted, 100, 1000))
+
+	result := agg.Aggregate()
+	if result == nil {
+		t.Fatal("expected non-nil aggregate")
+	}
+	if !shouldSignalCompletion(result) {
+		t.Errorf("expected completion to be signalled for genuine op-count run; aggregate CompletionPercent=%v",
+			result.CompletionPercent)
+	}
+}

--- a/cli/tui/completion_detection_test.go
+++ b/cli/tui/completion_detection_test.go
@@ -8,7 +8,9 @@ import (
 
 // timeBoundedNode builds a per-node metric for a time-bounded run.
 func timeBoundedNode(nodeID string, state int, stepTime float64, limitSec int64) *PerformanceMetric {
-	m := newNodeMetric(nodeID, 100.0, 1000, 1000, 0, 0, 5.0, state)
+	m := newNodeMetric(100, 0, 1000, 0, 0, 0, 5, 5.0)
+	m.NodeID = nodeID
+	m.TestState = state
 	m.HasLimit = true
 	m.LimitType = constants.LimitTypeTime
 	m.LimitTimeSec = limitSec
@@ -18,7 +20,10 @@ func timeBoundedNode(nodeID string, state int, stepTime float64, limitSec int64)
 
 // opCountBoundedNode builds a per-node metric for an op-count-bounded run.
 func opCountBoundedNode(nodeID string, state int, completionPercent float64, limitOps int64) *PerformanceMetric {
-	m := newNodeMetric(nodeID, 100.0, 500, 500, 0, 0, 5.0, state)
+	completedOps := int64((completionPercent / 100) * float64(limitOps))
+	m := newNodeMetric(100, 0, completedOps, 0, 0, 0, 5, 5.0)
+	m.NodeID = nodeID
+	m.TestState = state
 	m.HasLimit = true
 	m.LimitType = constants.LimitTypeOpCount
 	m.LimitOpCount = limitOps
@@ -32,10 +37,11 @@ func opCountBoundedNode(nodeID string, state int, completionPercent float64, lim
 // HasLimit=false, so this hung (or never required the time guard at all).
 func TestShouldSignalCompletion_TimeBounded_GenuineThroughAggregate(t *testing.T) {
 	agg := NewMetricsAggregator()
-	agg.AddNodeMetrics("node1", timeBoundedNode("node1", constants.TestStateCompleted, 120, 120))
-	agg.AddNodeMetrics("node2", timeBoundedNode("node2", constants.TestStateCompleted, 121, 120))
 
-	result := agg.Aggregate()
+	result := agg.Aggregate(map[string]*PerformanceMetric{
+		"node1": timeBoundedNode("node1", constants.TestStateCompleted, 120, 120),
+		"node2": timeBoundedNode("node2", constants.TestStateCompleted, 121, 120),
+	})
 	if result == nil {
 		t.Fatal("expected non-nil aggregate")
 	}
@@ -49,10 +55,11 @@ func TestShouldSignalCompletion_TimeBounded_GenuineThroughAggregate(t *testing.T
 // signal completion, through the real aggregator.
 func TestShouldSignalCompletion_TimeBounded_TransientThroughAggregate(t *testing.T) {
 	agg := NewMetricsAggregator()
-	agg.AddNodeMetrics("node1", timeBoundedNode("node1", constants.TestStateCompleted, 5, 120))
-	agg.AddNodeMetrics("node2", timeBoundedNode("node2", constants.TestStateCompleted, 4, 120))
 
-	result := agg.Aggregate()
+	result := agg.Aggregate(map[string]*PerformanceMetric{
+		"node1": timeBoundedNode("node1", constants.TestStateCompleted, 5, 120),
+		"node2": timeBoundedNode("node2", constants.TestStateCompleted, 4, 120),
+	})
 	if result == nil {
 		t.Fatal("expected non-nil aggregate")
 	}
@@ -66,11 +73,12 @@ func TestShouldSignalCompletion_TimeBounded_TransientThroughAggregate(t *testing
 // has not reached 100% across the fleet must NOT signal completion.
 func TestShouldSignalCompletion_OpCount_TransientThroughAggregate(t *testing.T) {
 	agg := NewMetricsAggregator()
-	// node1 fully done, node2 lagging -> fleet completion is the MIN.
-	agg.AddNodeMetrics("node1", opCountBoundedNode("node1", constants.TestStateCompleted, 100, 1000))
-	agg.AddNodeMetrics("node2", opCountBoundedNode("node2", constants.TestStateCompleted, 40, 1000))
+	// node1 fully done, node2 lagging -> fleet completion remains below 100%.
 
-	result := agg.Aggregate()
+	result := agg.Aggregate(map[string]*PerformanceMetric{
+		"node1": opCountBoundedNode("node1", constants.TestStateCompleted, 100, 1000),
+		"node2": opCountBoundedNode("node2", constants.TestStateCompleted, 40, 1000),
+	})
 	if result == nil {
 		t.Fatal("expected non-nil aggregate")
 	}
@@ -84,10 +92,11 @@ func TestShouldSignalCompletion_OpCount_TransientThroughAggregate(t *testing.T) 
 // node at 100%) must signal completion.
 func TestShouldSignalCompletion_OpCount_GenuineThroughAggregate(t *testing.T) {
 	agg := NewMetricsAggregator()
-	agg.AddNodeMetrics("node1", opCountBoundedNode("node1", constants.TestStateCompleted, 100, 1000))
-	agg.AddNodeMetrics("node2", opCountBoundedNode("node2", constants.TestStateCompleted, 100, 1000))
 
-	result := agg.Aggregate()
+	result := agg.Aggregate(map[string]*PerformanceMetric{
+		"node1": opCountBoundedNode("node1", constants.TestStateCompleted, 100, 1000),
+		"node2": opCountBoundedNode("node2", constants.TestStateCompleted, 100, 1000),
+	})
 	if result == nil {
 		t.Fatal("expected non-nil aggregate")
 	}

--- a/cli/tui/metrics_aggregator.go
+++ b/cli/tui/metrics_aggregator.go
@@ -374,21 +374,16 @@ func AggregateByOpType(metrics []*PerformanceMetric) (combined *PerformanceMetri
 // detection (shouldSignalCompletion) has the data it needs.
 //
 //   - StepTime: MAX across nodes (the most-progressed elapsed time).
-//   - CompletionPercent: MIN across nodes (the slowest node represents true
-//     fleet completion).
-//   - HasLimit/LimitType/LimitTimeSec/LimitOpCount: taken from any node that
-//     reports a limit (these are identical per-step across nodes).
-//   - Unbounded: true if any node reports it.
+//   - HasLimit/LimitType/LimitTimeSec/LimitOpCount: filled from a node only when
+//     the aggregate has not already computed them.
 func applyProgressAndLimitFields(result *PerformanceMetric, metrics []*PerformanceMetric) {
 	if result == nil || len(metrics) == 0 {
 		return
 	}
 
 	var (
-		maxStepTime   float64
-		minCompletion float64
-		completionSet bool
-		limitSet      bool
+		maxStepTime float64
+		limitSet    = result.HasLimit
 	)
 
 	for _, m := range metrics {
@@ -398,15 +393,8 @@ func applyProgressAndLimitFields(result *PerformanceMetric, metrics []*Performan
 		if m.StepTime > maxStepTime {
 			maxStepTime = m.StepTime
 		}
-		if !completionSet || m.CompletionPercent < minCompletion {
-			minCompletion = m.CompletionPercent
-			completionSet = true
-		}
-		if m.Unbounded {
-			result.Unbounded = true
-		}
-		// Limit metadata is identical per-step across nodes; take it from the
-		// first node that actually reports a limit.
+		// Limit metadata is identical per-step across nodes. Preserve any aggregate
+		// values already computed by the caller, such as summed op-count limits.
 		if !limitSet && m.HasLimit {
 			result.HasLimit = m.HasLimit
 			result.LimitType = m.LimitType
@@ -417,7 +405,4 @@ func applyProgressAndLimitFields(result *PerformanceMetric, metrics []*Performan
 	}
 
 	result.StepTime = maxStepTime
-	if completionSet {
-		result.CompletionPercent = minCompletion
-	}
 }

--- a/cli/tui/metrics_aggregator.go
+++ b/cli/tui/metrics_aggregator.go
@@ -222,6 +222,12 @@ func (ma *MetricsAggregator) sumWorkerMetrics(nodeMetrics map[string]*Performanc
 	}
 	result.Timestamp = latestTimestamp
 
+	nodeList := make([]*PerformanceMetric, 0, len(nodeMetrics))
+	for _, metric := range nodeMetrics {
+		nodeList = append(nodeList, metric)
+	}
+	applyProgressAndLimitFields(&result, nodeList)
+
 	return &result
 }
 
@@ -358,5 +364,60 @@ func AggregateByOpType(metrics []*PerformanceMetric) (combined *PerformanceMetri
 	agg.Unbounded = first.Unbounded
 	agg.OverallUnbounded = first.OverallUnbounded
 
+	applyProgressAndLimitFields(&agg, metrics)
+
 	return &agg, perOp
+}
+
+// applyProgressAndLimitFields propagates per-step progress and limit metadata
+// from the per-node metrics onto an aggregate result so that completion
+// detection (shouldSignalCompletion) has the data it needs.
+//
+//   - StepTime: MAX across nodes (the most-progressed elapsed time).
+//   - CompletionPercent: MIN across nodes (the slowest node represents true
+//     fleet completion).
+//   - HasLimit/LimitType/LimitTimeSec/LimitOpCount: taken from any node that
+//     reports a limit (these are identical per-step across nodes).
+//   - Unbounded: true if any node reports it.
+func applyProgressAndLimitFields(result *PerformanceMetric, metrics []*PerformanceMetric) {
+	if result == nil || len(metrics) == 0 {
+		return
+	}
+
+	var (
+		maxStepTime   float64
+		minCompletion float64
+		completionSet bool
+		limitSet      bool
+	)
+
+	for _, m := range metrics {
+		if m == nil {
+			continue
+		}
+		if m.StepTime > maxStepTime {
+			maxStepTime = m.StepTime
+		}
+		if !completionSet || m.CompletionPercent < minCompletion {
+			minCompletion = m.CompletionPercent
+			completionSet = true
+		}
+		if m.Unbounded {
+			result.Unbounded = true
+		}
+		// Limit metadata is identical per-step across nodes; take it from the
+		// first node that actually reports a limit.
+		if !limitSet && m.HasLimit {
+			result.HasLimit = m.HasLimit
+			result.LimitType = m.LimitType
+			result.LimitTimeSec = m.LimitTimeSec
+			result.LimitOpCount = m.LimitOpCount
+			limitSet = true
+		}
+	}
+
+	result.StepTime = maxStepTime
+	if completionSet {
+		result.CompletionPercent = minCompletion
+	}
 }

--- a/cli/tui/orchestrator_multi.go
+++ b/cli/tui/orchestrator_multi.go
@@ -1012,6 +1012,13 @@ func shouldSignalCompletion(agg *PerformanceMetric) bool {
 	if agg.HasLimit && agg.LimitType == constants.LimitTypeTime && agg.LimitTimeSec > 0 {
 		return agg.StepTime >= float64(agg.LimitTimeSec)
 	}
+	// For op-count-bounded runs, require the fleet to have reached 100% completion
+	// before trusting the Completed state. CompletionPercent is normalization-safe
+	// across N nodes (it is the slowest node's progress); comparing a summed
+	// SuccessCount against a per-node LimitOpCount would be wrong once aggregated.
+	if agg.HasLimit && agg.LimitType == constants.LimitTypeOpCount {
+		return agg.CompletionPercent >= 100
+	}
 	return true
 }
 

--- a/cli/tui/orchestrator_multi.go
+++ b/cli/tui/orchestrator_multi.go
@@ -983,13 +983,36 @@ func (m *MultiHostTestOrchestrator) metricsPollingLoop(ctx context.Context) {
 			if update != nil && m.onMetrics != nil {
 				m.onMetrics(update)
 			}
-			if update != nil && update.Aggregated != nil && update.Aggregated.TestState >= constants.TestStateCompleted {
+			if update != nil && shouldSignalCompletion(update.Aggregated) {
 				m.signalCompletion()
 			}
 		case <-ctx.Done():
 			return
 		}
 	}
+}
+
+// shouldSignalCompletion reports whether an aggregated metrics sample indicates
+// the distributed test has truly finished and the headless coordinator should
+// stop.
+//
+// The engine reports test_state=Completed whenever operations have started but
+// the instantaneous concurrency is 0. The asynchronous Netty S3 driver hits that
+// transiently between operations at low thread counts, so a single Completed
+// sample is not a reliable end-of-test signal: in headless mode it caused
+// duration-bounded runs to abort within seconds of starting. For a time-bounded
+// run we therefore only honor completion once the configured duration has
+// actually elapsed (StepTime carries the engine-reported elapsed_time_seconds).
+// Op-count and unbounded runs are guarded by the engine-side fix and keep the
+// prior trust-the-state behavior here.
+func shouldSignalCompletion(agg *PerformanceMetric) bool {
+	if agg == nil || agg.TestState < constants.TestStateCompleted {
+		return false
+	}
+	if agg.HasLimit && agg.LimitType == constants.LimitTypeTime && agg.LimitTimeSec > 0 {
+		return agg.StepTime >= float64(agg.LimitTimeSec)
+	}
+	return true
 }
 
 // collectAllMetrics polls all ready hosts and creates a MultiNodeMetricsUpdate

--- a/cli/tui/orchestrator_multi_completion_test.go
+++ b/cli/tui/orchestrator_multi_completion_test.go
@@ -1,0 +1,96 @@
+/*
+Copyright © 2025 Dell Technologies
+*/
+
+package tui
+
+import (
+	"testing"
+
+	"github.com/dell/storage-performance-tool/cli/internal/constants"
+)
+
+// TestShouldSignalCompletion proves and guards the fix for premature headless
+// completion: the engine reports test_state=Completed whenever ops have started
+// but instantaneous concurrency is 0. The async Netty driver hits that
+// transiently between operations at low thread counts, so the headless
+// coordinator used to abort a duration-bounded run within seconds of starting.
+func TestShouldSignalCompletion(t *testing.T) {
+	tests := []struct {
+		name string
+		agg  *PerformanceMetric
+		want bool
+	}{
+		{
+			name: "nil aggregate never completes",
+			agg:  nil,
+			want: false,
+		},
+		{
+			name: "running state does not complete",
+			agg:  &PerformanceMetric{TestState: constants.TestStateRunning},
+			want: false,
+		},
+		{
+			// THE FAULT: transient Completed only 5s into a 120s run.
+			name: "transient completed during time-bounded run does not complete",
+			agg: &PerformanceMetric{
+				TestState:    constants.TestStateCompleted,
+				HasLimit:     true,
+				LimitType:    constants.LimitTypeTime,
+				LimitTimeSec: 120,
+				StepTime:     5,
+			},
+			want: false,
+		},
+		{
+			name: "completed at time limit completes",
+			agg: &PerformanceMetric{
+				TestState:    constants.TestStateCompleted,
+				HasLimit:     true,
+				LimitType:    constants.LimitTypeTime,
+				LimitTimeSec: 120,
+				StepTime:     120,
+			},
+			want: true,
+		},
+		{
+			name: "completed past time limit completes",
+			agg: &PerformanceMetric{
+				TestState:    constants.TestStateCompleted,
+				HasLimit:     true,
+				LimitType:    constants.LimitTypeTime,
+				LimitTimeSec: 120,
+				StepTime:     130,
+			},
+			want: true,
+		},
+		{
+			// Op-count and unbounded runs are covered by the engine-side fix;
+			// the CLI guard preserves the prior trust-the-state behavior for them.
+			name: "completed op-count run completes",
+			agg: &PerformanceMetric{
+				TestState: constants.TestStateCompleted,
+				HasLimit:  true,
+				LimitType: constants.LimitTypeOpCount,
+			},
+			want: true,
+		},
+		{
+			name: "completed unbounded run completes",
+			agg: &PerformanceMetric{
+				TestState: constants.TestStateCompleted,
+				HasLimit:  false,
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := shouldSignalCompletion(tt.agg); got != tt.want {
+				t.Errorf("shouldSignalCompletion() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/cli/tui/orchestrator_multi_completion_test.go
+++ b/cli/tui/orchestrator_multi_completion_test.go
@@ -66,13 +66,22 @@ func TestShouldSignalCompletion(t *testing.T) {
 			want: true,
 		},
 		{
-			// Op-count and unbounded runs are covered by the engine-side fix;
-			// the CLI guard preserves the prior trust-the-state behavior for them.
-			name: "completed op-count run completes",
+			name: "completed op-count below 100 percent does not complete",
 			agg: &PerformanceMetric{
-				TestState: constants.TestStateCompleted,
-				HasLimit:  true,
-				LimitType: constants.LimitTypeOpCount,
+				TestState:         constants.TestStateCompleted,
+				HasLimit:          true,
+				LimitType:         constants.LimitTypeOpCount,
+				CompletionPercent: 99,
+			},
+			want: false,
+		},
+		{
+			name: "completed op-count at 100 percent completes",
+			agg: &PerformanceMetric{
+				TestState:         constants.TestStateCompleted,
+				HasLimit:          true,
+				LimitType:         constants.LimitTypeOpCount,
+				CompletionPercent: 100,
 			},
 			want: true,
 		},

--- a/engine/core/spt-base/src/main/java/com/dell/spt/base/control/MetricsJsonResponder.java
+++ b/engine/core/spt-base/src/main/java/com/dell/spt/base/control/MetricsJsonResponder.java
@@ -137,7 +137,7 @@ final class MetricsJsonResponder {
 			cachedProgress = true;
 		}
 
-		final int testState = calculateTestState(snapshot, successCount, failCount);
+		final int testState = calculateTestState(ctx.metadata(), elapsedMillis, snapshot, successCount, failCount);
 		final int completionPercent = calculateCompletionPercent(ctx.metadata(), successCount, failCount, elapsedMillis);
 
 		final ObjectNode jsonObj = objectMapper.createObjectNode();
@@ -205,7 +205,7 @@ final class MetricsJsonResponder {
 			cachedProgress = true;
 		}
 
-		final int testState = calculateTestState(snapshot, successCount, failCount);
+		final int testState = calculateTestState(ctx.metadata(), elapsedMillis, snapshot, successCount, failCount);
 		final int completionPercent = calculateCompletionPercent(ctx.metadata(), successCount, failCount, elapsedMillis);
 
 		final ObjectNode jsonObj = objectMapper.createObjectNode();
@@ -624,13 +624,27 @@ final class MetricsJsonResponder {
 		}
 	}
 
-	private int calculateTestState(final AllMetricsSnapshot snapshot, final long successCount, final long failsCount) {
+	private int calculateTestState(
+					final java.util.Map meta, final long elapsedMillis,
+					final AllMetricsSnapshot snapshot, final long successCount, final long failsCount) {
 		final long totalOps = successCount + failsCount;
-		if (totalOps > 0) {
-			final long concurrency = snapshot.concurrencySnapshot().last();
-			return concurrency > 0 ? 1 : 2;
+		if (totalOps <= 0) {
+			return 1; // running: no operations issued yet
 		}
-		return 1;
+		final long concurrency = snapshot.concurrencySnapshot().last();
+		if (concurrency > 0) {
+			return 1; // running: operations in flight
+		}
+		// concurrency == 0 with operations already issued is ambiguous: it can be a
+		// genuine end-of-test, or merely a transient gap between asynchronous
+		// operations (e.g. the Netty S3 driver releases its concurrency permit
+		// between ops at low thread counts). For a duration-bounded run, do not
+		// report Completed until the configured time limit has actually elapsed.
+		final long timeLimitSec = metadataLong(meta, MetricsConstants.METADATA_LIMIT_TIME_SEC);
+		if (timeLimitSec > 0 && elapsedMillis < timeLimitSec * 1000L) {
+			return 1; // still within the configured duration: transient gap, not done
+		}
+		return 2; // completed
 	}
 
 	private int calculateCompletionPercent(

--- a/engine/core/spt-base/src/main/java/com/dell/spt/base/control/MetricsJsonResponder.java
+++ b/engine/core/spt-base/src/main/java/com/dell/spt/base/control/MetricsJsonResponder.java
@@ -644,6 +644,14 @@ final class MetricsJsonResponder {
 		if (timeLimitSec > 0 && elapsedMillis < timeLimitSec * 1000L) {
 			return 1; // still within the configured duration: transient gap, not done
 		}
+		// Op-count-bounded runs hit the same transient concurrency==0 gap. countLimit
+		// is per-node/per-context here (calculateTestState runs per context), matching
+		// the per-context totalOps, so do not report Completed until the configured
+		// operation count has actually been reached.
+		final long countLimit = metadataLong(meta, MetricsConstants.METADATA_LIMIT_OP_COUNT);
+		if (countLimit > 0 && totalOps < countLimit) {
+			return 1; // still below the configured op count: transient gap, not done
+		}
 		return 2; // completed
 	}
 

--- a/engine/core/spt-base/src/test/java/com/dell/spt/base/control/MetricsJsonResponderTest.java
+++ b/engine/core/spt-base/src/test/java/com/dell/spt/base/control/MetricsJsonResponderTest.java
@@ -641,6 +641,63 @@ public class MetricsJsonResponderTest {
 		return snapshot;
 	}
 
+	@Test
+	void clusterMetricsStayRunningWhenConcurrencyTransientlyZeroBeforeTimeLimit() throws Exception {
+		// Regression: the Netty S3 driver releases its concurrency permit between
+		// asynchronous operations, so concurrency momentarily hits 0 with ops
+		// already issued. For a duration-bounded run the engine must NOT report
+		// Completed until the configured time has elapsed, or headless coordinators
+		// abort the run within seconds of starting.
+		final DistributedAllMetricsSnapshot snapshot = mockDistributedSnapshot(80L, 0L, 5_000L);
+		final DistributedMetricsContext ctx = mockDistributedContext("step-transient", OpType.CREATE, snapshot,
+						Map.of(MetricsConstants.METADATA_LIMIT_TIME_SEC, 60L));
+
+		final MetricsManager mgr = mock(MetricsManager.class);
+		when(mgr.getDistributedContexts()).thenReturn(Set.of(ctx));
+		when(mgr.getAllContexts()).thenReturn(Set.of());
+		when(mgr.getTerminalSteps()).thenReturn(List.of());
+
+		final MetricsJsonResponder responder = new MetricsJsonResponder(mgr, defaultConfig());
+		final ArrayNode payload = responder.buildClusterMetrics(false);
+
+		JsonNode obj = null;
+		for (final JsonNode node : payload) {
+			if ("step-transient".equals(node.get("step_id").asText())) {
+				obj = node;
+			}
+		}
+		assertNotNull(obj, "expected metrics for step-transient");
+		assertEquals(1, obj.get("test_state").asInt(),
+						"transient concurrency==0 only 5s into a 60s run must report Running, not Completed");
+	}
+
+	@Test
+	void clusterMetricsReportCompletedWhenConcurrencyZeroAfterTimeLimit() throws Exception {
+		// Positive path: once the configured duration has elapsed, concurrency==0
+		// with operations issued is a genuine completion.
+		final DistributedAllMetricsSnapshot snapshot = mockDistributedSnapshot(80L, 0L, 65_000L);
+		final DistributedMetricsContext ctx = mockDistributedContext("step-done", OpType.CREATE, snapshot,
+						Map.of(MetricsConstants.METADATA_LIMIT_TIME_SEC, 60L));
+
+		final MetricsManager mgr = mock(MetricsManager.class);
+		when(mgr.getDistributedContexts()).thenReturn(Set.of(ctx));
+		when(mgr.getAllContexts()).thenReturn(Set.of());
+		when(mgr.getTerminalSteps()).thenReturn(List.of());
+
+		final MetricsJsonResponder responder = new MetricsJsonResponder(mgr, defaultConfig());
+		final ArrayNode payload = responder.buildClusterMetrics(false);
+
+		JsonNode obj = null;
+		for (final JsonNode node : payload) {
+			if ("step-done".equals(node.get("step_id").asText())) {
+				obj = node;
+			}
+		}
+		assertNotNull(obj, "expected metrics for step-done");
+		assertEquals(2, obj.get("test_state").asInt(),
+						"concurrency==0 after the configured duration must report Completed");
+	}
+
 	private static AllMetricsSnapshot mockNodeSnapshot(
 					final long succCount,
 					final long failCount,

--- a/engine/core/spt-base/src/test/java/com/dell/spt/base/control/MetricsJsonResponderTest.java
+++ b/engine/core/spt-base/src/test/java/com/dell/spt/base/control/MetricsJsonResponderTest.java
@@ -672,6 +672,34 @@ public class MetricsJsonResponderTest {
 	}
 
 	@Test
+	void clusterMetricsStayRunningWhenConcurrencyTransientlyZeroBeforeOpCountLimit() throws Exception {
+		// Regression: the same transient concurrency==0 gap also occurs for an
+		// op-count-bounded run. With only 80 of 1000 ops issued the engine must
+		// report Running, not Completed, or headless coordinators abort early.
+		final DistributedAllMetricsSnapshot snapshot = mockDistributedSnapshot(80L, 0L, 5_000L);
+		final DistributedMetricsContext ctx = mockDistributedContext("step-count-transient", OpType.CREATE, snapshot,
+						Map.of(MetricsConstants.METADATA_LIMIT_OP_COUNT, 1000L));
+
+		final MetricsManager mgr = mock(MetricsManager.class);
+		when(mgr.getDistributedContexts()).thenReturn(Set.of(ctx));
+		when(mgr.getAllContexts()).thenReturn(Set.of());
+		when(mgr.getTerminalSteps()).thenReturn(List.of());
+
+		final MetricsJsonResponder responder = new MetricsJsonResponder(mgr, defaultConfig());
+		final ArrayNode payload = responder.buildClusterMetrics(false);
+
+		JsonNode obj = null;
+		for (final JsonNode node : payload) {
+			if ("step-count-transient".equals(node.get("step_id").asText())) {
+				obj = node;
+			}
+		}
+		assertNotNull(obj, "expected metrics for step-count-transient");
+		assertEquals(1, obj.get("test_state").asInt(),
+						"transient concurrency==0 with only 80 of 1000 ops must report Running, not Completed");
+	}
+
+	@Test
 	void clusterMetricsReportCompletedWhenConcurrencyZeroAfterTimeLimit() throws Exception {
 		// Positive path: once the configured duration has elapsed, concurrency==0
 		// with operations issued is a genuine completion.


### PR DESCRIPTION
## Summary
- keep engine metrics in Running state during transient zero-concurrency gaps for time- and op-count-bounded runs
- gate headless completion on elapsed duration or op-count completion instead of trusting a single Completed sample
- propagate aggregate StepTime and preserve aggregate limit/progress fields used by completion detection
