### PR TITLE
Fix headless auto-results shutdown race

### DIFF
--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -893,13 +893,21 @@ Available workload types:
 		if resultsOpts.AutoResults {
 			autoResultsDone = startAutoResults(baseURL, resultsOpts.Label, resultsOpts.ResultsDir, expectedStepIDs, resultsOpts.Debug, hostInfos, apiPort, resultsOpts.ShutdownOnComplete, resultsOpts.ShutdownLingerSec, scenarioPath, metadata, progressOut, summaryWriter, traceOpts.Path)
 		}
-		waitForAutoResults := func() {
+		waitForAutoResults := func(required bool) bool {
 			if autoResultsDone != nil {
 				select {
 				case <-autoResultsDone:
-				case <-time.After(2 * time.Second):
+					return true
+				case <-time.After(func() time.Duration {
+					if required {
+						return 2 * time.Minute
+					}
+					return 2 * time.Second
+				}()):
+					return false
 				}
 			}
+			return true
 		}
 		finalizeTraceArtifact := func() {
 			if err := appendTraceToResultsManifest(plannedResultsRoot, traceOpts.Path); err != nil {
@@ -966,11 +974,13 @@ Available workload types:
 			if headlessMode {
 				verbose, _ := cmd.Flags().GetBool("verbose")
 
+				delegateShutdownToAutoResults := resultsOpts.AutoResults && resultsOpts.ShutdownOnComplete
 				options := headless.HeadlessOptions{
-					TraceFile:            traceOpts.Path,
-					TraceAppend:          traceOpts.Append,
-					Verbose:              verbose,
-					AutoTerminateSeconds: autoTerminate,
+					TraceFile:              traceOpts.Path,
+					TraceAppend:            traceOpts.Append,
+					Verbose:                verbose,
+					AutoTerminateSeconds:   autoTerminate,
+					DelegateNormalShutdown: delegateShutdownToAutoResults,
 				}
 
 				if autoTerminate > 0 {
@@ -978,7 +988,14 @@ Available workload types:
 				}
 
 				err := headless.StartHeadlessModeWithOrchestrator(orchestrator, sptImage, scenarioPath, params, options)
-				waitForAutoResults()
+				if !waitForAutoResults(delegateShutdownToAutoResults) && delegateShutdownToAutoResults {
+					logger.Warn("Timed out waiting for auto-results; forcing container cleanup")
+					cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 30*time.Second)
+					if stopErr := orchestrator.StopAllContainers(cleanupCtx); stopErr != nil {
+						logger.Error("Failed to clean up containers after auto-results timeout", "error", stopErr.Error())
+					}
+					cleanupCancel()
+				}
 				finalizeTraceArtifact()
 				return err
 			}
@@ -987,12 +1004,12 @@ Available workload types:
 			if autoTerminate > 0 {
 				fmt.Printf("Auto-terminate: will stop after %d seconds\n", autoTerminate)
 				err = tui.StartTUIWithMultiHostOrchestratorTimeoutWithTrace(orchestrator, sptImage, scenarioPath, params, autoTerminate, setSummarySink, traceOpts.Path, traceOpts.Append)
-				waitForAutoResults()
+				waitForAutoResults(false)
 				finalizeTraceArtifact()
 				return err
 			}
 			err = tui.StartTUIWithMultiHostOrchestratorWithTrace(orchestrator, sptImage, scenarioPath, params, setSummarySink, traceOpts.Path, traceOpts.Append)
-			waitForAutoResults()
+			waitForAutoResults(false)
 			finalizeTraceArtifact()
 			return err
 		}
@@ -1015,7 +1032,7 @@ Available workload types:
 			}
 
 			err := headless.StartHeadlessModeWithParams(sptImage, scenarioPath, params, options)
-			waitForAutoResults()
+			waitForAutoResults(false)
 			finalizeTraceArtifact()
 			return err
 		}
