### PR TITLE
Match engine image to CLI version

### DIFF
--- a/.github/workflows/release-artifacts.yaml
+++ b/.github/workflows/release-artifacts.yaml
@@ -112,7 +112,7 @@ jobs:
           cache-dependency-path: cli/go.sum
 
       - name: Build multi-platform binaries
-        run: make -C cli build-all
+        run: make -C cli build-all VERSION=${{ needs.prepare-version.outputs.version }}
 
       - name: Package binaries
         run: |

--- a/README.md
+++ b/README.md
@@ -243,3 +243,24 @@ For detailed engineering notes and planning documents, browse the `docs/` direct
 ## License
 
 SPT is released under the [MIT License](LICENSE). By submitting a pull request, you agree that your contribution will be licensed under MIT.
+
+## Engine image selection
+
+The CLI launches an engine container image whose tag is **derived from the CLI's
+own version**, so the engine you run always matches the CLI you invoked.
+
+Resolution order (highest precedence first):
+
+1. **`--spt-image <ref>`** flag, or the **`SPT_IMAGE`** environment variable — used
+   verbatim. This is how the comparison harness pins a specific version per run.
+2. **Release builds** → `ghcr.io/dell/storage-performance-tool:v<version>`
+   (e.g. a `5.10.3` CLI runs `...:v5.10.3`). Matches the published tag scheme.
+3. **Local/dev builds** → `ghcr.io/dell/storage-performance-tool:spt_dev`, the
+   local-only image produced by `make docker-local` and distributed to workers
+   with `engine/tools/push-worker-image.sh`. Dev images are never pulled from a
+   registry (the pull is auto-skipped).
+
+There is **no fallback to `:latest`**: if a release's matching image tag cannot be
+found it fails loudly rather than silently running a different engine version —
+this keeps benchmark comparisons honest. Use `--spt-image` / `SPT_IMAGE` if you
+explicitly want a floating tag such as `...:latest`.

--- a/cli/Makefile
+++ b/cli/Makefile
@@ -12,7 +12,18 @@ GOVET=$(GOCMD) vet
 
 # Build metadata (override via env in CI).
 VERSION_FILE ?= ../VERSION
-VERSION ?= $(shell if [ -f $(VERSION_FILE) ]; then tr -d '\n' < $(VERSION_FILE); else echo "0.0.0-dev"; fi)
+# Base version from the VERSION file (0.0.0 fallback when absent).
+BASE_VERSION ?= $(shell if [ -f $(VERSION_FILE) ]; then tr -d '\n' < $(VERSION_FILE); else echo "0.0.0"; fi)
+# Release builds set VERSION explicitly (CI passes VERSION=<ver>) or are built from
+# an exact git tag, and report a clean semver. All other (local/dev) builds are
+# dev-marked so they are never mistaken for a release engine image and so the CLI
+# selects the local spt_dev image. See buildinfo.IsRelease().
+VERSION ?= $(shell \
+	if git describe --tags --exact-match >/dev/null 2>&1; then \
+		echo "$(BASE_VERSION)"; \
+	else \
+		echo "$(BASE_VERSION)-dev+$$(git rev-parse --short HEAD 2>/dev/null || echo local)"; \
+	fi)
 GIT_COMMIT ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo "local")
 BUILD_DATE ?= $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 BUILDINFO_PKG=github.com/dell/storage-performance-tool/cli/internal/buildinfo

--- a/cli/README.md
+++ b/cli/README.md
@@ -368,7 +368,8 @@ Executes a benchmark test with the specified workload type.
 - `--generate-only`: Generate scenario file without executing Docker
 - `--force`: Automatically resolve port conflicts without user interaction. Spt uses port 9999 for its API - if another Spt instance is running, this flag will automatically stop it before starting the new test
 - `--api-port`: Specify custom Spt API port (defaults to 9999, legacy: 43234)
-- `--skip-image-pull`: Use the locally cached Spt image instead of pulling `latest` before each run (default: always pull)
+- `--spt-image`: Override the engine image ref. By default, release builds use an image tag matching the CLI version (for example, `...:v5.10.3`) and local/dev builds use `...:spt_dev`.
+- `--skip-image-pull`: Use the locally cached Spt image instead of pulling before each run. Dev images such as `spt_dev` automatically skip pulls because they are local-only.
 - `--keep-scenario`: Keep the generated JavaScript scenario file after test completes (useful for debugging)
 
 Multi-endpoint options:
@@ -550,8 +551,9 @@ Environment configuration
 - Variable expansion follows `godotenv` rules. Use `$VAR` or `${VAR}`. Command substitutions like `$(pwd)` are not supported; use `$PWD` instead.
 - Hosts: if `--test-hosts` is not specified, spt will use the `HOSTS` environment variable (from OS or `.env`). If neither is set, it falls back to localhost.
 - S3 defaults: you can provide `S3_ENDPOINTS` (CSV) or `S3_ENDPOINT` (single), plus `S3_ACCESS_KEY`, `S3_SECRET_KEY`, `S3_BUCKET`, and (optionally) `S3_AUTH_VERSION` via environment or `.env`. `S3_AUTH_VERSION` defaults to `4`; set it to `2` only when targeting legacy services that cannot accept SigV4.
