### PR TITLE
Fix headless multi-step completion detection

### DIFF
--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -369,6 +369,18 @@ type traceOptions struct {
 	Auto   bool
 }
 
+func buildHeadlessOptions(traceOpts traceOptions, verbose bool, apiPort string, autoTerminate int, delegateNormalShutdown bool, expectedStepIDs []string) headless.HeadlessOptions {
+	return headless.HeadlessOptions{
+		TraceFile:              traceOpts.Path,
+		TraceAppend:            traceOpts.Append,
+		Verbose:                verbose,
+		APIPort:                apiPort,
+		AutoTerminateSeconds:   autoTerminate,
+		DelegateNormalShutdown: delegateNormalShutdown,
+		ExpectedStepIDs:        append([]string(nil), expectedStepIDs...),
+	}
+}
+
 func prepareTraceOptions(explicitPath string, explicitAppend bool, autoResults bool, plannedResultsRoot string, runToken string, warnOut io.Writer) (traceOptions, error) {
 	path := strings.TrimSpace(explicitPath)
 	if path != "" {
@@ -975,13 +987,7 @@ Available workload types:
 				verbose, _ := cmd.Flags().GetBool("verbose")
 
 				delegateShutdownToAutoResults := resultsOpts.AutoResults && resultsOpts.ShutdownOnComplete
-				options := headless.HeadlessOptions{
-					TraceFile:              traceOpts.Path,
-					TraceAppend:            traceOpts.Append,
-					Verbose:                verbose,
-					AutoTerminateSeconds:   autoTerminate,
-					DelegateNormalShutdown: delegateShutdownToAutoResults,
-				}
+				options := buildHeadlessOptions(traceOpts, verbose, "", autoTerminate, delegateShutdownToAutoResults, expectedStepIDs)
 
 				if autoTerminate > 0 {
 					fmt.Printf("Auto-terminate: will stop after %d seconds\n", autoTerminate)
@@ -1019,14 +1025,8 @@ Available workload types:
 		if headlessMode {
 			verbose, _ := cmd.Flags().GetBool("verbose")
 
-			options := headless.HeadlessOptions{
-				TraceFile:            traceOpts.Path,
-				TraceAppend:          traceOpts.Append,
-				Verbose:              verbose,
-				APIPort:              apiPort,
-				AutoTerminateSeconds: autoTerminate,
-				// KeepScenario is now passed via params, not options
-			}
+			options := buildHeadlessOptions(traceOpts, verbose, apiPort, autoTerminate, false, nil)
+			// KeepScenario is now passed via params, not options.
 			if autoTerminate > 0 {
 				fmt.Printf("Auto-terminate: will stop after %d seconds\n", autoTerminate)
 			}

--- a/cli/cmd/run_headless_options_test.go
+++ b/cli/cmd/run_headless_options_test.go
@@ -1,0 +1,45 @@
+package cmd
+
+import "testing"
+
+func TestBuildHeadlessOptionsCarriesExpectedStepIDs(t *testing.T) {
+	expectedStepIDs := []string{"mt-001-seed", "mt-002-read"}
+	traceOpts := traceOptions{
+		Path:   "/tmp/spt.trace.log",
+		Append: true,
+	}
+
+	got := buildHeadlessOptions(traceOpts, true, "19090", 42, true, expectedStepIDs)
+
+	if got.TraceFile != traceOpts.Path {
+		t.Fatalf("TraceFile = %q, want %q", got.TraceFile, traceOpts.Path)
+	}
+	if !got.TraceAppend {
+		t.Fatal("TraceAppend = false, want true")
+	}
+	if !got.Verbose {
+		t.Fatal("Verbose = false, want true")
+	}
+	if got.APIPort != "19090" {
+		t.Fatalf("APIPort = %q, want 19090", got.APIPort)
+	}
+	if got.AutoTerminateSeconds != 42 {
+		t.Fatalf("AutoTerminateSeconds = %d, want 42", got.AutoTerminateSeconds)
+	}
+	if !got.DelegateNormalShutdown {
+		t.Fatal("DelegateNormalShutdown = false, want true")
+	}
+	if len(got.ExpectedStepIDs) != len(expectedStepIDs) {
+		t.Fatalf("ExpectedStepIDs length = %d, want %d", len(got.ExpectedStepIDs), len(expectedStepIDs))
+	}
+	for i, want := range expectedStepIDs {
+		if got.ExpectedStepIDs[i] != want {
+			t.Fatalf("ExpectedStepIDs[%d] = %q, want %q", i, got.ExpectedStepIDs[i], want)
+		}
+	}
+
+	expectedStepIDs[1] = "mutated"
+	if got.ExpectedStepIDs[1] != "mt-002-read" {
+		t.Fatalf("ExpectedStepIDs was aliased to caller slice, got %q", got.ExpectedStepIDs[1])
+	}
+}

--- a/cli/tui/headless/runner.go
+++ b/cli/tui/headless/runner.go
@@ -55,6 +55,7 @@ type HeadlessOptions struct {
 	// In multi-host runs, let auto-results fetch artifacts and request shutdown
 	// after normal completion instead of stopping containers immediately.
 	DelegateNormalShutdown bool
+	ExpectedStepIDs        []string
 }
 
 // NewHeadlessRunner creates a new headless runner
@@ -104,6 +105,7 @@ type MultiHostHeadlessRunner struct {
 	traceFile              *os.File
 	verbose                bool
 	delegateNormalShutdown bool
+	expectedStepIDs        []string
 }
 
 // NewMultiHostHeadlessRunner creates a new multi-host headless runner
@@ -112,6 +114,7 @@ func NewMultiHostHeadlessRunner(orchestrator *tui.MultiHostOrchestrator, options
 		orchestrator:           orchestrator,
 		verbose:                options.Verbose,
 		delegateNormalShutdown: options.DelegateNormalShutdown,
+		expectedStepIDs:        append([]string(nil), options.ExpectedStepIDs...),
 	}
 
 	// Set up trace file if specified
@@ -149,6 +152,7 @@ func (r *MultiHostHeadlessRunner) RunWithParams(ctx context.Context, image strin
 
 	// Start the distributed test on all hosts via orchestrator wrapper
 	testOrchestrator := tui.NewMultiHostTestOrchestrator(r.orchestrator)
+	testOrchestrator.SetExpectedStepIDs(r.expectedStepIDs)
 	// Standardize progress output in headless mode as well
 	r.orchestrator.SetNotifier(func(msg string) {
 		r.output("spt", msg)

--- a/cli/tui/headless/runner_multihost_test.go
+++ b/cli/tui/headless/runner_multihost_test.go
@@ -52,6 +52,35 @@ func TestNewMultiHostHeadlessRunner_Success(t *testing.T) {
 	}
 }
 
+func TestNewMultiHostHeadlessRunner_CopiesExpectedStepIDs(t *testing.T) {
+	hostInfos := []*hostparse.HostInfo{
+		{Host: "host1", IsLocal: false, Original: "host1"},
+	}
+	orchestrator := tui.NewMultiHostOrchestrator(hostInfos, 1)
+	expectedStepIDs := []string{"mt-001-seed", "mt-002-read"}
+
+	runner, err := NewMultiHostHeadlessRunner(orchestrator, HeadlessOptions{
+		ExpectedStepIDs: expectedStepIDs,
+	})
+	if err != nil {
+		t.Fatalf("NewMultiHostHeadlessRunner returned error: %v", err)
+	}
+
+	if len(runner.expectedStepIDs) != len(expectedStepIDs) {
+		t.Fatalf("expectedStepIDs length = %d, want %d", len(runner.expectedStepIDs), len(expectedStepIDs))
+	}
+	for i, want := range expectedStepIDs {
+		if runner.expectedStepIDs[i] != want {
+			t.Fatalf("expectedStepIDs[%d] = %q, want %q", i, runner.expectedStepIDs[i], want)
+		}
+	}
+
+	expectedStepIDs[1] = "mutated"
+	if runner.expectedStepIDs[1] != "mt-002-read" {
+		t.Fatalf("expectedStepIDs was aliased to caller slice, got %q", runner.expectedStepIDs[1])
+	}
+}
+
 func TestNewMultiHostHeadlessRunner_WithTraceFile(t *testing.T) {
 	oldArgs := os.Args
 	os.Args = []string{"spt", "run", "mixed", "-s", "secret", "-a=ACCESS"}

--- a/cli/tui/orchestrator_multi.go
+++ b/cli/tui/orchestrator_multi.go
@@ -780,6 +780,8 @@ type MultiHostTestOrchestrator struct {
 	// Message sink for TUI (e.g., p.Send(sptMessageMsg(...)))
 	messageSink func(string)
 
+	expectedStepIDs []string
+
 	compatOnce sync.Once
 }
 
@@ -820,6 +822,13 @@ func NewMultiHostTestOrchestrator(multiHost *MultiHostOrchestrator) *MultiHostTe
 		randSource:    rand.New(rand.NewSource(time.Now().UnixNano())), // #nosec G404 -- jitter only
 		logJSONBodies: os.Getenv("SPT_LOG_METRICS_BODY") == "1",
 	}
+}
+
+// SetExpectedStepIDs constrains completion detection to the final step in the
+// generated scenario. This prevents a precondition/seed step from ending a
+// multi-step headless run.
+func (m *MultiHostTestOrchestrator) SetExpectedStepIDs(stepIDs []string) {
+	m.expectedStepIDs = append([]string(nil), stepIDs...)
 }
 
 // BuildBaselineUpdate constructs a status-only update for all configured hosts (no per-node samples).
@@ -983,7 +992,7 @@ func (m *MultiHostTestOrchestrator) metricsPollingLoop(ctx context.Context) {
 			if update != nil && m.onMetrics != nil {
 				m.onMetrics(update)
 			}
-			if update != nil && shouldSignalCompletion(update.Aggregated) {
+			if update != nil && shouldSignalCompletionForExpectedSteps(update.Aggregated, m.expectedStepIDs) {
 				m.signalCompletion()
 			}
 		case <-ctx.Done():
@@ -1020,6 +1029,20 @@ func shouldSignalCompletion(agg *PerformanceMetric) bool {
 		return agg.CompletionPercent >= 100
 	}
 	return true
+}
+
+func shouldSignalCompletionForExpectedSteps(agg *PerformanceMetric, expectedStepIDs []string) bool {
+	if len(expectedStepIDs) == 0 {
+		return shouldSignalCompletion(agg)
+	}
+	if agg == nil {
+		return false
+	}
+	finalStepID := expectedStepIDs[len(expectedStepIDs)-1]
+	if finalStepID == "" || agg.StepID != finalStepID {
+		return false
+	}
+	return shouldSignalCompletion(agg)
 }
 
 // collectAllMetrics polls all ready hosts and creates a MultiNodeMetricsUpdate

--- a/cli/tui/orchestrator_multi_completion_test.go
+++ b/cli/tui/orchestrator_multi_completion_test.go
@@ -103,3 +103,43 @@ func TestShouldSignalCompletion(t *testing.T) {
 		})
 	}
 }
+
+func TestShouldSignalCompletionForExpectedSteps(t *testing.T) {
+	expectedSteps := []string{
+		"mt-001-20260531.002657.899-seed",
+		"mt-002-20260531.002657.899-read",
+	}
+
+	seedComplete := &PerformanceMetric{
+		StepID:            expectedSteps[0],
+		TestState:         constants.TestStateCompleted,
+		HasLimit:          true,
+		LimitType:         constants.LimitTypeOpCount,
+		CompletionPercent: 100,
+	}
+	if shouldSignalCompletionForExpectedSteps(seedComplete, expectedSteps) {
+		t.Fatal("seed step completion must not signal whole-scenario completion")
+	}
+
+	readComplete := &PerformanceMetric{
+		StepID:       expectedSteps[1],
+		TestState:    constants.TestStateCompleted,
+		HasLimit:     true,
+		LimitType:    constants.LimitTypeTime,
+		LimitTimeSec: 120,
+		StepTime:     120,
+	}
+	if !shouldSignalCompletionForExpectedSteps(readComplete, expectedSteps) {
+		t.Fatal("final read step completion should signal whole-scenario completion")
+	}
+}
+
+func TestShouldSignalCompletionForExpectedStepsFallback(t *testing.T) {
+	complete := &PerformanceMetric{
+		TestState: constants.TestStateCompleted,
+		HasLimit:  false,
+	}
+	if !shouldSignalCompletionForExpectedSteps(complete, nil) {
+		t.Fatal("missing expected step IDs should preserve existing completion behavior")
+	}
+}


### PR DESCRIPTION
## Summary
- Prevent multi-host headless completion from firing on seed/precondition steps.
- Pass generated step IDs through the command and headless runner path so only the final scenario step ends the run.
- Preserve fallback completion behavior when expected step IDs are unavailable and add focused regression coverage.