@@ -1028,7 +1045,7 @@ Available workload types:
 		} else {
 			err = tui.StartTUIWithScenarioAndParamsWithTrace(sptImage, scenarioPath, params, apiPort, setSummarySink, traceOpts.Path, traceOpts.Append)
 		}
-		waitForAutoResults()
+		waitForAutoResults(false)
 		finalizeTraceArtifact()
 		return err
 	},

--- a/cli/tui/headless/runner.go
+++ b/cli/tui/headless/runner.go
@@ -52,6 +52,9 @@ type HeadlessOptions struct {
 	DryRun      bool
 	// KeepScenario removed - this belongs in scenario.Params
 	AutoTerminateSeconds int // 0 = unlimited
+	// In multi-host runs, let auto-results fetch artifacts and request shutdown
+	// after normal completion instead of stopping containers immediately.
+	DelegateNormalShutdown bool
 }
 
 // NewHeadlessRunner creates a new headless runner
@@ -97,16 +100,18 @@ func NewHeadlessRunner(dockerManager tui.DockerInterface, options HeadlessOption
 
 // MultiHostHeadlessRunner manages headless execution across multiple hosts
 type MultiHostHeadlessRunner struct {
-	orchestrator *tui.MultiHostOrchestrator
-	traceFile    *os.File
-	verbose      bool
+	orchestrator           *tui.MultiHostOrchestrator
+	traceFile              *os.File
+	verbose                bool
+	delegateNormalShutdown bool
 }
 
 // NewMultiHostHeadlessRunner creates a new multi-host headless runner
 func NewMultiHostHeadlessRunner(orchestrator *tui.MultiHostOrchestrator, options HeadlessOptions) (*MultiHostHeadlessRunner, error) {
 	runner := &MultiHostHeadlessRunner{
-		orchestrator: orchestrator,
-		verbose:      options.Verbose,
+		orchestrator:           orchestrator,
+		verbose:                options.Verbose,
+		delegateNormalShutdown: options.DelegateNormalShutdown,
 	}
 
 	// Set up trace file if specified
@@ -186,6 +191,9 @@ func (r *MultiHostHeadlessRunner) RunWithParams(ctx context.Context, image strin
 	err = <-done
 	if err != nil {
 		r.output("SHUTDOWN", fmt.Sprintf("Shutting down due to: %v", err))
+	} else if r.delegateNormalShutdown {
+		r.output("SHUTDOWN", "Normal completion detected; auto-results will fetch artifacts and stop containers")
+		return nil
 	}
 
 	// Stop all containers

--- a/cli/tui/headless/runner_test.go
+++ b/cli/tui/headless/runner_test.go
@@ -428,12 +428,13 @@ func TestHeadlessRunner_SingleOpNoPerOpLines(t *testing.T) {
 func TestHeadlessOptions_AllFields(t *testing.T) {
 	// Test that all option fields can be set and retrieved
 	options := HeadlessOptions{
-		TraceFile:   "/tmp/test.log",
-		TraceAppend: true,
-		Verbose:     true,
-		JSONMode:    true,
-		MetricsOnly: true,
-		DryRun:      true,
+		TraceFile:              "/tmp/test.log",
+		TraceAppend:            true,
+		Verbose:                true,
+		JSONMode:               true,
+		MetricsOnly:            true,
+		DryRun:                 true,
+		DelegateNormalShutdown: true,
 	}
 
 	// Verify all fields are accessible
@@ -454,6 +455,9 @@ func TestHeadlessOptions_AllFields(t *testing.T) {
 	}
 	if !options.DryRun {
 		t.Errorf("DryRun not set correctly")
+	}
+	if !options.DelegateNormalShutdown {
+		t.Errorf("DelegateNormalShutdown not set correctly")
 	}
 	// KeepScenario removed from HeadlessOptions - now in ScenarioParams
 }


### PR DESCRIPTION
## Summary
- delegate normal multi-host headless shutdown to auto-results when shutdown-on-complete is enabled
- wait for required auto-results completion before final trace handling
- force container cleanup if required auto-results times out