-- Image override (optional): set `SPT_IMAGE` to override the default Docker image spt uses for verify and run.
-- Image pull control: set `SPT_SKIP_IMAGE_PULL=1` to skip pulling the Spt image before each run (spt still pulls if the image is missing locally). Default behaviour is to pull `latest` every run.
+- Image selection: by default, release CLIs run the matching engine image tag (`ghcr.io/dell/storage-performance-tool:v<version>`), while local/dev builds use the local-only `ghcr.io/dell/storage-performance-tool:spt_dev` image.
+- Image override (optional): set `SPT_IMAGE` or pass `--spt-image` to override the default Docker image spt uses for verify and run. Overrides are used verbatim, including floating tags such as `:latest`.
+- Image pull control: set `SPT_SKIP_IMAGE_PULL=1` to skip pulling the Spt image before each run. For non-dev images, spt still pulls if the image is missing locally. Dev images such as `spt_dev` are never pulled; if missing, build them with `make docker-local` and distribute them to workers with `engine/tools/push-worker-image.sh`.
 - Data shaping: `SPT_OBJECT_DATA_COMPRESSIBILITY` (0-100, default 0) sets target compressibility; `SPT_OBJECT_DATA_DEDUPABLE` (true/false, default true) controls anti-dedupe stamping.
 - Precedence: CLI flags > OS environment > `./.env` > `$HOME/.env` > built-in defaults. For endpoints specifically: `--endpoints` > `S3_ENDPOINTS` > `S3_ENDPOINT`. For authentication: CLI flag `--auth-version` overrides `S3_AUTH_VERSION`.
 - Quick start: copy `.env.example` to `.env` and edit placeholders for your environment.

--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -30,6 +30,7 @@ import (
 
 const (
 	flagSkipImagePull         = "skip-image-pull"
+	flagSptImage              = "spt-image"
 	flagAttachExistingWorkers = "attach-existing"
 )
 
@@ -750,6 +751,12 @@ Available workload types:
 			_ = os.Unsetenv(constants.EnvSkipImagePull)
 		}
 
+		// --spt-image overrides the engine image (precedence: flag > SPT_IMAGE env >
+		// version-matched default). Set the env so constants.EffectiveSptImage picks it up.
+		if sptImageFlag, _ := cmd.Flags().GetString(flagSptImage); strings.TrimSpace(sptImageFlag) != "" {
+			_ = os.Setenv(constants.EnvSptImage, strings.TrimSpace(sptImageFlag))
+		}
+
 		switch params.S3Driver {
 		case scenario.S3DriverRdma:
 			_ = os.Setenv(constants.EnvRdmaEnabled, "true")
@@ -1077,6 +1084,7 @@ func init() {
 	runCmd.Flags().Int("service-threads", 0, "Engine virtual-thread carrier parallelism (0 = JVM default, env: SPT_SERVICE_THREADS)")
 	runCmd.Flags().String("api-port", "", "Spt API port (defaults to 9999, legacy: 43234)")
 	runCmd.Flags().Bool(flagSkipImagePull, false, "Use the locally cached Docker image without pulling the latest tag (env: SPT_SKIP_IMAGE_PULL)")
+	runCmd.Flags().String(flagSptImage, "", "Override the engine image ref (default: matches the CLI version, e.g. ...:v5.10.3; dev builds use ...:spt_dev; env: SPT_IMAGE)")
 
 	// Results Retrieval Options (Phase 1: flags + parsing only)
 	runCmd.Flags().Bool("auto-results", true, "Automatically retrieve results artifacts at end of run")

--- a/cli/internal/buildinfo/buildinfo.go
+++ b/cli/internal/buildinfo/buildinfo.go
@@ -1,6 +1,11 @@
 // Package buildinfo exposes build-time metadata injected via ldflags.
 package buildinfo //nolint:revive // 'buildinfo' does not shadow a top-level stdlib package
 
+import (
+	"regexp"
+	"strings"
+)
+
 // Version, Commit, and BuildDate are injected at build time via ldflags.
 // Defaults keep local builds informative without extra wiring.
 var (
@@ -8,6 +13,29 @@ var (
 	Commit    = "unknown"
 	BuildDate = "unknown"
 )
+
+// releaseVersionRE matches a clean semver core (major.minor.patch), optionally
+// followed by a standard pre-release suffix (e.g. "5.10.0-rc.1"). It is used by
+// IsRelease together with an explicit dev-marker check.
+var releaseVersionRE = regexp.MustCompile(`^[0-9]+\.[0-9]+\.[0-9]+`)
+
+// IsRelease reports whether this binary is an official release build (a clean
+// semver version injected at release time) rather than a local/dev build.
+//
+// Local builds are dev-marked by the Makefile (e.g. "5.10.3-dev+abc1234") so they
+// are never mistaken for a release; the bare default is "dev". Anything carrying
+// the "-dev" marker, the "dev" default, or a non-semver string is treated as a dev
+// build. Pre-release tags such as "5.10.0-rc.1" are treated as releases (the
+// publish workflow pushes a matching v-prefixed image tag for them).
+func IsRelease() bool {
+	if Version == "" || Version == "dev" {
+		return false
+	}
+	if strings.Contains(Version, "-dev") {
+		return false
+	}
+	return releaseVersionRE.MatchString(Version)
+}
 
 // Summary returns a human-readable sentence summarizing build metadata.
 func Summary() string {

--- a/cli/internal/buildinfo/buildinfo.go
+++ b/cli/internal/buildinfo/buildinfo.go
@@ -17,7 +17,7 @@ var (
 // releaseVersionRE matches a clean semver core (major.minor.patch), optionally
 // followed by a standard pre-release suffix (e.g. "5.10.0-rc.1"). It is used by
 // IsRelease together with an explicit dev-marker check.
-var releaseVersionRE = regexp.MustCompile(`^[0-9]+\.[0-9]+\.[0-9]+`)
+var releaseVersionRE = regexp.MustCompile(`^[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z][0-9A-Za-z.-]*)?$`)
 
 // IsRelease reports whether this binary is an official release build (a clean
 // semver version injected at release time) rather than a local/dev build.

--- a/cli/internal/buildinfo/buildinfo_test.go
+++ b/cli/internal/buildinfo/buildinfo_test.go
@@ -13,6 +13,9 @@ func TestIsRelease(t *testing.T) {
 		{"dev", false},
 		{"", false},
 		{"5.10.3-dev+abc1234", false},
+		{"5.10.3+local", false},
+		{"5.10.3junk", false},
+		{"5.10.3-rc.1+local", false},
 		{"0.0.0-dev+local", false},
 		{"not-a-version", false},
 	}

--- a/cli/internal/buildinfo/buildinfo_test.go
+++ b/cli/internal/buildinfo/buildinfo_test.go
@@ -1,0 +1,27 @@
+package buildinfo
+
+import "testing"
+
+func TestIsRelease(t *testing.T) {
+	cases := []struct {
+		version string
+		want    bool
+	}{
+		{"5.10.3", true},
+		{"5.10.0-rc.1", true},
+		{"5.9.0", true},
+		{"dev", false},
+		{"", false},
+		{"5.10.3-dev+abc1234", false},
+		{"0.0.0-dev+local", false},
+		{"not-a-version", false},
+	}
+	restore := Version
+	t.Cleanup(func() { Version = restore })
+	for _, c := range cases {
+		Version = c.version
+		if got := IsRelease(); got != c.want {
+			t.Errorf("IsRelease() with Version=%q = %v, want %v", c.version, got, c.want)
+		}
+	}
+}

--- a/cli/internal/constants/image_override.go
+++ b/cli/internal/constants/image_override.go
@@ -4,16 +4,49 @@ import (
 	"os"
 	"strconv"
 	"strings"
+
+	"github.com/dell/storage-performance-tool/cli/internal/buildinfo"
 )
 
-// EffectiveSptImage returns the image to use for running/pulling Spt.
-// If the environment variable SPT_IMAGE is set and non-empty, it overrides
-// the built-in default. Otherwise, DefaultSptImage is returned.
+// DevImageTag is the tag used for local, build-only engine images that are never
+// published to a registry. Produced by `make docker-local` and distributed to
+// workers with engine/tools/push-worker-image.sh.
+const DevImageTag = "spt_dev"
+
+// EffectiveSptImage returns the image ref to run/pull for the engine.
+//
+// Precedence:
+//  1. $SPT_IMAGE override — used verbatim (keeps the comparison harness / cli/.env
+//     and the --spt-image flag working).
+//  2. Release build → DefaultSptImage:v<version>, matching the published tag scheme
+//     (see .github/workflows/docker-publish.yaml). There is deliberately no
+//     fallback to ":latest": a missing release tag fails loudly at pull time rather
+//     than silently running a different engine version.
+//  3. Dev/local build → DefaultSptImage:spt_dev (local-only image, see IsDevImage).
 func EffectiveSptImage() string {
 	if v := strings.TrimSpace(os.Getenv(EnvSptImage)); v != "" {
 		return v
 	}
-	return DefaultSptImage
+	if buildinfo.IsRelease() {
+		return DefaultSptImage + ":v" + buildinfo.Version
+	}
+	return DefaultSptImage + ":" + DevImageTag
+}
+
+// IsDevImage reports whether ref points at a local-only dev image that must never
+// be pulled from a registry. It matches the DevImageTag exactly as well as
+// discriminator variants like "spt_dev-baseline" used for dev-vs-dev comparisons.
+func IsDevImage(ref string) bool {
+	tagPart := ref
+	if slash := strings.LastIndex(ref, "/"); slash >= 0 {
+		tagPart = ref[slash:]
+	}
+	colon := strings.LastIndex(tagPart, ":")
+	if colon < 0 {
+		return false
+	}
+	tag := tagPart[colon+1:]
+	return tag == DevImageTag || strings.HasPrefix(tag, DevImageTag+"-")
 }
 
 // IsRdmaEnabled returns true when SPT_RDMA is set to a truthy value (1, true, yes).

--- a/cli/internal/constants/image_override_test.go
+++ b/cli/internal/constants/image_override_test.go
@@ -86,7 +86,6 @@ func TestIsDevImage(t *testing.T) {
 		}
 	}
 }
-
 func TestIsRdmaEnabled(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -137,4 +136,3 @@ func TestIsRdmaEnabled(t *testing.T) {
 		})
 	}
 }
-

--- a/cli/internal/constants/image_override_test.go
+++ b/cli/internal/constants/image_override_test.go
@@ -3,7 +3,89 @@ package constants
 import (
 	"os"
 	"testing"
+
+	"github.com/dell/storage-performance-tool/cli/internal/buildinfo"
 )
+
+func TestEffectiveSptImage(t *testing.T) {
+	t.Run("SPT_IMAGE override is used verbatim", func(t *testing.T) {
+		t.Setenv(EnvSptImage, "myregistry.example.com/spt:custom")
+		if got := EffectiveSptImage(); got != "myregistry.example.com/spt:custom" {
+			t.Fatalf("EffectiveSptImage() = %q, want override value", got)
+		}
+	})
+
+	t.Run("override is trimmed", func(t *testing.T) {
+		t.Setenv(EnvSptImage, "  myregistry.example.com/spt:custom  ")
+		if got := EffectiveSptImage(); got != "myregistry.example.com/spt:custom" {
+			t.Fatalf("EffectiveSptImage() = %q, want trimmed override", got)
+		}
+	})
+
+	t.Run("release build maps to v-prefixed version tag", func(t *testing.T) {
+		t.Setenv(EnvSptImage, "")
+		restore := buildinfo.Version
+		buildinfo.Version = "5.10.3"
+		t.Cleanup(func() { buildinfo.Version = restore })
+		want := DefaultSptImage + ":v5.10.3"
+		if got := EffectiveSptImage(); got != want {
+			t.Fatalf("EffectiveSptImage() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("pre-release build maps to v-prefixed tag", func(t *testing.T) {
+		t.Setenv(EnvSptImage, "")
+		restore := buildinfo.Version
+		buildinfo.Version = "5.10.0-rc.1"
+		t.Cleanup(func() { buildinfo.Version = restore })
+		want := DefaultSptImage + ":v5.10.0-rc.1"
+		if got := EffectiveSptImage(); got != want {
+			t.Fatalf("EffectiveSptImage() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("bare dev default maps to spt_dev tag", func(t *testing.T) {
+		t.Setenv(EnvSptImage, "")
+		restore := buildinfo.Version
+		buildinfo.Version = "dev"
+		t.Cleanup(func() { buildinfo.Version = restore })
+		want := DefaultSptImage + ":" + DevImageTag
+		if got := EffectiveSptImage(); got != want {
+			t.Fatalf("EffectiveSptImage() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("dev-marked local build maps to spt_dev tag", func(t *testing.T) {
+		t.Setenv(EnvSptImage, "")
+		restore := buildinfo.Version
+		buildinfo.Version = "5.10.3-dev+abc1234"
+		t.Cleanup(func() { buildinfo.Version = restore })
+		want := DefaultSptImage + ":" + DevImageTag
+		if got := EffectiveSptImage(); got != want {
+			t.Fatalf("EffectiveSptImage() = %q, want %q", got, want)
+		}
+	})
+}
+
+func TestIsDevImage(t *testing.T) {
+	cases := []struct {
+		ref  string
+		want bool
+	}{
+		{"ghcr.io/dell/storage-performance-tool:spt_dev", true},
+		{"ghcr.io/dell/storage-performance-tool:spt_dev-baseline", true},
+		{"ghcr.io/dell/storage-performance-tool:v5.10.3", false},
+		{"ghcr.io/dell/storage-performance-tool:latest", false},
+		{"ghcr.io/dell/storage-performance-tool", false},
+		{"localhost:5000/spt:spt_dev", true},
+		{"localhost:5000/spt:v5.10.3", false},
+	}
+	for _, c := range cases {
+		if got := IsDevImage(c.ref); got != c.want {
+			t.Errorf("IsDevImage(%q) = %v, want %v", c.ref, got, c.want)
+		}
+	}
+}
 
 func TestIsRdmaEnabled(t *testing.T) {
 	tests := []struct {
@@ -35,8 +117,8 @@ func TestIsRdmaEnabled(t *testing.T) {
 		{name: "garbage string", envValue: "garbage", want: false},
 		{name: "no", envValue: "no", want: false},
 		{name: "NO", envValue: "NO", want: false},
-		{name: "2", envValue: "2", want: false},             // strconv.ParseBool rejects "2"
-		{name: "enabled", envValue: "enabled", want: false}, // only "yes" is special-cased
+		{name: "2", envValue: "2", want: false},
+		{name: "enabled", envValue: "enabled", want: false},
 	}
 
 	for _, tt := range tests {
@@ -56,32 +138,3 @@ func TestIsRdmaEnabled(t *testing.T) {
 	}
 }
 
-func TestEffectiveSptImage(t *testing.T) {
-	tests := []struct {
-		name     string
-		envValue string
-		unset    bool
-		want     string
-	}{
-		{name: "default when unset", unset: true, want: DefaultSptImage},
-		{name: "default when empty", envValue: "", want: DefaultSptImage},
-		{name: "custom image", envValue: "myregistry/spt:v2", want: "myregistry/spt:v2"},
-		{name: "whitespace trimmed", envValue: "  myregistry/spt:v3  ", want: "myregistry/spt:v3"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if tt.unset {
-				os.Unsetenv(EnvSptImage)
-			} else {
-				os.Setenv(EnvSptImage, tt.envValue)
-			}
-			t.Cleanup(func() { os.Unsetenv(EnvSptImage) })
-
-			got := EffectiveSptImage()
-			if got != tt.want {
-				t.Errorf("EffectiveSptImage() = %q, want %q", got, tt.want)
-			}
-		})
-	}
-}

--- a/cli/internal/docker/command/operations.go
+++ b/cli/internal/docker/command/operations.go
@@ -24,7 +24,12 @@ type DockerOperationsImpl struct {
 	builder  DockerCommandBuilder
 }
 
-func shouldSkipImagePull() bool {
+func shouldSkipImagePull(image string) bool {
+	// Local-only dev images (spt_dev) are never in a registry; skip the pull so the
+	// run uses the image distributed via engine/tools/push-worker-image.sh.
+	if constants.IsDevImage(image) {
+		return true
+	}
 	val := strings.TrimSpace(os.Getenv(constants.EnvSkipImagePull))
 	if val == "" {
 		return false
@@ -48,7 +53,7 @@ func NewDockerOperations(executor CommandExecutor, host *hostparse.HostInfo) Doc
 // StartContainer starts a container and returns container ID plus detailed command results
 func (d *DockerOperationsImpl) StartContainer(ctx context.Context, config ContainerConfig) (string, CommandResult, error) {
 	// Build the docker run command
-	skipPull := shouldSkipImagePull()
+	skipPull := shouldSkipImagePull(config.Image)
 	if !skipPull {
 		if _, err := d.PullImage(ctx, config.Image); err != nil {
 			result := CommandResult{Command: constants.DockerCommand + " " + constants.DockerCmdPull + " " + config.Image, Error: err}
@@ -293,7 +298,7 @@ func (d *DockerOperationsImpl) StartContainerWithBuilder(ctx context.Context, im
 // StartWorkerNodeContainer starts a worker node container with RMI configuration
 func (d *DockerOperationsImpl) StartWorkerNodeContainer(ctx context.Context, image, containerName, rmiHostname string, rmiPortStart, rmiPortCount int) (string, error) {
 	// Ensure image is available locally; attempt auto-pull if not
-	skipPull := shouldSkipImagePull()
+	skipPull := shouldSkipImagePull(image)
 	if !skipPull {
 		if _, err := d.PullImage(ctx, image); err != nil {
 			return "", fmt.Errorf("failed to pull image %s: %w", image, err)
@@ -330,7 +335,7 @@ func (d *DockerOperationsImpl) StartWorkerNodeContainer(ctx context.Context, ima
 // StartEntryNodeContainer starts an entry node container with worker addresses
 func (d *DockerOperationsImpl) StartEntryNodeContainer(ctx context.Context, image, containerName string, workerAddresses []string, networkMode NetworkMode) (string, error) {
 	// Ensure image is available locally; attempt auto-pull if not
-	skipPull := shouldSkipImagePull()
+	skipPull := shouldSkipImagePull(image)
 	if !skipPull {
 		if _, err := d.PullImage(ctx, image); err != nil {
 			return "", fmt.Errorf("failed to pull image %s: %w", image, err)

--- a/cli/internal/docker/command/operations.go
+++ b/cli/internal/docker/command/operations.go
@@ -41,6 +41,16 @@ func shouldSkipImagePull(image string) bool {
 	return parsed
 }
 
+func missingDevImageError(image string, host *hostparse.HostInfo) error {
+	hostName := "local host"
+	if host != nil && strings.TrimSpace(host.Original) != "" {
+		hostName = host.Original
+	} else if host != nil && strings.TrimSpace(host.Host) != "" {
+		hostName = host.Host
+	}
+	return fmt.Errorf("dev image %s not present on %s; build it with `make docker-local` and distribute it with engine/tools/push-worker-image.sh", image, hostName)
+}
+
 // NewDockerOperations creates a new DockerOperations instance
 func NewDockerOperations(executor CommandExecutor, host *hostparse.HostInfo) DockerOperations {
 	return &DockerOperationsImpl{
@@ -60,6 +70,11 @@ func (d *DockerOperationsImpl) StartContainer(ctx context.Context, config Contai
 			return "", result, fmt.Errorf("failed to pull image %s: %w", config.Image, err)
 		}
 	} else if available, err := d.IsImageAvailable(ctx, config.Image); err == nil && !available {
+		if constants.IsDevImage(config.Image) {
+			result := CommandResult{Command: constants.DockerCommand + " " + constants.DockerCmdImages + " -q " + config.Image}
+			result.Error = missingDevImageError(config.Image, d.host)
+			return "", result, result.Error
+		}
 		logging.LogInfo("docker-command", "Docker image not found locally; pulling despite skip", "host", d.host.Host, "image", config.Image)
 		if _, perr := d.PullImage(ctx, config.Image); perr != nil {
 			result := CommandResult{Command: constants.DockerCommand + " " + constants.DockerCmdPull + " " + config.Image, Error: perr}
@@ -304,6 +319,9 @@ func (d *DockerOperationsImpl) StartWorkerNodeContainer(ctx context.Context, ima
 			return "", fmt.Errorf("failed to pull image %s: %w", image, err)
 		}
 	} else if available, err := d.IsImageAvailable(ctx, image); err == nil && !available {
+		if constants.IsDevImage(image) {
+			return "", missingDevImageError(image, d.host)
+		}
 		logging.LogInfo("docker-command", "Docker image not found locally; pulling despite skip", "host", d.host.Host, "image", image)
 		if _, perr := d.PullImage(ctx, image); perr != nil {
 			return "", fmt.Errorf("image %s not available and pull failed: %w", image, perr)
@@ -341,6 +359,9 @@ func (d *DockerOperationsImpl) StartEntryNodeContainer(ctx context.Context, imag
 			return "", fmt.Errorf("failed to pull image %s: %w", image, err)
 		}
 	} else if available, err := d.IsImageAvailable(ctx, image); err == nil && !available {
+		if constants.IsDevImage(image) {
+			return "", missingDevImageError(image, d.host)
+		}
 		logging.LogInfo("docker-command", "Docker image not found locally; pulling despite skip", "host", d.host.Host, "image", image)
 		if _, perr := d.PullImage(ctx, image); perr != nil {
 			return "", fmt.Errorf("image %s not available and pull failed: %w", image, perr)

--- a/cli/internal/docker/command/operations_test.go
+++ b/cli/internal/docker/command/operations_test.go
@@ -1067,6 +1067,92 @@ func TestDockerOperationsImpl_DevImagePullSkipping(t *testing.T) {
 			}
 		}
 	})
+
+	t.Run("StartContainer fails without pulling when dev image missing", func(t *testing.T) {
+		t.Setenv(constants.EnvSkipImagePull, "false")
+		devImage := constants.DefaultSptImage + ":" + constants.DevImageTag
+
+		mockExecutor := NewMockCommandExecutor()
+		mockExecutor.SetCommandSuccess("docker images -q "+devImage, "")
+
+		host := CreateLocalHost()
+		ops := NewDockerOperations(mockExecutor, host)
+		ctx := context.Background()
+
+		config := ContainerConfig{
+			Image:    devImage,
+			Name:     "missing-dev-container",
+			Detached: true,
+		}
+		_, _, err := ops.StartContainer(ctx, config)
+		if err == nil {
+			t.Fatal("expected missing dev image error")
+		}
+		if !strings.Contains(err.Error(), "dev image") {
+			t.Fatalf("expected dev image error, got %v", err)
+		}
+
+		for _, cmd := range mockExecutor.ExecutedCommands {
+			cmdStr := strings.Join(cmd.Command, " ")
+			if strings.Contains(cmdStr, "pull") {
+				t.Fatalf("docker pull should not be executed for missing dev image, but got: %q", cmdStr)
+			}
+		}
+	})
+
+	t.Run("StartWorkerNodeContainer fails without pulling when dev image missing", func(t *testing.T) {
+		t.Setenv(constants.EnvSkipImagePull, "false")
+		devImage := constants.DefaultSptImage + ":" + constants.DevImageTag
+
+		mockExecutor := NewMockCommandExecutor()
+		mockExecutor.SetCommandSuccess("docker images -q "+devImage, "")
+
+		host := CreateLocalHost()
+		ops := NewDockerOperations(mockExecutor, host).(*DockerOperationsImpl)
+		ctx := context.Background()
+
+		_, err := ops.StartWorkerNodeContainer(ctx, devImage, "worker-dev", "localhost", 1099, 1)
+		if err == nil {
+			t.Fatal("expected missing dev image error")
+		}
+		if !strings.Contains(err.Error(), "dev image") {
+			t.Fatalf("expected dev image error, got %v", err)
+		}
+
+		for _, cmd := range mockExecutor.ExecutedCommands {
+			cmdStr := strings.Join(cmd.Command, " ")
+			if strings.Contains(cmdStr, "pull") {
+				t.Fatalf("docker pull should not be executed for missing dev image, but got: %q", cmdStr)
+			}
+		}
+	})
+
+	t.Run("StartEntryNodeContainer fails without pulling when dev image missing", func(t *testing.T) {
+		t.Setenv(constants.EnvSkipImagePull, "false")
+		devImage := constants.DefaultSptImage + ":" + constants.DevImageTag
+
+		mockExecutor := NewMockCommandExecutor()
+		mockExecutor.SetCommandSuccess("docker images -q "+devImage, "")
+
+		host := CreateLocalHost()
+		ops := NewDockerOperations(mockExecutor, host).(*DockerOperationsImpl)
+		ctx := context.Background()
+
+		_, err := ops.StartEntryNodeContainer(ctx, devImage, "entry-dev", []string{"192.168.1.100"}, NetworkModeBridge)
+		if err == nil {
+			t.Fatal("expected missing dev image error")
+		}
+		if !strings.Contains(err.Error(), "dev image") {
+			t.Fatalf("expected dev image error, got %v", err)
+		}
+
+		for _, cmd := range mockExecutor.ExecutedCommands {
+			cmdStr := strings.Join(cmd.Command, " ")
+			if strings.Contains(cmdStr, "pull") {
+				t.Fatalf("docker pull should not be executed for missing dev image, but got: %q", cmdStr)
+			}
+		}
+	})
 }
 
 // Helper functions

--- a/cli/internal/docker/command/operations_test.go
+++ b/cli/internal/docker/command/operations_test.go
@@ -972,6 +972,103 @@ func TestParsePortFromString(t *testing.T) {
 	}
 }
 
+func TestDockerOperationsImpl_DevImagePullSkipping(t *testing.T) {
+	t.Run("shouldSkipImagePull for dev image", func(t *testing.T) {
+		// Env SPT_SKIP_IMAGE_PULL=false, but dev image should still skip
+		t.Setenv(constants.EnvSkipImagePull, "false")
+		devImage := constants.DefaultSptImage + ":" + constants.DevImageTag
+
+		mockExecutor := NewMockCommandExecutor()
+		// We expect IsImageAvailable to be called to check if dev image is present locally
+		mockExecutor.SetCommandSuccess("docker images -q "+devImage, "sha256:abc1234")
+		// The run command succeeds
+		expectedCmd := "docker run -d --name test-dev-container " + devImage
+		mockExecutor.SetCommandSuccess(expectedCmd, "devcontainer123")
+
+		host := CreateLocalHost()
+		ops := NewDockerOperations(mockExecutor, host)
+		ctx := context.Background()
+
+		config := ContainerConfig{
+			Image:    devImage,
+			Name:     "test-dev-container",
+			Detached: true,
+		}
+		// StartContainer should NOT call PullImage (which executes "docker pull")
+		_, _, err := ops.StartContainer(ctx, config)
+		if err != nil {
+			t.Fatalf("StartContainer failed: %v", err)
+		}
+
+		// Verify no docker pull was attempted
+		for _, cmd := range mockExecutor.ExecutedCommands {
+			cmdStr := strings.Join(cmd.Command, " ")
+			if strings.Contains(cmdStr, "pull") {
+				t.Fatalf("docker pull should not be executed for dev image, but got: %q", cmdStr)
+			}
+		}
+	})
+
+	t.Run("StartWorkerNodeContainer skips pull for dev image", func(t *testing.T) {
+		t.Setenv(constants.EnvSkipImagePull, "false")
+		devImage := constants.DefaultSptImage + ":" + constants.DevImageTag
+
+		mockExecutor := NewMockCommandExecutor()
+		// IsImageAvailable succeeds
+		mockExecutor.SetCommandSuccess("docker images -q "+devImage, "sha256:abc1234")
+		// docker run succeeds
+		expectedCmd := "docker run -d --name worker-dev -e JAVA_OPTS=-Djava.rmi.server.hostname=localhost -e JAVA_TOOL_OPTIONS=-Djava.rmi.server.hostname=localhost --network host " +
+			devImage + " --run-node=true --run-port=9999 --load-step-node-port=1099"
+		mockExecutor.SetCommandSuccess(expectedCmd, "workerdev123")
+
+		host := CreateLocalHost()
+		ops := NewDockerOperations(mockExecutor, host).(*DockerOperationsImpl)
+		ctx := context.Background()
+
+		_, err := ops.StartWorkerNodeContainer(ctx, devImage, "worker-dev", "localhost", 1099, 1)
+		if err != nil {
+			t.Fatalf("StartWorkerNodeContainer failed: %v", err)
+		}
+
+		// Verify no docker pull was attempted
+		for _, cmd := range mockExecutor.ExecutedCommands {
+			cmdStr := strings.Join(cmd.Command, " ")
+			if strings.Contains(cmdStr, "pull") {
+				t.Fatalf("docker pull should not be executed for dev image, but got: %q", cmdStr)
+			}
+		}
+	})
+
+	t.Run("StartEntryNodeContainer skips pull for dev image", func(t *testing.T) {
+		t.Setenv(constants.EnvSkipImagePull, "false")
+		devImage := constants.DefaultSptImage + ":" + constants.DevImageTag
+
+		mockExecutor := NewMockCommandExecutor()
+		// IsImageAvailable succeeds
+		mockExecutor.SetCommandSuccess("docker images -q "+devImage, "sha256:abc1234")
+		// docker run succeeds
+		expectedCmd := "docker run -d --name entry-dev -p 9999:9999/tcp " + devImage + " --load-step-node-addrs=192.168.1.100 --run-node=true"
+		mockExecutor.SetCommandSuccess(expectedCmd, "entrydev123")
+
+		host := CreateLocalHost()
+		ops := NewDockerOperations(mockExecutor, host).(*DockerOperationsImpl)
+		ctx := context.Background()
+
+		_, err := ops.StartEntryNodeContainer(ctx, devImage, "entry-dev", []string{"192.168.1.100"}, NetworkModeBridge)
+		if err != nil {
+			t.Fatalf("StartEntryNodeContainer failed: %v", err)
+		}
+
+		// Verify no docker pull was attempted
+		for _, cmd := range mockExecutor.ExecutedCommands {
+			cmdStr := strings.Join(cmd.Command, " ")
+			if strings.Contains(cmdStr, "pull") {
+				t.Fatalf("docker pull should not be executed for dev image, but got: %q", cmdStr)
+			}
+		}
+	})
+}
+
 // Helper functions
 
 func compareStringSlices(a, b []string) bool {

--- a/cli/internal/preflight/checker.go
+++ b/cli/internal/preflight/checker.go
@@ -75,6 +75,9 @@ func (c *DefaultChecker) EnsureImage(ctx context.Context, host *hostparse.HostIn
 	if available {
 		return nil
 	}
+	if constants.IsDevImage(image) {
+		return fmt.Errorf("dev image %s not present on %s; build it with `make docker-local` and distribute it with engine/tools/push-worker-image.sh", image, host.Original)
+	}
 	_, err = ops.PullImage(tctx, image)
 	return err
 }

--- a/cli/internal/preflight/checker_test.go
+++ b/cli/internal/preflight/checker_test.go
@@ -7,6 +7,7 @@ package preflight
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/dell/storage-performance-tool/cli/internal/constants"
@@ -44,6 +45,34 @@ func TestPreflight_EnsureImage_PullsWhenMissing(t *testing.T) {
 	pf := &DefaultChecker{exec: mock}
 	if err := pf.EnsureImage(context.Background(), testHost(), image); err != nil {
 		t.Fatalf("EnsureImage error: %v", err)
+	}
+}
+
+func TestPreflight_EnsureImage_DevImagePresent(t *testing.T) {
+	mock := command.NewMockCommandExecutor()
+	image := constants.DefaultSptImage + ":" + constants.DevImageTag
+	// Image present
+	mock.SetCommandSuccess(fmt.Sprintf("%s %s -q %s", constants.DockerCommand, constants.DockerCmdImages, image), "sha256:abc1234")
+
+	pf := &DefaultChecker{exec: mock}
+	if err := pf.EnsureImage(context.Background(), testHost(), image); err != nil {
+		t.Fatalf("EnsureImage error: %v", err)
+	}
+}
+
+func TestPreflight_EnsureImage_DevImageMissing(t *testing.T) {
+	mock := command.NewMockCommandExecutor()
+	image := constants.DefaultSptImage + ":" + constants.DevImageTag
+	// Image missing
+	mock.SetCommandSuccess(fmt.Sprintf("%s %s -q %s", constants.DockerCommand, constants.DockerCmdImages, image), "")
+
+	pf := &DefaultChecker{exec: mock}
+	err := pf.EnsureImage(context.Background(), testHost(), image)
+	if err == nil {
+		t.Fatal("expected error when dev image is missing locally")
+	}
+	if !strings.Contains(err.Error(), "dev image") {
+		t.Errorf("unexpected error message: %v", err)
 	}
 }
 

--- a/cli/tui/docker.go
+++ b/cli/tui/docker.go
@@ -62,7 +62,11 @@ type DockerManager struct {
 	remote      *RemoteDockerManager // When non-nil, delegate operations to remote CLI manager
 }
 
-func skipImagePull() bool {
+func skipImagePull(image string) bool {
+	// Local-only dev images (spt_dev) are never in a registry; never try to pull them.
+	if constants.IsDevImage(image) {
+		return true
+	}
 	val := strings.TrimSpace(os.Getenv(constants.EnvSkipImagePull))
 	if val == "" {
 		return false
@@ -119,7 +123,7 @@ func NewDockerManager() (*DockerManager, error) {
 
 // ensureImageAvailable checks for the image locally and pulls it if missing
 func (dm *DockerManager) ensureImageAvailable(imageName string) error {
-	if !skipImagePull() {
+	if !skipImagePull(imageName) {
 		logging.LogInfo("docker", "Pulling Docker image before start", "image", imageName)
 		return dm.pullImage(imageName)
 	}
@@ -127,6 +131,10 @@ func (dm *DockerManager) ensureImageAvailable(imageName string) error {
 	if _, err := dm.client.ImageInspect(dm.ctx, imageName); err == nil {
 		logging.LogInfo("docker", "Using cached Docker image", "image", imageName)
 		return nil
+	}
+
+	if constants.IsDevImage(imageName) {
+		return fmt.Errorf("dev image %s not present locally; build it with `make docker-local` inside the engine directory", imageName)
 	}
 
 	logging.LogInfo("docker", "Cached Docker image missing; pulling despite skip request", "image", imageName)

--- a/cli/tui/docker_client_shim_test.go
+++ b/cli/tui/docker_client_shim_test.go
@@ -75,6 +75,34 @@ func TestEnsureImageAvailable_SkipPullWhenPresent(t *testing.T) {
 	}
 }
 
+func TestEnsureImageAvailable_DevImagePresent(t *testing.T) {
+	t.Setenv(constants.EnvSkipImagePull, "false")
+	devImage := constants.DefaultSptImage + ":" + constants.DevImageTag
+	dm := &DockerManager{client: &fakeDockerClient{}, ctx: context.Background()}
+	if err := dm.ensureImageAvailable(devImage); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if dm.client.(*fakeDockerClient).pulled {
+		t.Fatalf("did not expect pull for present dev image")
+	}
+}
+
+func TestEnsureImageAvailable_DevImageMissing(t *testing.T) {
+	t.Setenv(constants.EnvSkipImagePull, "false")
+	devImage := constants.DefaultSptImage + ":" + constants.DevImageTag
+	dm := &DockerManager{client: &fakeDockerClient{inspectErr: io.EOF}, ctx: context.Background()}
+	err := dm.ensureImageAvailable(devImage)
+	if err == nil {
+		t.Fatal("expected error when dev image is missing locally")
+	}
+	if !strings.Contains(err.Error(), "dev image") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+	if dm.client.(*fakeDockerClient).pulled {
+		t.Fatalf("did not expect pull attempt for missing dev image")
+	}
+}
+
 func TestCleanup_UsesClientToStopAndRemove(t *testing.T) {
 	f := &fakeDockerClient{}
 	dm := &DockerManager{client: f, containerID: "xyz", ctx: context.Background()}


### PR DESCRIPTION
## Summary
- resolve the default engine image from the CLI build version instead of Docker's implicit latest tag
- stamp local CLI builds as dev builds so they use the local-only spt_dev engine image
- add --spt-image / SPT_IMAGE override support and shared dev-image skip-pull handling
- fail clearly when local dev images are missing instead of trying to pull them
- update docs for version-matched release images and dev-image workflow