### PR TITLE
Improve mixed workload reporting

### DIFF
--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/dell/storage-performance-tool/cli/internal/config"
@@ -25,7 +26,6 @@ import (
 	"github.com/dell/storage-performance-tool/cli/tui"
 	"github.com/dell/storage-performance-tool/cli/tui/headless"
 	"github.com/spf13/cobra"
-	"sync"
 )
 
 const (
@@ -73,6 +73,7 @@ var (
 		return &fetcherAdapter{results.NewFetcher(baseURL, outputDir)}
 	}
 	generateRunSummaryFunc = generateRunSummary
+	requestShutdownAllFunc = requestShutdownAll
 )
 
 // shouldRunHeadless determines if the application should run in headless mode
@@ -160,7 +161,7 @@ func startAutoResults(baseURL, label, resultsDir string, expectedStepIDs []strin
 		tracker := newRunTrackerFunc(baseURL)
 		// Wait for terminal run state; step IDs discovered later via metrics/json
 		if len(expectedStepIDs) > 0 {
-			fmt.Printf("Auto-results: expecting %d step(s)\n", len(expectedStepIDs))
+			writeProgress("Auto-results: expecting %d step(s)\n", len(expectedStepIDs))
 		}
 		tracker.SetDebug(debug)
 		// While we wait, continuously discover step IDs so we have exact IDs on completion
@@ -307,14 +308,6 @@ func startAutoResults(baseURL, label, resultsDir string, expectedStepIDs []strin
 			}
 		}
 		writeProgress("Auto-results: results saved to %s\n", root)
-		writer := summaryOut
-		if writer == nil {
-			writer = io.Discard
-		}
-		if err := generateRunSummaryFunc(context.Background(), root, writer); err != nil {
-			logging.LogError("auto-results", "generate summary", err)
-			writeProgress("Auto-results: summary generation encountered issues; see log.\n")
-		}
 
 		// Optional: graceful shutdown of all nodes via /shutdown
 		if shutdownOn {
@@ -327,13 +320,22 @@ func startAutoResults(baseURL, label, resultsDir string, expectedStepIDs []strin
 			if lingerSec <= 0 {
 				lingerSec = int(constants.APILingerDefault / time.Second)
 			}
-			reqErr := requestShutdownAll(shutdownCtx, allHosts, apiPort, time.Duration(lingerSec)*time.Second, debug)
+			reqErr := requestShutdownAllFunc(shutdownCtx, allHosts, apiPort, time.Duration(lingerSec)*time.Second, debug)
 			if reqErr != nil {
 				logging.LogError("auto-results", "shutdown encountered issues", reqErr)
 				writeProgress("Shutdown completed with warnings; see logs for details.\n")
 			} else {
 				writeProgress("Shutdown completed successfully.\n")
 			}
+		}
+
+		writer := summaryOut
+		if writer == nil {
+			writer = io.Discard
+		}
+		if err := generateRunSummaryFunc(context.Background(), root, writer); err != nil {
+			logging.LogError("auto-results", "generate summary", err)
+			writeProgress("Auto-results: summary generation encountered issues; see log.\n")
 		}
 	}()
 	return done

--- a/cli/cmd/run_auto_results_test.go
+++ b/cli/cmd/run_auto_results_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/dell/storage-performance-tool/cli/internal/constants"
+	"github.com/dell/storage-performance-tool/cli/internal/hostparse"
 	"github.com/dell/storage-performance-tool/cli/internal/portcheck"
 	"github.com/dell/storage-performance-tool/cli/internal/results"
 )
@@ -67,6 +68,39 @@ func (f *fakeFetcher) FetchArtifactsForSteps(ctx context.Context, stepIDs []stri
 		return f.manifest, f.err
 	}
 	return &results.Manifest{}, nil
+}
+
+type eventWriter struct {
+	mu     sync.Mutex
+	events []string
+}
+
+func (w *eventWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	for _, line := range strings.Split(string(p), "\n") {
+		if strings.TrimSpace(line) != "" {
+			w.events = append(w.events, line)
+		}
+	}
+	return len(p), nil
+}
+
+func (w *eventWriter) snapshot() []string {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	out := make([]string, len(w.events))
+	copy(out, w.events)
+	return out
+}
+
+func indexOfEventContaining(events []string, needle string) int {
+	for i, event := range events {
+		if strings.Contains(event, needle) {
+			return i
+		}
+	}
+	return -1
 }
 
 // TestStartAutoResults_StaleDiscoveredIDsFromPriorRun reproduces the bug where the background
@@ -492,5 +526,74 @@ func TestStartAutoResults_AppendsTraceArtifactToManifest(t *testing.T) {
 	traceCopyPath := filepath.Join(fetcher.output, filepath.Base(traceFile))
 	if _, err := os.Stat(traceCopyPath); err != nil {
 		t.Fatalf("expected trace file copied to results root: %v", err)
+	}
+}
+
+func TestStartAutoResults_EmitsSummaryAfterShutdown(t *testing.T) {
+	origRunTracker := newRunTrackerFunc
+	origDiscover := discoverStepIDsFunc
+	origFleetDiscover := discoverFleetStepIDsFunc
+	origFetcher := newResultsFetcherFunc
+	origSummary := generateRunSummaryFunc
+	origShutdown := requestShutdownAllFunc
+	defer func() {
+		newRunTrackerFunc = origRunTracker
+		discoverStepIDsFunc = origDiscover
+		discoverFleetStepIDsFunc = origFleetDiscover
+		newResultsFetcherFunc = origFetcher
+		generateRunSummaryFunc = origSummary
+		requestShutdownAllFunc = origShutdown
+	}()
+
+	stepID := "mt-001-20260604.195722.504-mixed"
+	newRunTrackerFunc = func(baseURL string) autoResultsRunTracker { return &fakeRunTracker{} }
+	discoverStepIDsFunc = func(baseURL string) ([]string, error) { return []string{stepID}, nil }
+	discoverFleetStepIDsFunc = func(baseURL string) ([]string, error) { return nil, nil }
+	newResultsFetcherFunc = func(baseURL, outputDir string) autoResultsFetcher {
+		return &fakeFetcher{output: outputDir}
+	}
+	requestShutdownAllFunc = func(context.Context, []*hostparse.HostInfo, string, time.Duration, bool) error {
+		return nil
+	}
+	generateRunSummaryFunc = func(ctx context.Context, runDir string, out io.Writer) error {
+		_, err := io.WriteString(out, "FINAL SUMMARY\n")
+		return err
+	}
+
+	events := &eventWriter{}
+	done := startAutoResults(
+		"http://example",
+		"mt",
+		t.TempDir(),
+		[]string{stepID},
+		false,
+		nil,
+		"9999",
+		true,
+		1,
+		"",
+		nil,
+		events,
+		events,
+		"",
+	)
+
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("startAutoResults did not complete in time")
+	}
+
+	got := events.snapshot()
+	summaryIndex := indexOfEventContaining(got, "FINAL SUMMARY")
+	shutdownIndex := indexOfEventContaining(got, "Shutdown completed successfully.")
+	if summaryIndex < 0 {
+		t.Fatalf("summary was not emitted; events=%v", got)
+	}
+	if shutdownIndex < 0 {
+		t.Fatalf("shutdown completion was not emitted; events=%v", got)
+	}
+	if summaryIndex <= shutdownIndex {
+		t.Fatalf("summary should be emitted after shutdown completion; events=%v", got)
 	}
 }

--- a/cli/cmd/run_summary_test.go
+++ b/cli/cmd/run_summary_test.go
@@ -193,6 +193,106 @@ func TestGenerateRunSummaryHandlesListWorkload(t *testing.T) {
 	}
 }
 
+func TestGenerateRunSummaryMixedWorkloadIncludesBreakdown(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	runID := "mt-20260604.180000.000"
+	runDir := filepath.Join(tempDir, runID)
+	if err := os.Mkdir(runDir, 0o755); err != nil {
+		t.Fatalf("mkdir run dir: %v", err)
+	}
+
+	stepID := "mt-002-20260604.180001.000-mixed"
+	metricsName := fmt.Sprintf("%s.%s", stepID, constants.ResultsArtifactSuffixMetricsTotal)
+	metricsCSV := "DateTimeISO8601,OpType,Concurrency,NodeCount,ConcurrencyCurr,ConcurrencyMean,CountSucc,CountFail,Size,StepDuration[s],DurationSum[s],TPAvg[op/s],TPLast[op/s],BWAvg[MB/s],BWLast[MB/s],DurationAvg[us],DurationMin[us],DurationQ_0.25[us],DurationQ_0.5[us],DurationQ_0.75[us],DurationMax[us],LatencyAvg[us],LatencyMin[us],LatencyQ_0.25[us],LatencyQ_0.5[us],LatencyQ_0.75[us],LatencyMax[us]\n" +
+		"\"2026-06-04T18:00:10Z\",READ,8,4,8,8,445,5,1866465280,30,20,14.8,13.9,59.3,55.6,8100,2200,4300,6200,9100,18000,8100,2200,4300,6200,9100,18000\n" +
+		"\"2026-06-04T18:00:10Z\",STAT,8,4,8,8,301,1,0,30,8,10.0,9.5,0,0,4200,1000,2100,3100,5000,9000,4200,1000,2100,3100,5000,9000\n" +
+		"\"2026-06-04T18:00:10Z\",CREATE,8,4,8,8,151,2,633339904,30,11,5.1,4.8,21.1,20.0,11200,3000,6200,8700,13000,25000,11200,3000,6200,8700,13000,25000\n" +
+		"\"2026-06-04T18:00:10Z\",DELETE,8,4,8,8,103,4,0,30,6,3.6,3.1,0,0,7300,1700,3000,5200,8600,14000,7300,1700,3000,5200,8600,14000\n"
+	if err := os.WriteFile(filepath.Join(runDir, metricsName), []byte(metricsCSV), 0o644); err != nil {
+		t.Fatalf("write metrics csv: %v", err)
+	}
+
+	manifest := &results.Manifest{
+		BaseURL:     "http://localhost:9999",
+		OutputDir:   runDir,
+		GeneratedAt: time.Now().UTC(),
+		Steps: []results.StepManifest{
+			{
+				StepID:      stepID,
+				CompletedAt: time.Now().UTC(),
+				Files: []results.FileStatus{{Name: metricsName, Size: int64(len(metricsCSV)), Status: "ok"}},
+			},
+		},
+	}
+	manifestBytes, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal manifest: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(runDir, constants.ResultsManifestFileName), manifestBytes, 0o644); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+
+	meta := &runMetadata{
+		GeneratedAt:        time.Date(2026, 6, 4, 18, 0, 0, 0, time.UTC),
+		WorkloadType:       "mixed",
+		SptImage:           "ghcr.io/dell/storage-performance-tool",
+		APIPort:            "9999",
+		BaseURL:            "http://localhost:9999",
+		Label:              "mt",
+		ResultsDir:         "./results",
+		ResultsRoot:        filepath.Base(runDir),
+		ScenarioFile:       "scenario.js",
+		ScenarioStoredPath: "scenario.js",
+		ScenarioParams: scenario.Params{
+			WorkloadType:  "mixed",
+			ObjectSize:    "4MB",
+			Threads:       8,
+			Duration:      "30s",
+			GetDistrib:    45,
+			StatDistrib:   30,
+			PutDistrib:    15,
+			DeleteDistrib: 10,
+		},
+		Hosts: []runHostMetadata{{Host: "localhost", User: "tester", Original: "tester@localhost"}},
+		ExpectedStepIDs: []string{stepID},
+		ActualStepIDs:   []string{stepID},
+	}
+	if err := writeRunMetadata(meta, runDir); err != nil {
+		t.Fatalf("write run metadata: %v", err)
+	}
+
+	var buf strings.Builder
+	if err := generateRunSummary(context.Background(), runDir, &buf); err != nil {
+		t.Fatalf("generateRunSummary error: %v", err)
+	}
+
+	snippet := buf.String()
+	if !strings.Contains(snippet, "Mixed Operation Breakdown") {
+		t.Fatalf("snippet missing mixed section: %q", snippet)
+	}
+	if !strings.Contains(snippet, "Configured distribution: READ 45%, STAT 30%, CREATE 15%, DELETE 10%") {
+		t.Fatalf("snippet missing configured mixed detail: %q", snippet)
+	}
+
+	summaryPath := filepath.Join(runDir, fmt.Sprintf(constants.ResultsSummaryFilePattern, runID))
+	content, err := os.ReadFile(summaryPath)
+	if err != nil {
+		t.Fatalf("read summary file: %v", err)
+	}
+	report := string(content)
+	if !strings.Contains(report, "Mixed Operation Breakdown") {
+		t.Fatalf("summary file missing mixed section: %s", report)
+	}
+	if !strings.Contains(report, "Configured distribution: READ 45%, STAT 30%, CREATE 15%, DELETE 10%") {
+		t.Fatalf("summary file missing configured distribution: %s", report)
+	}
+	if !strings.Contains(report, "see ops") {
+		t.Fatalf("summary file missing mixed latency marker: %s", report)
+	}
+}
+
 func TestGenerateRunSummaryErrorOnMissingManifest(t *testing.T) {
 	t.Parallel()
 

--- a/cli/cmd/run_summary_test.go
+++ b/cli/cmd/run_summary_test.go
@@ -222,7 +222,7 @@ func TestGenerateRunSummaryMixedWorkloadIncludesBreakdown(t *testing.T) {
 			{
 				StepID:      stepID,
 				CompletedAt: time.Now().UTC(),
-				Files: []results.FileStatus{{Name: metricsName, Size: int64(len(metricsCSV)), Status: "ok"}},
+				Files:       []results.FileStatus{{Name: metricsName, Size: int64(len(metricsCSV)), Status: "ok"}},
 			},
 		},
 	}
@@ -255,7 +255,7 @@ func TestGenerateRunSummaryMixedWorkloadIncludesBreakdown(t *testing.T) {
 			PutDistrib:    15,
 			DeleteDistrib: 10,
 		},
-		Hosts: []runHostMetadata{{Host: "localhost", User: "tester", Original: "tester@localhost"}},
+		Hosts:           []runHostMetadata{{Host: "localhost", User: "tester", Original: "tester@localhost"}},
 		ExpectedStepIDs: []string{stepID},
 		ActualStepIDs:   []string{stepID},
 	}
@@ -290,6 +290,97 @@ func TestGenerateRunSummaryMixedWorkloadIncludesBreakdown(t *testing.T) {
 	}
 	if !strings.Contains(report, "see ops") {
 		t.Fatalf("summary file missing mixed latency marker: %s", report)
+	}
+}
+
+func TestGenerateRunSummaryMixedWorkloadPropagatesDistributionWarning(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	runID := "mt-20260604.190000.000"
+	runDir := filepath.Join(tempDir, runID)
+	if err := os.Mkdir(runDir, 0o755); err != nil {
+		t.Fatalf("mkdir run dir: %v", err)
+	}
+
+	stepID := "mt-002-20260604.190001.000-mixed"
+	metricsName := fmt.Sprintf("%s.%s", stepID, constants.ResultsArtifactSuffixMetricsTotal)
+	metricsCSV := "DateTimeISO8601,OpType,Concurrency,NodeCount,ConcurrencyCurr,ConcurrencyMean,CountSucc,CountFail,Size,StepDuration[s],DurationSum[s],TPAvg[op/s],TPLast[op/s],BWAvg[MB/s],BWLast[MB/s],DurationAvg[us],DurationMin[us],DurationQ_0.25[us],DurationQ_0.5[us],DurationQ_0.75[us],DurationMax[us],LatencyAvg[us],LatencyMin[us],LatencyQ_0.25[us],LatencyQ_0.5[us],LatencyQ_0.75[us],LatencyMax[us]\n" +
+		"\"2026-06-04T19:00:10Z\",READ,8,4,8,8,445,5,1866465280,30,20,14.8,13.9,59.3,55.6,8100,2200,4300,6200,9100,18000,8100,2200,4300,6200,9100,18000\n" +
+		"\"2026-06-04T19:00:10Z\",STAT,8,4,8,8,301,1,0,30,8,10.0,9.5,0,0,4200,1000,2100,3100,5000,9000,4200,1000,2100,3100,5000,9000\n" +
+		"\"2026-06-04T19:00:10Z\",CREATE,8,4,8,8,151,2,633339904,30,11,5.1,4.8,21.1,20.0,11200,3000,6200,8700,13000,25000,11200,3000,6200,8700,13000,25000\n" +
+		"\"2026-06-04T19:00:10Z\",DELETE,8,4,8,8,103,4,0,30,6,3.6,3.1,0,0,7300,1700,3000,5200,8600,14000,7300,1700,3000,5200,8600,14000\n"
+	if err := os.WriteFile(filepath.Join(runDir, metricsName), []byte(metricsCSV), 0o644); err != nil {
+		t.Fatalf("write metrics csv: %v", err)
+	}
+
+	manifest := &results.Manifest{
+		BaseURL:     "http://localhost:9999",
+		OutputDir:   runDir,
+		GeneratedAt: time.Now().UTC(),
+		Steps: []results.StepManifest{
+			{
+				StepID:      stepID,
+				CompletedAt: time.Now().UTC(),
+				Files:       []results.FileStatus{{Name: metricsName, Size: int64(len(metricsCSV)), Status: "ok"}},
+			},
+		},
+	}
+	manifestBytes, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal manifest: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(runDir, constants.ResultsManifestFileName), manifestBytes, 0o644); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+
+	meta := &runMetadata{
+		GeneratedAt:        time.Date(2026, 6, 4, 19, 0, 0, 0, time.UTC),
+		WorkloadType:       "mixed",
+		SptImage:           "ghcr.io/dell/storage-performance-tool",
+		APIPort:            "9999",
+		BaseURL:            "http://localhost:9999",
+		Label:              "mt",
+		ResultsDir:         "./results",
+		ResultsRoot:        filepath.Base(runDir),
+		ScenarioFile:       "scenario.js",
+		ScenarioStoredPath: "scenario.js",
+		ScenarioParams: scenario.Params{
+			WorkloadType:  "mixed",
+			ObjectSize:    "4MB",
+			Threads:       8,
+			Duration:      "30s",
+			GetDistrib:    45,
+			StatDistrib:   30,
+			PutDistrib:    10,
+			DeleteDistrib: 5,
+		},
+		Hosts:           []runHostMetadata{{Host: "localhost", User: "tester", Original: "tester@localhost"}},
+		ExpectedStepIDs: []string{stepID},
+		ActualStepIDs:   []string{stepID},
+	}
+	if err := writeRunMetadata(meta, runDir); err != nil {
+		t.Fatalf("write run metadata: %v", err)
+	}
+
+	var buf strings.Builder
+	if err := generateRunSummary(context.Background(), runDir, &buf); err != nil {
+		t.Fatalf("generateRunSummary error: %v", err)
+	}
+
+	const wantWarning = "mixed configured distribution sums to 90%, expected 100%"
+	snippet := buf.String()
+	if !strings.Contains(snippet, wantWarning) {
+		t.Fatalf("snippet missing warning %q: %q", wantWarning, snippet)
+	}
+
+	summaryPath := filepath.Join(runDir, fmt.Sprintf(constants.ResultsSummaryFilePattern, runID))
+	content, err := os.ReadFile(summaryPath)
+	if err != nil {
+		t.Fatalf("read summary file: %v", err)
+	}
+	if !strings.Contains(string(content), wantWarning) {
+		t.Fatalf("summary file missing warning %q: %s", wantWarning, string(content))
 	}
 }
 

--- a/cli/internal/results/summary/aggregate.go
+++ b/cli/internal/results/summary/aggregate.go
@@ -303,7 +303,7 @@ func buildStepSummaries(data *RunData, workload WorkloadSummary) ([]StepSummary,
 			summary.Metrics = metrics
 			totals.DurationSeconds += metrics.DurationSeconds
 			totals.DataBytes += metrics.DataBytes
-		} else {
+		} else if !stepData.MetricsSuppressed {
 			statusLabel := string(stepData.Status)
 			if statusLabel == "" {
 				statusLabel = string(StepStatusUnknown)

--- a/cli/internal/results/summary/aggregate.go
+++ b/cli/internal/results/summary/aggregate.go
@@ -68,6 +68,7 @@ type WorkloadSummary struct {
 	CleanupEnabled  bool
 	KeepScenario    bool
 	SliceEndpoints  bool
+	MixedDistribution MixedDistribution
 }
 
 // StepSummary aggregates per-step metrics and artifact health.
@@ -78,9 +79,28 @@ type StepSummary struct {
 	Operation       string
 	Status          StepStatus
 	Metrics         *PhaseMetrics
+	IsMixed         bool
+	OperationBreakdown []OperationBreakdown
+	MixedLatencyNote string
 	MissingRequired []string
 	MissingOptional []string
 	Notes           []string
+}
+
+type MixedDistribution struct {
+	Available     bool
+	ReadPercent   int
+	StatPercent   int
+	CreatePercent int
+	DeletePercent int
+}
+
+type OperationBreakdown struct {
+	Operation       string
+	ConfiguredShare *float64
+	ActualShare     *float64
+	ActualOps       int64
+	Metrics         PhaseMetrics
 }
 
 // PhaseMetrics holds derived statistics for a single run phase.
@@ -154,7 +174,7 @@ func Aggregate(data *RunData) (*RunSummary, error) {
 	summary.Workload = workload
 	summary.Warnings = append(summary.Warnings, workloadWarnings...)
 
-	steps, totals, stepWarnings := buildStepSummaries(data, workload.ObjectSizeBytes)
+	steps, totals, stepWarnings := buildStepSummaries(data, workload)
 	summary.Steps = steps
 	summary.Totals = totals
 	summary.Warnings = append(summary.Warnings, stepWarnings...)
@@ -220,6 +240,7 @@ func buildWorkloadSummary(data *RunData) (WorkloadSummary, []string) {
 		CleanupEnabled:  params.Cleanup,
 		KeepScenario:    params.KeepScenario,
 		SliceEndpoints:  params.SliceEndpoints,
+		MixedDistribution: mixedDistributionFromParams(data.Params.WorkloadType, params),
 	}
 	if isList {
 		summary.ObjectSizeHuman = ""
@@ -227,7 +248,7 @@ func buildWorkloadSummary(data *RunData) (WorkloadSummary, []string) {
 	return summary, warnings
 }
 
-func buildStepSummaries(data *RunData, objectSizeBytes int64) ([]StepSummary, RunTotals, []string) {
+func buildStepSummaries(data *RunData, workload WorkloadSummary) ([]StepSummary, RunTotals, []string) {
 	steps := make([]StepSummary, 0, len(data.StepOrder))
 	totals := RunTotals{}
 	warnings := make([]string, 0)
@@ -248,7 +269,19 @@ func buildStepSummaries(data *RunData, objectSizeBytes int64) ([]StepSummary, Ru
 			Notes:           append([]string(nil), stepData.Notes...),
 		}
 
-		metrics := deriveMetrics(stepData, objectSizeBytes)
+		var metrics *PhaseMetrics
+		if isMixedStep(stepData.StepID, workload, stepData.Metrics) {
+			var mixedWarnings []string
+			metrics, summary.OperationBreakdown, mixedWarnings = deriveMixedMetrics(stepData, workload, workload.ObjectSizeBytes)
+			summary.IsMixed = metrics != nil
+			if summary.IsMixed {
+				summary.Operation = "MIXED"
+				summary.MixedLatencyNote = "Mixed latency is shown per operation; no combined p50 is derived from per-op quantiles."
+			}
+			warnings = append(warnings, mixedWarnings...)
+		} else {
+			metrics = deriveMetrics(stepData, workload.ObjectSizeBytes)
+		}
 		if metrics != nil {
 			summary.Metrics = metrics
 			totals.DurationSeconds += metrics.DurationSeconds
@@ -272,6 +305,229 @@ func buildStepSummaries(data *RunData, objectSizeBytes int64) ([]StepSummary, Ru
 	totals.DataMB = bytesToMB(totals.DataBytes)
 	totals.DataGiB = bytesToGiB(totals.DataBytes)
 	return steps, totals, warnings
+}
+
+func mixedDistributionFromParams(workloadType string, params ScenarioParams) MixedDistribution {
+	if !strings.EqualFold(workloadType, "mixed") && !strings.EqualFold(params.WorkloadType, "mixed") {
+		return MixedDistribution{}
+	}
+	return MixedDistribution{
+		Available:     true,
+		ReadPercent:   params.GetDistrib,
+		StatPercent:   params.StatDistrib,
+		CreatePercent: params.PutDistrib,
+		DeletePercent: params.DeleteDistrib,
+	}
+	}
+
+func isMixedStep(stepID string, workload WorkloadSummary, totals *MetricsTotals) bool {
+	if totals == nil || len(totals.Rows) < 2 {
+		return false
+	}
+	if !strings.EqualFold(workload.Type, "mixed") {
+		return false
+	}
+	if !strings.HasSuffix(strings.ToLower(stepID), "-mixed") {
+		return false
+	}
+	seen := make(map[string]struct{}, len(totals.Rows))
+	for _, row := range totals.Rows {
+		op := normalizeReportOperation(row.Operation)
+		if op == "" {
+			continue
+		}
+		seen[op] = struct{}{}
+	}
+	return len(seen) >= 2
+}
+
+func deriveMixedMetrics(stepData *StepData, workload WorkloadSummary, objectSizeBytes int64) (*PhaseMetrics, []OperationBreakdown, []string) {
+	if stepData == nil || stepData.Metrics == nil || len(stepData.Metrics.Rows) == 0 {
+		return nil, nil, nil
+	}
+	groups := make(map[string][]MetricsTotalsRow, len(stepData.Metrics.Rows))
+	for _, row := range stepData.Metrics.Rows {
+		op := normalizeReportOperation(row.Operation)
+		if op == "" {
+			op = strings.ToUpper(strings.TrimSpace(row.Operation))
+		}
+		groups[op] = append(groups[op], row)
+	}
+
+	warnings := make([]string, 0, 1)
+	if workload.MixedDistribution.Available {
+		sum := workload.MixedDistribution.ReadPercent + workload.MixedDistribution.StatPercent + workload.MixedDistribution.CreatePercent + workload.MixedDistribution.DeletePercent
+		if sum != 100 {
+			warnings = append(warnings, fmt.Sprintf("mixed configured distribution sums to %d%%, expected 100%%", sum))
+		}
+	}
+
+	orderedOps := orderedOperationKeys(groups)
+	breakdown := make([]OperationBreakdown, 0, len(orderedOps))
+	metrics := &PhaseMetrics{}
+	var totalActualOps int64
+	for _, op := range orderedOps {
+		opMetrics := deriveOperationMetrics(groups[op], objectSizeBytes)
+		actualOps := opMetrics.SuccessCount + opMetrics.FailureCount
+		totalActualOps += actualOps
+		breakdown = append(breakdown, OperationBreakdown{
+			Operation:       op,
+			ConfiguredShare: operationConfiguredShare(op, workload.MixedDistribution),
+			ActualOps:       actualOps,
+			Metrics:         opMetrics,
+		})
+		metrics.SuccessCount += opMetrics.SuccessCount
+		metrics.FailureCount += opMetrics.FailureCount
+		metrics.DataBytes += opMetrics.DataBytes
+		metrics.ThroughputAvgOps += opMetrics.ThroughputAvgOps
+		metrics.ThroughputLastOps += opMetrics.ThroughputLastOps
+		metrics.BandwidthAvgMBps += opMetrics.BandwidthAvgMBps
+		metrics.BandwidthLastMBps += opMetrics.BandwidthLastMBps
+		if opMetrics.DurationSeconds > metrics.DurationSeconds {
+			metrics.DurationSeconds = opMetrics.DurationSeconds
+		}
+		if opMetrics.Concurrency > metrics.Concurrency {
+			metrics.Concurrency = opMetrics.Concurrency
+		}
+		if opMetrics.ConcurrencyMean > metrics.ConcurrencyMean {
+			metrics.ConcurrencyMean = opMetrics.ConcurrencyMean
+		}
+		if opMetrics.NodeCount > metrics.NodeCount {
+			metrics.NodeCount = opMetrics.NodeCount
+		}
+		if opMetrics.SampleTimestamp > metrics.SampleTimestamp {
+			metrics.SampleTimestamp = opMetrics.SampleTimestamp
+		}
+	}
+	metrics.DurationHuman = formatSeconds(metrics.DurationSeconds)
+	metrics.DataMB = bytesToMB(metrics.DataBytes)
+	metrics.DataGiB = bytesToGiB(metrics.DataBytes)
+	metrics.HasDataTransfer = metrics.DataBytes > 0
+	if objectSizeBytes > 0 {
+		metrics.ObjectSizeBytes = objectSizeBytes
+		metrics.ObjectSizeMB = bytesToMB(objectSizeBytes)
+		metrics.ObjectSizeGiB = bytesToGiB(objectSizeBytes)
+		metrics.ObjectSizeHuman = formatBytes(objectSizeBytes)
+	}
+	if totalActualOps > 0 {
+		for i := range breakdown {
+			share := float64(breakdown[i].ActualOps) * 100 / float64(totalActualOps)
+			breakdown[i].ActualShare = &share
+		}
+	}
+	return metrics, breakdown, warnings
+}
+
+func deriveOperationMetrics(rows []MetricsTotalsRow, objectSizeBytes int64) PhaseMetrics {
+	if len(rows) == 0 {
+		return PhaseMetrics{}
+	}
+	best := rows[0]
+	metrics := PhaseMetrics{}
+	for _, row := range rows {
+		metrics.SuccessCount += row.SuccessCount
+		metrics.FailureCount += row.FailureCount
+		metrics.DataBytes += row.SizeBytes
+		metrics.ThroughputAvgOps += row.ThroughputAvgOps
+		metrics.ThroughputLastOps += row.ThroughputLastOps
+		metrics.BandwidthAvgMBps += row.BandwidthAvgMBps
+		metrics.BandwidthLastMBps += row.BandwidthLastMBps
+		if row.StepDurationSeconds > metrics.DurationSeconds {
+			metrics.DurationSeconds = row.StepDurationSeconds
+		}
+		if row.Concurrency > metrics.Concurrency {
+			metrics.Concurrency = row.Concurrency
+		}
+		if row.ConcurrencyMean > metrics.ConcurrencyMean {
+			metrics.ConcurrencyMean = row.ConcurrencyMean
+		}
+		if row.NodeCount > metrics.NodeCount {
+			metrics.NodeCount = row.NodeCount
+		}
+		if row.SampleTimestamp > metrics.SampleTimestamp {
+			metrics.SampleTimestamp = row.SampleTimestamp
+		}
+		if row.SuccessCount+row.FailureCount > best.SuccessCount+best.FailureCount {
+			best = row
+		}
+	}
+	metrics.DataMB = bytesToMB(metrics.DataBytes)
+	metrics.DataGiB = bytesToGiB(metrics.DataBytes)
+	metrics.HasDataTransfer = metrics.DataBytes > 0
+	metrics.DurationHuman = formatSeconds(metrics.DurationSeconds)
+	metrics.LatencyHeadlineMs = preferredLatencyMicros(best) / 1000.0
+	metrics.LatencyMedianMs = best.LatencyP50Micros / 1000.0
+	metrics.LatencyP90Ms = best.LatencyP90Micros / 1000.0
+	metrics.LatencyP99Ms = best.LatencyP99Micros / 1000.0
+	metrics.LatencyP999Ms = best.LatencyP999Micros / 1000.0
+	metrics.TTFBMedianMs = best.TTFBP50Micros / 1000.0
+	metrics.TTFBP90Ms = best.TTFBP90Micros / 1000.0
+	metrics.TTFBP99Ms = best.TTFBP99Micros / 1000.0
+	metrics.TTFBP999Ms = best.TTFBP999Micros / 1000.0
+	if objectSizeBytes > 0 {
+		metrics.ObjectSizeBytes = objectSizeBytes
+		metrics.ObjectSizeMB = bytesToMB(objectSizeBytes)
+		metrics.ObjectSizeGiB = bytesToGiB(objectSizeBytes)
+		metrics.ObjectSizeHuman = formatBytes(objectSizeBytes)
+	}
+	return metrics
+}
+
+func operationConfiguredShare(op string, dist MixedDistribution) *float64 {
+	if !dist.Available {
+		return nil
+	}
+	var value float64
+	switch normalizeReportOperation(op) {
+	case "READ":
+		value = float64(dist.ReadPercent)
+	case "STAT":
+		value = float64(dist.StatPercent)
+	case "CREATE":
+		value = float64(dist.CreatePercent)
+	case "DELETE":
+		value = float64(dist.DeletePercent)
+	default:
+		return nil
+	}
+	return &value
+}
+
+func orderedOperationKeys(groups map[string][]MetricsTotalsRow) []string {
+	ordered := make([]string, 0, len(groups))
+	for _, op := range []string{"READ", "STAT", "CREATE", "DELETE"} {
+		if _, ok := groups[op]; ok {
+			ordered = append(ordered, op)
+		}
+	}
+	unknown := make([]string, 0, len(groups))
+	for op := range groups {
+		switch op {
+		case "READ", "STAT", "CREATE", "DELETE":
+			continue
+		default:
+			unknown = append(unknown, op)
+		}
+	}
+	if len(unknown) > 1 {
+		sort.Strings(unknown)
+	}
+	return append(ordered, unknown...)
+}
+
+func normalizeReportOperation(op string) string {
+	switch strings.ToUpper(strings.TrimSpace(op)) {
+	case "GET", "READ":
+		return "READ"
+	case "HEAD", "STAT":
+		return "STAT"
+	case "PUT", "CREATE", "WRITE":
+		return "CREATE"
+	case "DELETE":
+		return "DELETE"
+	default:
+		return strings.ToUpper(strings.TrimSpace(op))
+	}
 }
 
 func deriveMetrics(stepData *StepData, objectSizeBytes int64) *PhaseMetrics {
@@ -351,6 +607,15 @@ func phaseLabelFromStep(stepID string) string {
 	if stepID == "" {
 		return ""
 	}
+	lowerStepID := strings.ToLower(stepID)
+	switch {
+	case strings.HasSuffix(lowerStepID, "-cleanup-seed"):
+		return "Cleanup seed"
+	case strings.HasSuffix(lowerStepID, "-cleanup-put"):
+		return "Cleanup CREATE"
+	case strings.HasSuffix(lowerStepID, "-mixed"):
+		return "Mixed"
+	}
 	parts := strings.Split(stepID, "-")
 	if len(parts) == 0 {
 		return ""
@@ -363,17 +628,26 @@ func phaseLabelFromStep(stepID string) string {
 }
 
 func operationFromStep(stepID string, totals *MetricsTotals) string {
+	if strings.HasSuffix(strings.ToLower(stepID), "-mixed") {
+		return "MIXED"
+	}
+	if totals != nil && len(totals.Rows) == 1 {
+		op := normalizeReportOperation(totals.Rows[0].Operation)
+		if op != "" {
+			return op
+		}
+	}
 	if stepID != "" {
 		parts := strings.Split(stepID, "-")
 		if len(parts) > 0 {
 			op := parts[len(parts)-1]
 			if op != "" {
-				return strings.ToUpper(op)
+				return normalizeReportOperation(op)
 			}
 		}
 	}
 	if totals != nil && len(totals.Rows) > 0 {
-		return strings.ToUpper(strings.TrimSpace(totals.Rows[0].Operation))
+		return normalizeReportOperation(totals.Rows[0].Operation)
 	}
 	return ""
 }

--- a/cli/internal/results/summary/aggregate.go
+++ b/cli/internal/results/summary/aggregate.go
@@ -54,39 +54,40 @@ type HostSummary struct {
 
 // WorkloadSummary records key scenario parameters.
 type WorkloadSummary struct {
-	Type            string
-	ObjectSizeBytes int64
-	ObjectSizeMB    float64
-	ObjectSizeGiB   float64
-	ObjectSizeHuman string
-	ObjectCount     int64
-	Threads         int
-	Endpoints       []string
-	Bucket          string
-	Prefix          string
-	DurationRequest string
-	CleanupEnabled  bool
-	KeepScenario    bool
-	SliceEndpoints  bool
+	Type              string
+	ObjectSizeBytes   int64
+	ObjectSizeMB      float64
+	ObjectSizeGiB     float64
+	ObjectSizeHuman   string
+	ObjectCount       int64
+	Threads           int
+	Endpoints         []string
+	Bucket            string
+	Prefix            string
+	DurationRequest   string
+	CleanupEnabled    bool
+	KeepScenario      bool
+	SliceEndpoints    bool
 	MixedDistribution MixedDistribution
 }
 
 // StepSummary aggregates per-step metrics and artifact health.
 type StepSummary struct {
-	Ordinal         int
-	StepID          string
-	PhaseLabel      string
-	Operation       string
-	Status          StepStatus
-	Metrics         *PhaseMetrics
-	IsMixed         bool
+	Ordinal            int
+	StepID             string
+	PhaseLabel         string
+	Operation          string
+	Status             StepStatus
+	Metrics            *PhaseMetrics
+	IsMixed            bool
 	OperationBreakdown []OperationBreakdown
-	MixedLatencyNote string
-	MissingRequired []string
-	MissingOptional []string
-	Notes           []string
+	MixedLatencyNote   string
+	MissingRequired    []string
+	MissingOptional    []string
+	Notes              []string
 }
 
+// MixedDistribution stores the configured mixed-workload share for each known operation.
 type MixedDistribution struct {
 	Available     bool
 	ReadPercent   int
@@ -95,6 +96,7 @@ type MixedDistribution struct {
 	DeletePercent int
 }
 
+// OperationBreakdown holds one operation-specific row within a mixed step summary.
 type OperationBreakdown struct {
 	Operation       string
 	ConfiguredShare *float64
@@ -146,10 +148,21 @@ type RunTotals struct {
 }
 
 const (
-	bytesInKB = 1024
-	bytesInMB = bytesInKB * 1024
-	bytesInGB = bytesInMB * 1024
+	bytesInKB             = 1024
+	bytesInMB             = bytesInKB * 1024
+	bytesInGB             = bytesInMB * 1024
+	reportOperationRead   = "READ"
+	reportOperationStat   = "STAT"
+	reportOperationCreate = "CREATE"
+	reportOperationDelete = "DELETE"
 )
+
+var mixedOperationOrder = []string{
+	reportOperationRead,
+	reportOperationStat,
+	reportOperationCreate,
+	reportOperationDelete,
+}
 
 // Aggregate builds a RunSummary from Loader output.
 func Aggregate(data *RunData) (*RunSummary, error) {
@@ -224,23 +237,27 @@ func buildWorkloadSummary(data *RunData) (WorkloadSummary, []string) {
 	if sizeWarn != nil {
 		warnings = append(warnings, fmt.Sprintf("object size parse error: %v", sizeWarn))
 	}
-	isList := strings.EqualFold(data.Params.WorkloadType, workloadTypeList)
+	workloadType := strings.ToLower(strings.TrimSpace(data.Params.WorkloadType))
+	if workloadType == "" {
+		workloadType = strings.ToLower(strings.TrimSpace(params.WorkloadType))
+	}
+	isList := strings.EqualFold(workloadType, workloadTypeList)
 	summary := WorkloadSummary{
-		Type:            strings.ToLower(data.Params.WorkloadType),
-		ObjectSizeBytes: sizeBytes,
-		ObjectSizeMB:    bytesToMB(sizeBytes),
-		ObjectSizeGiB:   bytesToGiB(sizeBytes),
-		ObjectSizeHuman: formatBytes(sizeBytes),
-		ObjectCount:     params.ObjectCount,
-		Threads:         params.Threads,
-		Endpoints:       append([]string(nil), params.Endpoints...),
-		Bucket:          params.Bucket,
-		Prefix:          params.Prefix,
-		DurationRequest: params.Duration,
-		CleanupEnabled:  params.Cleanup,
-		KeepScenario:    params.KeepScenario,
-		SliceEndpoints:  params.SliceEndpoints,
-		MixedDistribution: mixedDistributionFromParams(data.Params.WorkloadType, params),
+		Type:              workloadType,
+		ObjectSizeBytes:   sizeBytes,
+		ObjectSizeMB:      bytesToMB(sizeBytes),
+		ObjectSizeGiB:     bytesToGiB(sizeBytes),
+		ObjectSizeHuman:   formatBytes(sizeBytes),
+		ObjectCount:       params.ObjectCount,
+		Threads:           params.Threads,
+		Endpoints:         append([]string(nil), params.Endpoints...),
+		Bucket:            params.Bucket,
+		Prefix:            params.Prefix,
+		DurationRequest:   params.Duration,
+		CleanupEnabled:    params.Cleanup,
+		KeepScenario:      params.KeepScenario,
+		SliceEndpoints:    params.SliceEndpoints,
+		MixedDistribution: mixedDistributionFromParams(workloadType, params),
 	}
 	if isList {
 		summary.ObjectSizeHuman = ""
@@ -311,6 +328,9 @@ func mixedDistributionFromParams(workloadType string, params ScenarioParams) Mix
 	if !strings.EqualFold(workloadType, "mixed") && !strings.EqualFold(params.WorkloadType, "mixed") {
 		return MixedDistribution{}
 	}
+	if params.GetDistrib == 0 && params.StatDistrib == 0 && params.PutDistrib == 0 && params.DeleteDistrib == 0 {
+		return MixedDistribution{}
+	}
 	return MixedDistribution{
 		Available:     true,
 		ReadPercent:   params.GetDistrib,
@@ -318,27 +338,23 @@ func mixedDistributionFromParams(workloadType string, params ScenarioParams) Mix
 		CreatePercent: params.PutDistrib,
 		DeletePercent: params.DeleteDistrib,
 	}
-	}
+}
 
 func isMixedStep(stepID string, workload WorkloadSummary, totals *MetricsTotals) bool {
 	if totals == nil || len(totals.Rows) < 2 {
 		return false
 	}
-	if !strings.EqualFold(workload.Type, "mixed") {
+	seen, allKnown := mixedOperationSet(totals.Rows)
+	if len(seen) < 2 {
 		return false
 	}
-	if !strings.HasSuffix(strings.ToLower(stepID), "-mixed") {
-		return false
+	if strings.HasSuffix(strings.ToLower(stepID), "-mixed") {
+		return true
 	}
-	seen := make(map[string]struct{}, len(totals.Rows))
-	for _, row := range totals.Rows {
-		op := normalizeReportOperation(row.Operation)
-		if op == "" {
-			continue
-		}
-		seen[op] = struct{}{}
+	if strings.EqualFold(workload.Type, "mixed") {
+		return true
 	}
-	return len(seen) >= 2
+	return allKnown
 }
 
 func deriveMixedMetrics(stepData *StepData, workload WorkloadSummary, objectSizeBytes int64) (*PhaseMetrics, []OperationBreakdown, []string) {
@@ -349,9 +365,12 @@ func deriveMixedMetrics(stepData *StepData, workload WorkloadSummary, objectSize
 	for _, row := range stepData.Metrics.Rows {
 		op := normalizeReportOperation(row.Operation)
 		if op == "" {
-			op = strings.ToUpper(strings.TrimSpace(row.Operation))
+			continue
 		}
 		groups[op] = append(groups[op], row)
+	}
+	if len(groups) == 0 {
+		return nil, nil, nil
 	}
 
 	warnings := make([]string, 0, 1)
@@ -479,13 +498,13 @@ func operationConfiguredShare(op string, dist MixedDistribution) *float64 {
 	}
 	var value float64
 	switch normalizeReportOperation(op) {
-	case "READ":
+	case reportOperationRead:
 		value = float64(dist.ReadPercent)
-	case "STAT":
+	case reportOperationStat:
 		value = float64(dist.StatPercent)
-	case "CREATE":
+	case reportOperationCreate:
 		value = float64(dist.CreatePercent)
-	case "DELETE":
+	case reportOperationDelete:
 		value = float64(dist.DeletePercent)
 	default:
 		return nil
@@ -495,17 +514,14 @@ func operationConfiguredShare(op string, dist MixedDistribution) *float64 {
 
 func orderedOperationKeys(groups map[string][]MetricsTotalsRow) []string {
 	ordered := make([]string, 0, len(groups))
-	for _, op := range []string{"READ", "STAT", "CREATE", "DELETE"} {
+	for _, op := range mixedOperationOrder {
 		if _, ok := groups[op]; ok {
 			ordered = append(ordered, op)
 		}
 	}
 	unknown := make([]string, 0, len(groups))
 	for op := range groups {
-		switch op {
-		case "READ", "STAT", "CREATE", "DELETE":
-			continue
-		default:
+		if !isKnownMixedOperation(op) {
 			unknown = append(unknown, op)
 		}
 	}
@@ -517,16 +533,41 @@ func orderedOperationKeys(groups map[string][]MetricsTotalsRow) []string {
 
 func normalizeReportOperation(op string) string {
 	switch strings.ToUpper(strings.TrimSpace(op)) {
-	case "GET", "READ":
-		return "READ"
-	case "HEAD", "STAT":
-		return "STAT"
-	case "PUT", "CREATE", "WRITE":
-		return "CREATE"
-	case "DELETE":
-		return "DELETE"
+	case "GET", reportOperationRead:
+		return reportOperationRead
+	case "HEAD", reportOperationStat:
+		return reportOperationStat
+	case "PUT", reportOperationCreate, "WRITE":
+		return reportOperationCreate
+	case reportOperationDelete:
+		return reportOperationDelete
 	default:
 		return strings.ToUpper(strings.TrimSpace(op))
+	}
+}
+
+func mixedOperationSet(rows []MetricsTotalsRow) (map[string]struct{}, bool) {
+	seen := make(map[string]struct{}, len(rows))
+	allKnown := true
+	for _, row := range rows {
+		op := normalizeReportOperation(row.Operation)
+		if op == "" {
+			continue
+		}
+		seen[op] = struct{}{}
+		if !isKnownMixedOperation(op) {
+			allKnown = false
+		}
+	}
+	return seen, allKnown && len(seen) > 0
+}
+
+func isKnownMixedOperation(op string) bool {
+	switch op {
+	case reportOperationRead, reportOperationStat, reportOperationCreate, reportOperationDelete:
+		return true
+	default:
+		return false
 	}
 }
 

--- a/cli/internal/results/summary/aggregate_test.go
+++ b/cli/internal/results/summary/aggregate_test.go
@@ -261,6 +261,145 @@ func TestAggregateListWorkloadOmitsObjectSize(t *testing.T) {
 	}
 }
 
+func TestAggregateBuildsMixedSummary(t *testing.T) {
+	t.Parallel()
+
+	stepID := "mt-002-20260604.180001.000-mixed"
+	runData := &RunData{
+		RunID:     "mt-20260604.180000.000",
+		StepOrder: []string{stepID},
+		Steps:     make(map[string]*StepData),
+		Params: &RunParams{
+			WorkloadType: "mixed",
+			ScenarioParams: ScenarioParams{
+				WorkloadType:  "mixed",
+				ObjectSize:    "4MB",
+				Duration:      "30s",
+				GetDistrib:    45,
+				StatDistrib:   30,
+				PutDistrib:    15,
+				DeleteDistrib: 10,
+			},
+		},
+	}
+
+	runData.Steps[stepID] = &StepData{
+		StepID: stepID,
+		Status: StepStatusComplete,
+		Metrics: &MetricsTotals{
+			StepID: stepID,
+			Rows: []MetricsTotalsRow{
+				{Operation: "READ", SuccessCount: 445, FailureCount: 5, SizeBytes: 1866465280, StepDurationSeconds: 30, ThroughputAvgOps: 14.8, ThroughputLastOps: 13.9, BandwidthAvgMBps: 59.3, BandwidthLastMBps: 55.6, LatencyAvgMicros: 8100, LatencyP50Micros: 6200, Concurrency: 8, ConcurrencyMean: 8, NodeCount: 4, SampleTimestamp: "2026-06-04T18:00:10Z"},
+				{Operation: "STAT", SuccessCount: 301, FailureCount: 1, SizeBytes: 0, StepDurationSeconds: 30, ThroughputAvgOps: 10.0, ThroughputLastOps: 9.5, BandwidthAvgMBps: 0, BandwidthLastMBps: 0, LatencyAvgMicros: 4200, LatencyP50Micros: 3100, Concurrency: 8, ConcurrencyMean: 8, NodeCount: 4, SampleTimestamp: "2026-06-04T18:00:10Z"},
+				{Operation: "CREATE", SuccessCount: 151, FailureCount: 2, SizeBytes: 633339904, StepDurationSeconds: 30, ThroughputAvgOps: 5.1, ThroughputLastOps: 4.8, BandwidthAvgMBps: 21.1, BandwidthLastMBps: 20.0, LatencyAvgMicros: 11200, LatencyP50Micros: 8700, Concurrency: 8, ConcurrencyMean: 8, NodeCount: 4, SampleTimestamp: "2026-06-04T18:00:10Z"},
+				{Operation: "DELETE", SuccessCount: 103, FailureCount: 4, SizeBytes: 0, StepDurationSeconds: 30, ThroughputAvgOps: 3.6, ThroughputLastOps: 3.1, BandwidthAvgMBps: 0, BandwidthLastMBps: 0, LatencyAvgMicros: 7300, LatencyP50Micros: 5200, Concurrency: 8, ConcurrencyMean: 8, NodeCount: 4, SampleTimestamp: "2026-06-04T18:00:10Z"},
+			},
+		},
+	}
+
+	summary, err := Aggregate(runData)
+	if err != nil {
+		t.Fatalf("Aggregate returned error: %v", err)
+	}
+	if summary == nil {
+		t.Fatal("Aggregate returned nil summary")
+	}
+	if len(summary.Steps) != 1 {
+		t.Fatalf("expected 1 step, got %d", len(summary.Steps))
+	}
+	mixed := summary.Steps[0]
+	if !mixed.IsMixed {
+		t.Fatal("expected mixed step")
+	}
+	if mixed.PhaseLabel != "Mixed" {
+		t.Fatalf("phase label = %q, want Mixed", mixed.PhaseLabel)
+	}
+	if mixed.Operation != "MIXED" {
+		t.Fatalf("operation = %q, want MIXED", mixed.Operation)
+	}
+	if mixed.Metrics == nil {
+		t.Fatal("mixed metrics missing")
+	}
+	if got := mixed.Metrics.DurationSeconds; got != 30 {
+		t.Fatalf("mixed duration seconds = %.2f, want 30", got)
+	}
+	if got := mixed.Metrics.SuccessCount; got != 1000 {
+		t.Fatalf("mixed success count = %d, want 1000", got)
+	}
+	if got := mixed.Metrics.FailureCount; got != 12 {
+		t.Fatalf("mixed failure count = %d, want 12", got)
+	}
+	if got := mixed.Metrics.DataBytes; got != 2499805184 {
+		t.Fatalf("mixed data bytes = %d", got)
+	}
+	if !approxEqual(mixed.Metrics.ThroughputAvgOps, 33.5, 0.001) {
+		t.Fatalf("mixed avg throughput = %.3f", mixed.Metrics.ThroughputAvgOps)
+	}
+	if !approxEqual(summary.Totals.DurationSeconds, 30, 0.001) {
+		t.Fatalf("totals duration seconds = %.3f, want 30", summary.Totals.DurationSeconds)
+	}
+	if got := summary.Totals.DataBytes; got != 2499805184 {
+		t.Fatalf("totals data bytes = %d", got)
+	}
+	if len(mixed.OperationBreakdown) != 4 {
+		t.Fatalf("expected 4 breakdown rows, got %d", len(mixed.OperationBreakdown))
+	}
+	gotOps := []string{
+		mixed.OperationBreakdown[0].Operation,
+		mixed.OperationBreakdown[1].Operation,
+		mixed.OperationBreakdown[2].Operation,
+		mixed.OperationBreakdown[3].Operation,
+	}
+	if strings.Join(gotOps, ",") != "READ,STAT,CREATE,DELETE" {
+		t.Fatalf("unexpected breakdown order: %v", gotOps)
+	}
+	if mixed.OperationBreakdown[0].ConfiguredShare == nil || *mixed.OperationBreakdown[0].ConfiguredShare != 45 {
+		t.Fatalf("read configured share = %v", mixed.OperationBreakdown[0].ConfiguredShare)
+	}
+	if mixed.OperationBreakdown[1].ConfiguredShare == nil || *mixed.OperationBreakdown[1].ConfiguredShare != 30 {
+		t.Fatalf("stat configured share = %v", mixed.OperationBreakdown[1].ConfiguredShare)
+	}
+	if mixed.OperationBreakdown[2].ConfiguredShare == nil || *mixed.OperationBreakdown[2].ConfiguredShare != 15 {
+		t.Fatalf("create configured share = %v", mixed.OperationBreakdown[2].ConfiguredShare)
+	}
+	if mixed.OperationBreakdown[3].ConfiguredShare == nil || *mixed.OperationBreakdown[3].ConfiguredShare != 10 {
+		t.Fatalf("delete configured share = %v", mixed.OperationBreakdown[3].ConfiguredShare)
+	}
+	var shareSum float64
+	for _, row := range mixed.OperationBreakdown {
+		if row.ActualShare == nil {
+			t.Fatalf("actual share missing for %s", row.Operation)
+		}
+		shareSum += *row.ActualShare
+	}
+	if !approxEqual(shareSum, 100, 0.01) {
+		t.Fatalf("actual share sum = %.4f", shareSum)
+	}
+	if mixed.MixedLatencyNote == "" {
+		t.Fatal("expected mixed latency note")
+	}
+	if mixed.Metrics.LatencyMedianMs != 0 {
+		t.Fatalf("expected no combined latency median, got %.3f", mixed.Metrics.LatencyMedianMs)
+	}
+	if len(summary.Warnings) != 0 {
+		t.Fatalf("expected no warnings, got %v", summary.Warnings)
+	}
+}
+
+func TestPhaseLabelFromStepHandlesMixedCleanupSteps(t *testing.T) {
+	t.Parallel()
+
+	if got := phaseLabelFromStep("mt-003-20260604.180001.000-cleanup-seed"); got != "Cleanup seed" {
+		t.Fatalf("cleanup-seed label = %q", got)
+	}
+	if got := phaseLabelFromStep("mt-004-20260604.180001.000-cleanup-put"); got != "Cleanup CREATE" {
+		t.Fatalf("cleanup-put label = %q", got)
+	}
+	if got := phaseLabelFromStep("mt-002-20260604.180001.000-mixed"); got != "Mixed" {
+		t.Fatalf("mixed label = %q", got)
+	}
+}
+
 func TestParseSizeString(t *testing.T) {
 	t.Parallel()
 

--- a/cli/internal/results/summary/aggregate_test.go
+++ b/cli/internal/results/summary/aggregate_test.go
@@ -184,6 +184,39 @@ func TestAggregateHandlesMissingMetrics(t *testing.T) {
 	}
 }
 
+func TestAggregateSuppressesMissingMetricsWarningForSuppressedStep(t *testing.T) {
+	t.Parallel()
+
+	runData := &RunData{
+		RunID:        "run-1",
+		StepOrder:    []string{"mt-001-20260604.195722.504-seed"},
+		Steps:        make(map[string]*StepData),
+		Params:       &RunParams{},
+		ManifestPath: "index.json",
+		MetadataPath: "params.json",
+	}
+	runData.Params.ScenarioParams.ObjectSize = "4k"
+	runData.Steps["mt-001-20260604.195722.504-seed"] = &StepData{
+		StepID:            "mt-001-20260604.195722.504-seed",
+		Status:            StepStatusComplete,
+		MetricsSuppressed: true,
+	}
+
+	summary, err := Aggregate(runData)
+	if err != nil {
+		t.Fatalf("Aggregate returned error: %v", err)
+	}
+	if len(summary.Steps) != 1 {
+		t.Fatalf("expected 1 step, got %d", len(summary.Steps))
+	}
+	if summary.Steps[0].Metrics != nil {
+		t.Fatalf("expected nil metrics for suppressed step")
+	}
+	if len(summary.Warnings) != 0 {
+		t.Fatalf("expected no warnings for suppressed metrics, got %v", summary.Warnings)
+	}
+}
+
 func TestAggregateListWorkloadOmitsObjectSize(t *testing.T) {
 	t.Parallel()
 

--- a/cli/internal/results/summary/aggregate_test.go
+++ b/cli/internal/results/summary/aggregate_test.go
@@ -365,6 +365,15 @@ func TestAggregateBuildsMixedSummary(t *testing.T) {
 	if mixed.OperationBreakdown[3].ConfiguredShare == nil || *mixed.OperationBreakdown[3].ConfiguredShare != 10 {
 		t.Fatalf("delete configured share = %v", mixed.OperationBreakdown[3].ConfiguredShare)
 	}
+	if got := mixed.OperationBreakdown[0].ActualOps; got != 450 {
+		t.Fatalf("read actual ops = %d, want 450", got)
+	}
+	if !approxEqual(*mixed.OperationBreakdown[0].ActualShare, 44.47, 0.01) {
+		t.Fatalf("read actual share = %.4f, want about 44.47", *mixed.OperationBreakdown[0].ActualShare)
+	}
+	if !approxEqual(*mixed.OperationBreakdown[3].ActualShare, 10.57, 0.01) {
+		t.Fatalf("delete actual share = %.4f, want about 10.57", *mixed.OperationBreakdown[3].ActualShare)
+	}
 	var shareSum float64
 	for _, row := range mixed.OperationBreakdown {
 		if row.ActualShare == nil {
@@ -383,6 +392,137 @@ func TestAggregateBuildsMixedSummary(t *testing.T) {
 	}
 	if len(summary.Warnings) != 0 {
 		t.Fatalf("expected no warnings, got %v", summary.Warnings)
+	}
+}
+
+func TestAggregateBuildsMixedSummaryFromScenarioWorkloadType(t *testing.T) {
+	t.Parallel()
+
+	stepID := "mt-002-20260604.180001.000-mixed"
+	runData := &RunData{
+		RunID:     "mt-20260604.180000.000",
+		StepOrder: []string{stepID},
+		Steps:     make(map[string]*StepData),
+		Params: &RunParams{
+			ScenarioParams: ScenarioParams{
+				WorkloadType: "mixed",
+				ObjectSize:   "4MB",
+				Duration:     "30s",
+			},
+		},
+	}
+
+	runData.Steps[stepID] = &StepData{
+		StepID: stepID,
+		Status: StepStatusComplete,
+		Metrics: &MetricsTotals{
+			StepID: stepID,
+			Rows: []MetricsTotalsRow{
+				{Operation: "READ", SuccessCount: 10, SizeBytes: 40960, StepDurationSeconds: 30, ThroughputAvgOps: 0.3, BandwidthAvgMBps: 0.2, LatencyAvgMicros: 4000, LatencyP50Micros: 3000},
+				{Operation: "CREATE", SuccessCount: 5, SizeBytes: 20480, StepDurationSeconds: 30, ThroughputAvgOps: 0.2, BandwidthAvgMBps: 0.1, LatencyAvgMicros: 5000, LatencyP50Micros: 3500},
+			},
+		},
+	}
+
+	summary, err := Aggregate(runData)
+	if err != nil {
+		t.Fatalf("Aggregate returned error: %v", err)
+	}
+	if summary.Workload.Type != "mixed" {
+		t.Fatalf("workload type = %q, want mixed", summary.Workload.Type)
+	}
+	if len(summary.Steps) != 1 || !summary.Steps[0].IsMixed {
+		t.Fatalf("expected mixed step summary, got %+v", summary.Steps)
+	}
+}
+
+func TestAggregateMixedSummaryHidesZeroConfiguredDistribution(t *testing.T) {
+	t.Parallel()
+
+	stepID := "mt-002-20260604.180001.000-mixed"
+	runData := &RunData{
+		RunID:     "mt-20260604.180000.000",
+		StepOrder: []string{stepID},
+		Steps:     make(map[string]*StepData),
+		Params: &RunParams{
+			WorkloadType: "mixed",
+			ScenarioParams: ScenarioParams{
+				WorkloadType: "mixed",
+				ObjectSize:   "4MB",
+				Duration:     "30s",
+			},
+		},
+	}
+
+	runData.Steps[stepID] = &StepData{
+		StepID: stepID,
+		Status: StepStatusComplete,
+		Metrics: &MetricsTotals{
+			StepID: stepID,
+			Rows: []MetricsTotalsRow{
+				{Operation: "READ", SuccessCount: 12, SizeBytes: 49152, StepDurationSeconds: 30, ThroughputAvgOps: 0.4, BandwidthAvgMBps: 0.2, LatencyAvgMicros: 4200, LatencyP50Micros: 3100},
+				{Operation: "STAT", SuccessCount: 8, SizeBytes: 0, StepDurationSeconds: 30, ThroughputAvgOps: 0.3, BandwidthAvgMBps: 0, LatencyAvgMicros: 2800, LatencyP50Micros: 2000},
+			},
+		},
+	}
+
+	summary, err := Aggregate(runData)
+	if err != nil {
+		t.Fatalf("Aggregate returned error: %v", err)
+	}
+	if summary.Workload.MixedDistribution.Available {
+		t.Fatalf("expected mixed distribution to be unavailable when all values are zero")
+	}
+	for _, row := range summary.Steps[0].OperationBreakdown {
+		if row.ConfiguredShare != nil {
+			t.Fatalf("expected nil configured share for %s, got %v", row.Operation, *row.ConfiguredShare)
+		}
+	}
+}
+
+func TestAggregateBuildsMixedSummaryOrdersKnownOpsBeforeUnknowns(t *testing.T) {
+	t.Parallel()
+
+	stepID := "mt-002-20260604.180001.000-mixed"
+	runData := &RunData{
+		RunID:     "mt-20260604.180000.000",
+		StepOrder: []string{stepID},
+		Steps:     make(map[string]*StepData),
+		Params: &RunParams{
+			WorkloadType: "mixed",
+			ScenarioParams: ScenarioParams{
+				WorkloadType: "mixed",
+				ObjectSize:   "4MB",
+				Duration:     "30s",
+			},
+		},
+	}
+
+	runData.Steps[stepID] = &StepData{
+		StepID: stepID,
+		Status: StepStatusComplete,
+		Metrics: &MetricsTotals{
+			StepID: stepID,
+			Rows: []MetricsTotalsRow{
+				{Operation: "DELETE", SuccessCount: 5, StepDurationSeconds: 30, ThroughputAvgOps: 0.1, LatencyAvgMicros: 3000, LatencyP50Micros: 2000},
+				{Operation: "LIST", SuccessCount: 3, StepDurationSeconds: 30, ThroughputAvgOps: 0.1, LatencyAvgMicros: 2000, LatencyP50Micros: 1500},
+				{Operation: "CREATE", SuccessCount: 7, SizeBytes: 28672, StepDurationSeconds: 30, ThroughputAvgOps: 0.2, BandwidthAvgMBps: 0.1, LatencyAvgMicros: 5000, LatencyP50Micros: 3500},
+				{Operation: "READ", SuccessCount: 11, SizeBytes: 45056, StepDurationSeconds: 30, ThroughputAvgOps: 0.3, BandwidthAvgMBps: 0.2, LatencyAvgMicros: 4000, LatencyP50Micros: 3000},
+				{Operation: "STAT", SuccessCount: 9, StepDurationSeconds: 30, ThroughputAvgOps: 0.2, LatencyAvgMicros: 2500, LatencyP50Micros: 1800},
+			},
+		},
+	}
+
+	summary, err := Aggregate(runData)
+	if err != nil {
+		t.Fatalf("Aggregate returned error: %v", err)
+	}
+	gotOps := make([]string, 0, len(summary.Steps[0].OperationBreakdown))
+	for _, row := range summary.Steps[0].OperationBreakdown {
+		gotOps = append(gotOps, row.Operation)
+	}
+	if strings.Join(gotOps, ",") != "READ,STAT,CREATE,DELETE,LIST" {
+		t.Fatalf("unexpected operation order: %v", gotOps)
 	}
 }
 

--- a/cli/internal/results/summary/aggregate_test.go
+++ b/cli/internal/results/summary/aggregate_test.go
@@ -335,6 +335,15 @@ func TestAggregateBuildsMixedSummary(t *testing.T) {
 	if !approxEqual(mixed.Metrics.ThroughputAvgOps, 33.5, 0.001) {
 		t.Fatalf("mixed avg throughput = %.3f", mixed.Metrics.ThroughputAvgOps)
 	}
+	if !approxEqual(mixed.Metrics.ThroughputLastOps, 31.3, 0.001) {
+		t.Fatalf("mixed last throughput = %.3f", mixed.Metrics.ThroughputLastOps)
+	}
+	if !approxEqual(mixed.Metrics.BandwidthAvgMBps, 80.4, 0.001) {
+		t.Fatalf("mixed avg bandwidth = %.3f", mixed.Metrics.BandwidthAvgMBps)
+	}
+	if !approxEqual(mixed.Metrics.BandwidthLastMBps, 75.6, 0.001) {
+		t.Fatalf("mixed last bandwidth = %.3f", mixed.Metrics.BandwidthLastMBps)
+	}
 	if !approxEqual(summary.Totals.DurationSeconds, 30, 0.001) {
 		t.Fatalf("totals duration seconds = %.3f, want 30", summary.Totals.DurationSeconds)
 	}

--- a/cli/internal/results/summary/loader.go
+++ b/cli/internal/results/summary/loader.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/dell/storage-performance-tool/cli/internal/constants"
 	"github.com/dell/storage-performance-tool/cli/internal/results"
+	"gopkg.in/yaml.v3"
 )
 
 // Loader ingests fetched run artifacts into structured data for later aggregation.
@@ -45,13 +46,14 @@ type RunData struct {
 
 // StepData captures per-step artifact availability and metrics totals.
 type StepData struct {
-	StepID          string
-	Manifest        *results.StepManifest
-	Metrics         *MetricsTotals
-	Status          StepStatus
-	MissingRequired []string
-	MissingOptional []string
-	Notes           []string
+	StepID            string
+	Manifest          *results.StepManifest
+	Metrics           *MetricsTotals
+	Status            StepStatus
+	MetricsSuppressed bool
+	MissingRequired   []string
+	MissingOptional   []string
+	Notes             []string
 }
 
 // StepStatus indicates ingestion completeness for a step.
@@ -125,9 +127,13 @@ func (l *Loader) Load(ctx context.Context, runDir string) (*RunData, error) {
 			Manifest: sm,
 			Status:   StepStatusUnknown,
 		}
+		step.MetricsSuppressed = l.metricsSummaryPersistSuppressed(runDir, sm)
 		required, optional := l.categorizeMissing(sm)
 		if len(required) > 0 {
 			step.MissingRequired = append([]string(nil), required...)
+		}
+		if step.MetricsSuppressed {
+			step.MissingRequired = removeString(step.MissingRequired, constants.ResultsArtifactSuffixMetricsTotal)
 		}
 		if len(optional) > 0 {
 			step.MissingOptional = append([]string(nil), optional...)
@@ -144,7 +150,7 @@ func (l *Loader) Load(ctx context.Context, runDir string) (*RunData, error) {
 			} else {
 				step.Metrics = totals
 			}
-		} else {
+		} else if !step.MetricsSuppressed {
 			step.MissingRequired = appendUnique(step.MissingRequired, constants.ResultsArtifactSuffixMetricsTotal)
 			if metricsEntry != nil && metricsEntry.Status != fileStatusOK && metricsEntry.Error != "" {
 				step.Notes = append(step.Notes, metricsEntry.Error)
@@ -251,6 +257,42 @@ func (l *Loader) findMetricsEntry(sm *results.StepManifest) *results.FileStatus 
 	return nil
 }
 
+func (l *Loader) findConfigEntry(sm *results.StepManifest) *results.FileStatus {
+	for i := range sm.Files {
+		fs := &sm.Files[i]
+		if strings.HasSuffix(fs.Name, constants.ResultsArtifactSuffixConfig) {
+			return fs
+		}
+	}
+	return nil
+}
+
+type stepConfigProbe struct {
+	Output struct {
+		Metrics struct {
+			Summary struct {
+				Persist *bool `yaml:"persist"`
+			} `yaml:"summary"`
+		} `yaml:"metrics"`
+	} `yaml:"output"`
+}
+
+func (l *Loader) metricsSummaryPersistSuppressed(runDir string, sm *results.StepManifest) bool {
+	entry := l.findConfigEntry(sm)
+	if entry == nil || entry.Status != fileStatusOK {
+		return false
+	}
+	content, err := os.ReadFile(filepath.Join(runDir, entry.Name)) // #nosec G304 -- path restricted to fetched results directory
+	if err != nil {
+		return false
+	}
+	var config stepConfigProbe
+	if err := yaml.Unmarshal(content, &config); err != nil {
+		return false
+	}
+	return config.Output.Metrics.Summary.Persist != nil && !*config.Output.Metrics.Summary.Persist
+}
+
 func appendUnique(list []string, value string) []string {
 	for _, v := range list {
 		if v == value {
@@ -258,6 +300,19 @@ func appendUnique(list []string, value string) []string {
 		}
 	}
 	return append(list, value)
+}
+
+func removeString(list []string, value string) []string {
+	if len(list) == 0 {
+		return list
+	}
+	out := list[:0]
+	for _, item := range list {
+		if item != value {
+			out = append(out, item)
+		}
+	}
+	return out
 }
 
 // RunParams mirrors the structure of spt_run_params.json for ingestion purposes.

--- a/cli/internal/results/summary/loader.go
+++ b/cli/internal/results/summary/loader.go
@@ -297,6 +297,10 @@ type ScenarioParams struct {
 	Threads        int      `json:"Threads"`
 	ObjectSize     string   `json:"ObjectSize"`
 	ObjectCount    int64    `json:"ObjectCount"`
+	GetDistrib     int      `json:"GetDistrib"`
+	PutDistrib     int      `json:"PutDistrib"`
+	DeleteDistrib  int      `json:"DeleteDistrib"`
+	StatDistrib    int      `json:"StatDistrib"`
 	Duration       string   `json:"Duration"`
 	Cleanup        bool     `json:"Cleanup"`
 	KeepScenario   bool     `json:"KeepScenario"`

--- a/cli/internal/results/summary/loader_test.go
+++ b/cli/internal/results/summary/loader_test.go
@@ -234,6 +234,65 @@ func TestLoaderLoadMissingMetrics(t *testing.T) {
 	}
 }
 
+func TestLoaderLoadMetricsSuppressedStepDoesNotRequireMetricsTotal(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	runDir := filepath.Join(tempDir, "mt-20260604.195722.505")
+	if err := os.Mkdir(runDir, 0o755); err != nil {
+		t.Fatalf("mkdir run dir: %v", err)
+	}
+
+	stepID := "mt-001-20260604.195722.504-seed"
+	configName := stepID + "." + constants.ResultsArtifactSuffixConfig
+	configContent := []byte("output:\n  metrics:\n    summary:\n      persist: false\n")
+	if err := os.WriteFile(filepath.Join(runDir, configName), configContent, 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	manifest := &results.Manifest{
+		BaseURL:     "http://example",
+		OutputDir:   runDir,
+		GeneratedAt: time.Now().UTC(),
+		Steps: []results.StepManifest{
+			{
+				StepID: stepID,
+				Files: []results.FileStatus{
+					{
+						Name:   stepID + "." + constants.ResultsArtifactSuffixMetricsTotal,
+						Status: "missing",
+						Error:  "not listed in index.json",
+					},
+					{
+						Name:   configName,
+						Status: fileStatusOK,
+					},
+				},
+			},
+		},
+	}
+	writeManifest(t, runDir, manifest)
+	writeParams(t, runDir, &RunParams{ExpectedStepIDs: []string{stepID}})
+
+	loader := NewLoader()
+	data, err := loader.Load(context.Background(), runDir)
+	if err != nil {
+		t.Fatalf("Load returned error: %v", err)
+	}
+	step := data.Steps[stepID]
+	if step == nil {
+		t.Fatalf("step not found")
+	}
+	if !step.MetricsSuppressed {
+		t.Fatalf("expected metrics to be marked suppressed")
+	}
+	if step.Status != StepStatusComplete {
+		t.Fatalf("expected complete status for metrics-suppressed step, got %s", step.Status)
+	}
+	if len(step.MissingRequired) != 0 {
+		t.Fatalf("metrics-suppressed step should not have missing required artifacts: %v", step.MissingRequired)
+	}
+}
+
 func TestLoaderLoadMalformedMetrics(t *testing.T) {
 	t.Parallel()
 

--- a/cli/internal/results/summary/loader_test.go
+++ b/cli/internal/results/summary/loader_test.go
@@ -109,6 +109,86 @@ func TestLoaderLoadSuccess(t *testing.T) {
 	}
 }
 
+func TestLoaderLoadMixedDistributionAndMultiRowMetrics(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	runDir := filepath.Join(tempDir, "mt-20260604.180000.000")
+	if err := os.Mkdir(runDir, 0o755); err != nil {
+		t.Fatalf("mkdir run dir: %v", err)
+	}
+
+	stepID := "mt-002-20260604.180001.000-mixed"
+	manifest := makeManifest(t, runDir, []stepFixture{
+		{
+			ID: stepID,
+			MetricsContent: sampleMetricsCSV([]string{
+				`"2026-06-04T18:00:10Z",READ,8,4,8,8,445,5,1866465280,30.0,20.0,14.8,13.9,59.3,55.6,8100,2200,4300,6200,9100,18000,8100,2200,4300,6200,9100,18000`,
+				`"2026-06-04T18:00:10Z",STAT,8,4,8,8,301,1,0,30.0,8.0,10.0,9.5,0.0,0.0,4200,1000,2100,3100,5000,9000,4200,1000,2100,3100,5000,9000`,
+				`"2026-06-04T18:00:10Z",CREATE,8,4,8,8,151,2,633339904,30.0,11.0,5.1,4.8,21.1,20.0,11200,3000,6200,8700,13000,25000,11200,3000,6200,8700,13000,25000`,
+				`"2026-06-04T18:00:10Z",DELETE,8,4,8,8,103,4,0,30.0,6.0,3.6,3.1,0.0,0.0,7300,1700,3000,5200,8600,14000,7300,1700,3000,5200,8600,14000`,
+			}),
+		},
+	})
+	writeManifest(t, runDir, manifest)
+
+	params := RunParams{
+		GeneratedAt:  time.Date(2026, 6, 4, 18, 0, 0, 0, time.UTC),
+		WorkloadType: "mixed",
+		ResultsRoot:  "results/mt-20260604.180000.000",
+		ScenarioParams: ScenarioParams{
+			WorkloadType:  "mixed",
+			Bucket:        "mixed-bucket",
+			Threads:       8,
+			ObjectSize:    "4MB",
+			Duration:      "30s",
+			GetDistrib:    45,
+			StatDistrib:   30,
+			PutDistrib:    15,
+			DeleteDistrib: 10,
+		},
+		ExpectedStepIDs: []string{stepID},
+	}
+	writeParams(t, runDir, &params)
+
+	loader := NewLoader()
+	data, err := loader.Load(context.Background(), runDir)
+	if err != nil {
+		t.Fatalf("Load returned error: %v", err)
+	}
+	step := data.Steps[stepID]
+	if step == nil {
+		t.Fatalf("step %s missing", stepID)
+	}
+	if step.Metrics == nil {
+		t.Fatalf("expected metrics for %s", stepID)
+	}
+	if len(step.Metrics.Rows) != 4 {
+		t.Fatalf("expected 4 mixed metrics rows, got %d", len(step.Metrics.Rows))
+	}
+	gotOps := []string{
+		step.Metrics.Rows[0].Operation,
+		step.Metrics.Rows[1].Operation,
+		step.Metrics.Rows[2].Operation,
+		step.Metrics.Rows[3].Operation,
+	}
+	if strings.Join(gotOps, ",") != "READ,STAT,CREATE,DELETE" {
+		t.Fatalf("unexpected operation order: %v", gotOps)
+	}
+	if data.Params.ScenarioParams.GetDistrib != 45 ||
+		data.Params.ScenarioParams.StatDistrib != 30 ||
+		data.Params.ScenarioParams.PutDistrib != 15 ||
+		data.Params.ScenarioParams.DeleteDistrib != 10 {
+		t.Fatalf("unexpected mixed distribution: %+v", data.Params.ScenarioParams)
+	}
+	if got := step.Metrics.Rows[2].SizeBytes; got != 633339904 {
+		t.Fatalf("create size bytes = %d", got)
+	}
+	if got := step.Metrics.Rows[3].FailureCount; got != 4 {
+		t.Fatalf("delete failure count = %d", got)
+	}
+}
+
 func TestLoaderLoadMissingMetrics(t *testing.T) {
 	t.Parallel()
 

--- a/cli/internal/results/summary/render.go
+++ b/cli/internal/results/summary/render.go
@@ -2,6 +2,7 @@ package summary
 
 import (
 	"fmt"
+	"math"
 	"sort"
 	"strings"
 	"time"
@@ -52,6 +53,7 @@ func (r *Renderer) FullReport(summary *RunSummary) string {
 	r.renderEnvironment(b, summary)
 	r.renderWorkload(b, summary)
 	r.renderPerformance(b, summary)
+	r.renderMixedBreakdowns(b, summary)
 	r.renderTotals(b, summary)
 	r.renderArtifactsAndWarnings(b, summary)
 
@@ -62,10 +64,14 @@ func (r *Renderer) FullReport(summary *RunSummary) string {
 func (r *Renderer) ConsoleSnippet(summary *RunSummary) string {
 	full := r.FullReport(summary)
 	lines := strings.Split(full, "\n")
-	if len(lines) <= r.SnippetLineCap {
+	lineCap := r.SnippetLineCap
+	if hasMixedSteps(summary) && lineCap < 60 {
+		lineCap = 60
+	}
+	if len(lines) <= lineCap {
 		return full
 	}
-	truncated := lines[:r.SnippetLineCap-1]
+	truncated := lines[:lineCap-1]
 	truncated = append(truncated, "… (report truncated; see file for full details)")
 	return strings.Join(truncated, "\n") + "\n"
 }
@@ -93,6 +99,12 @@ func (r *Renderer) CompactSnippet(summary *RunSummary) string {
 	sb.WriteString("Performance by Phase\n")
 	sb.WriteString(r.performanceTable(summary))
 	sb.WriteByte('\n')
+	for _, line := range compactMixedLines(summary) {
+		for _, wrapped := range textutil.WrapWords(line, wrapWidth) {
+			sb.WriteString(wrapped)
+			sb.WriteByte('\n')
+		}
+	}
 	fmt.Fprintf(sb, "Totals: duration %s, data moved %s\n", summary.Totals.DurationHuman, formatBytesHuman(summary.Totals.DataBytes))
 	if len(summary.Warnings) > 0 {
 		sb.WriteString("Warnings:\n")
@@ -212,7 +224,7 @@ func (r *Renderer) performanceTable(summary *RunSummary) string {
 			formatInt(m.SuccessCount),
 			formatBytesHuman(m.DataBytes),
 			formatNumber(m.ThroughputAvgOps, "ops/s"),
-			formatNumber(m.LatencyHeadlineMs, "ms"),
+			mixedLatencyCell(step, m),
 			formatNumber(m.BandwidthAvgMBps, "MB/s"),
 		}
 		rows = append(rows, row)
@@ -221,6 +233,39 @@ func (r *Renderer) performanceTable(summary *RunSummary) string {
 		rows = append(rows, []string{"—", "—", "—", "—", "—", "—", "—"})
 	}
 	return renderUnicodeTable(headers, rows, []Alignment{AlignLeft, AlignLeft, AlignRight, AlignRight, AlignRight, AlignRight, AlignRight})
+}
+
+func (r *Renderer) renderMixedBreakdowns(b *strings.Builder, summary *RunSummary) {
+	if !hasMixedSteps(summary) {
+		return
+	}
+	b.WriteString("Mixed Operation Breakdown\n")
+	for _, step := range summary.Steps {
+		if !step.IsMixed || len(step.OperationBreakdown) == 0 {
+			continue
+		}
+		fmt.Fprintf(b, "Step: %s\n", step.StepID)
+		if configured := configuredDistributionText(summary.Workload.MixedDistribution); configured != "" {
+			fmt.Fprintf(b, "Configured distribution: %s\n", configured)
+		}
+		headers := []string{"Operation", "Configured", "Actual Ops", "Success", "Failure", "Data Moved", "IOPS Avg", "Bandwidth Avg", "Latency P50"}
+		rows := make([][]string, 0, len(step.OperationBreakdown))
+		for _, op := range step.OperationBreakdown {
+			rows = append(rows, []string{
+				op.Operation,
+				formatConfiguredShare(op.ConfiguredShare),
+				formatActualOps(op.ActualShare, op.ActualOps),
+				formatInt(op.Metrics.SuccessCount),
+				formatInt(op.Metrics.FailureCount),
+				formatBytesHuman(op.Metrics.DataBytes),
+				formatNumber(op.Metrics.ThroughputAvgOps, "ops/s"),
+				formatNumber(op.Metrics.BandwidthAvgMBps, "MB/s"),
+				formatNumber(op.Metrics.LatencyMedianMs, "ms"),
+			})
+		}
+		b.WriteString(renderUnicodeTable(headers, rows, []Alignment{AlignLeft, AlignRight, AlignRight, AlignRight, AlignRight, AlignRight, AlignRight, AlignRight, AlignRight}))
+		b.WriteString("\n\n")
+	}
 }
 
 func (r *Renderer) renderTotals(b *strings.Builder, summary *RunSummary) {
@@ -342,8 +387,99 @@ func formatNumber(value float64, suffix string) string {
 	}
 }
 
+func formatPercent(value float64) string {
+	if value == 0 {
+		return "0%"
+	}
+	if value == math.Trunc(value) {
+		return fmt.Sprintf("%.0f%%", value)
+	}
+	return fmt.Sprintf("%.1f%%", value)
+}
+
 func formatBytesHuman(bytes int64) string {
 	return formatBytes(bytes)
+}
+
+func hasMixedSteps(summary *RunSummary) bool {
+	if summary == nil {
+		return false
+	}
+	for _, step := range summary.Steps {
+		if step.IsMixed && len(step.OperationBreakdown) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func mixedLatencyCell(step StepSummary, metrics *PhaseMetrics) string {
+	if step.IsMixed {
+		return "see ops"
+	}
+	return formatNumber(metrics.LatencyHeadlineMs, "ms")
+}
+
+func configuredDistributionText(dist MixedDistribution) string {
+	if !dist.Available {
+		return ""
+	}
+	parts := make([]string, 0, 4)
+	for _, item := range []struct {
+		label string
+		value int
+	}{
+		{label: "READ", value: dist.ReadPercent},
+		{label: "STAT", value: dist.StatPercent},
+		{label: "CREATE", value: dist.CreatePercent},
+		{label: "DELETE", value: dist.DeletePercent},
+	} {
+		if item.value <= 0 {
+			continue
+		}
+		parts = append(parts, fmt.Sprintf("%s %d%%", item.label, item.value))
+	}
+	return strings.Join(parts, ", ")
+}
+
+func formatConfiguredShare(value *float64) string {
+	if value == nil {
+		return "-"
+	}
+	return formatPercent(*value)
+}
+
+func formatActualOps(share *float64, count int64) string {
+	if share == nil {
+		return formatInt(count)
+	}
+	return fmt.Sprintf("%s (%s)", formatPercent(*share), formatInt(count))
+}
+
+func compactMixedLines(summary *RunSummary) []string {
+	if !hasMixedSteps(summary) {
+		return nil
+	}
+	lines := make([]string, 0, len(summary.Steps))
+	for _, step := range summary.Steps {
+		if !step.IsMixed || len(step.OperationBreakdown) == 0 {
+			continue
+		}
+		parts := make([]string, 0, len(step.OperationBreakdown))
+		for _, op := range step.OperationBreakdown {
+			part := op.Operation
+			if op.ActualShare != nil {
+				part += " " + formatPercent(*op.ActualShare)
+			}
+			if op.ConfiguredShare != nil {
+				part += fmt.Sprintf(" (cfg %s)", formatPercent(*op.ConfiguredShare))
+			}
+			part += " " + formatNumber(op.Metrics.ThroughputAvgOps, "ops/s")
+			parts = append(parts, part)
+		}
+		lines = append(lines, "Mixed operations: "+strings.Join(parts, ", "))
+	}
+	return lines
 }
 
 func collectIncompleteSteps(summary *RunSummary) []string {

--- a/cli/internal/results/summary/render.go
+++ b/cli/internal/results/summary/render.go
@@ -25,6 +25,9 @@ type RenderOptions struct {
 const (
 	defaultMaxWidth       = 100
 	defaultSnippetLineCap = 40
+	headerIOPSAvg         = "IOPS Avg"
+	headerLatencyP50      = "Latency P50"
+	headerBandwidthAvg    = "Bandwidth Avg"
 )
 
 // NewRenderer builds a Renderer using the provided options.
@@ -99,12 +102,7 @@ func (r *Renderer) CompactSnippet(summary *RunSummary) string {
 	sb.WriteString("Performance by Phase\n")
 	sb.WriteString(r.performanceTable(summary))
 	sb.WriteByte('\n')
-	for _, line := range compactMixedLines(summary) {
-		for _, wrapped := range textutil.WrapWords(line, wrapWidth) {
-			sb.WriteString(wrapped)
-			sb.WriteByte('\n')
-		}
-	}
+	r.renderCompactMixedBreakdowns(sb, summary)
 	fmt.Fprintf(sb, "Totals: duration %s, data moved %s\n", summary.Totals.DurationHuman, formatBytesHuman(summary.Totals.DataBytes))
 	if len(summary.Warnings) > 0 {
 		sb.WriteString("Warnings:\n")
@@ -203,7 +201,7 @@ func (r *Renderer) renderPerformance(b *strings.Builder, summary *RunSummary) {
 }
 
 func (r *Renderer) performanceTable(summary *RunSummary) string {
-	headers := []string{"Phase", "Object Size", "Success", "Data Moved", "IOPS Avg", "Latency P50", "Bandwidth Avg"}
+	headers := []string{"Phase", "Object Size", "Success", "Data Moved", headerIOPSAvg, headerLatencyP50, headerBandwidthAvg}
 	isList := strings.EqualFold(summary.Workload.Type, workloadTypeList)
 	if isList {
 		headers[4] = "Ops/s Avg"
@@ -235,6 +233,45 @@ func (r *Renderer) performanceTable(summary *RunSummary) string {
 	return renderUnicodeTable(headers, rows, []Alignment{AlignLeft, AlignLeft, AlignRight, AlignRight, AlignRight, AlignRight, AlignRight})
 }
 
+func (r *Renderer) renderCompactMixedBreakdowns(b *strings.Builder, summary *RunSummary) {
+	if !hasMixedSteps(summary) {
+		return
+	}
+	mixedStepCount := 0
+	for _, step := range summary.Steps {
+		if step.IsMixed && len(step.OperationBreakdown) > 0 {
+			mixedStepCount++
+		}
+	}
+	b.WriteString("Mixed Operation Breakdown\n")
+	first := true
+	for _, step := range summary.Steps {
+		if !step.IsMixed || len(step.OperationBreakdown) == 0 {
+			continue
+		}
+		if !first {
+			b.WriteByte('\n')
+		}
+		first = false
+		if mixedStepCount > 1 && step.StepID != "" {
+			fmt.Fprintf(b, "Step: %s\n", step.StepID)
+		}
+		headers := []string{"Operation", "Configured", "Actual Ops", headerIOPSAvg, headerLatencyP50}
+		rows := make([][]string, 0, len(step.OperationBreakdown))
+		for _, op := range step.OperationBreakdown {
+			rows = append(rows, []string{
+				op.Operation,
+				formatConfiguredShare(op.ConfiguredShare),
+				formatActualOps(op.ActualShare, op.ActualOps),
+				formatNumber(op.Metrics.ThroughputAvgOps, "ops/s"),
+				formatNumber(op.Metrics.LatencyMedianMs, "ms"),
+			})
+		}
+		b.WriteString(renderUnicodeTable(headers, rows, []Alignment{AlignLeft, AlignRight, AlignRight, AlignRight, AlignRight}))
+		b.WriteByte('\n')
+	}
+}
+
 func (r *Renderer) renderMixedBreakdowns(b *strings.Builder, summary *RunSummary) {
 	if !hasMixedSteps(summary) {
 		return
@@ -248,7 +285,7 @@ func (r *Renderer) renderMixedBreakdowns(b *strings.Builder, summary *RunSummary
 		if configured := configuredDistributionText(summary.Workload.MixedDistribution); configured != "" {
 			fmt.Fprintf(b, "Configured distribution: %s\n", configured)
 		}
-		headers := []string{"Operation", "Configured", "Actual Ops", "Success", "Failure", "Data Moved", "IOPS Avg", "Bandwidth Avg", "Latency P50"}
+		headers := []string{"Operation", "Configured", "Actual Ops", "Success", "Failure", "Data Moved", headerIOPSAvg, headerBandwidthAvg, headerLatencyP50}
 		rows := make([][]string, 0, len(step.OperationBreakdown))
 		for _, op := range step.OperationBreakdown {
 			rows = append(rows, []string{
@@ -454,32 +491,6 @@ func formatActualOps(share *float64, count int64) string {
 		return formatInt(count)
 	}
 	return fmt.Sprintf("%s (%s)", formatPercent(*share), formatInt(count))
-}
-
-func compactMixedLines(summary *RunSummary) []string {
-	if !hasMixedSteps(summary) {
-		return nil
-	}
-	lines := make([]string, 0, len(summary.Steps))
-	for _, step := range summary.Steps {
-		if !step.IsMixed || len(step.OperationBreakdown) == 0 {
-			continue
-		}
-		parts := make([]string, 0, len(step.OperationBreakdown))
-		for _, op := range step.OperationBreakdown {
-			part := op.Operation
-			if op.ActualShare != nil {
-				part += " " + formatPercent(*op.ActualShare)
-			}
-			if op.ConfiguredShare != nil {
-				part += fmt.Sprintf(" (cfg %s)", formatPercent(*op.ConfiguredShare))
-			}
-			part += " " + formatNumber(op.Metrics.ThroughputAvgOps, "ops/s")
-			parts = append(parts, part)
-		}
-		lines = append(lines, "Mixed operations: "+strings.Join(parts, ", "))
-	}
-	return lines
 }
 
 func collectIncompleteSteps(summary *RunSummary) []string {

--- a/cli/internal/results/summary/render_test.go
+++ b/cli/internal/results/summary/render_test.go
@@ -249,12 +249,17 @@ func TestRendererConsoleSnippetKeepsMixedDetailWithElevatedCap(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		summary.Warnings = append(summary.Warnings, "warning line for mixed report truncation coverage")
 	}
+	summary.Steps[0].MissingRequired = []string{"metrics.total.csv"}
 
 	renderer := NewRenderer(RenderOptions{MaxWidth: 120, SnippetLineCap: 40})
 	snippet := renderer.ConsoleSnippet(summary)
 
 	mustContain(t, snippet, "Mixed Operation Breakdown")
 	mustContain(t, snippet, "Run Totals")
+	mustContain(t, snippet, "Warnings")
+	mustContain(t, snippet, "warning line for mixed report truncation coverage")
+	mustContain(t, snippet, "Artifact Health")
+	mustContain(t, snippet, "missing required artifacts: metrics.total.csv")
 	if strings.Contains(snippet, "report truncated") {
 		t.Fatalf("expected elevated mixed cap to avoid truncation, got:\n%s", snippet)
 	}

--- a/cli/internal/results/summary/render_test.go
+++ b/cli/internal/results/summary/render_test.go
@@ -213,16 +213,26 @@ func TestRendererFullReportIncludesMixedBreakdown(t *testing.T) {
 	mustContain(t, report, "│ DELETE")
 }
 
-func TestRendererCompactSnippetIncludesMixedOperationDetail(t *testing.T) {
+func TestRendererCompactSnippetIncludesMixedOperationTable(t *testing.T) {
 	t.Parallel()
 
 	renderer := NewRenderer(RenderOptions{MaxWidth: 100})
 	snippet := renderer.CompactSnippet(mixedSummaryFixture())
 
-	mustContain(t, snippet, "Mixed operations: READ")
-	mustContain(t, snippet, "cfg 45%")
-	mustContain(t, snippet, "CREATE")
+	mustContain(t, snippet, "Mixed Operation Breakdown")
+	mustContain(t, snippet, "│ Operation")
+	mustContain(t, snippet, "│ READ")
+	mustContain(t, snippet, "│ STAT")
+	mustContain(t, snippet, "│ CREATE")
+	mustContain(t, snippet, "│ DELETE")
 	mustContain(t, snippet, "Totals: duration 30s")
+	mustNotContain(t, snippet, "Mixed operations:")
+	perfIndex := strings.Index(snippet, "Performance by Phase")
+	mixedIndex := strings.Index(snippet, "Mixed Operation Breakdown")
+	totalsIndex := strings.Index(snippet, "Totals: duration 30s")
+	if perfIndex < 0 || mixedIndex < 0 || totalsIndex < 0 || !(perfIndex < mixedIndex && mixedIndex < totalsIndex) {
+		t.Fatalf("expected mixed table after performance table and before totals, got:\n%s", snippet)
+	}
 }
 
 func TestRendererMixedBreakdownOmitsConfiguredDistributionWhenUnavailable(t *testing.T) {

--- a/cli/internal/results/summary/render_test.go
+++ b/cli/internal/results/summary/render_test.go
@@ -198,6 +198,105 @@ func TestRendererListWorkloadDisplaysPrefix(t *testing.T) {
 	}
 }
 
+func TestRendererFullReportIncludesMixedBreakdown(t *testing.T) {
+	t.Parallel()
+
+	summary := mixedSummaryFixture()
+	renderer := NewRenderer(RenderOptions{MaxWidth: 120})
+	report := renderer.FullReport(summary)
+
+	mustContain(t, report, "Mixed Operation Breakdown")
+	mustContain(t, report, "Step: mt-002-20260604.180001.000-mixed")
+	mustContain(t, report, "Configured distribution: READ 45%, STAT 30%, CREATE 15%, DELETE 10%")
+	mustContain(t, report, "see ops")
+	mustContain(t, report, "│ READ")
+	mustContain(t, report, "│ DELETE")
+}
+
+func TestRendererCompactSnippetIncludesMixedOperationDetail(t *testing.T) {
+	t.Parallel()
+
+	renderer := NewRenderer(RenderOptions{MaxWidth: 100})
+	snippet := renderer.CompactSnippet(mixedSummaryFixture())
+
+	mustContain(t, snippet, "Mixed operations: READ")
+	mustContain(t, snippet, "cfg 45%")
+	mustContain(t, snippet, "CREATE")
+	mustContain(t, snippet, "Totals: duration 30s")
+}
+
+func TestRendererConsoleSnippetKeepsMixedDetailWithElevatedCap(t *testing.T) {
+	t.Parallel()
+
+	summary := mixedSummaryFixture()
+	for i := 0; i < 10; i++ {
+		summary.Warnings = append(summary.Warnings, "warning line for mixed report truncation coverage")
+	}
+
+	renderer := NewRenderer(RenderOptions{MaxWidth: 120, SnippetLineCap: 40})
+	snippet := renderer.ConsoleSnippet(summary)
+
+	mustContain(t, snippet, "Mixed Operation Breakdown")
+	mustContain(t, snippet, "Run Totals")
+	if strings.Contains(snippet, "report truncated") {
+		t.Fatalf("expected elevated mixed cap to avoid truncation, got:\n%s", snippet)
+	}
+}
+
+func mixedSummaryFixture() *RunSummary {
+	configuredRead := 45.0
+	configuredStat := 30.0
+	configuredCreate := 15.0
+	configuredDelete := 10.0
+	actualRead := 44.5
+	actualStat := 29.8
+	actualCreate := 15.1
+	actualDelete := 10.6
+
+	return &RunSummary{
+		RunID:       "mt-20260604.180000.000",
+		GeneratedAt: time.Date(2026, 6, 4, 18, 0, 0, 0, time.UTC),
+		Workload: WorkloadSummary{
+			Type:            "mixed",
+			ObjectSizeHuman: "4.00 MiB",
+			DurationRequest: "30s",
+			MixedDistribution: MixedDistribution{
+				Available:     true,
+				ReadPercent:   45,
+				StatPercent:   30,
+				CreatePercent: 15,
+				DeletePercent: 10,
+			},
+		},
+		Steps: []StepSummary{
+			{
+				StepID:          "mt-002-20260604.180001.000-mixed",
+				PhaseLabel:      "Mixed",
+				Operation:       "MIXED",
+				IsMixed:         true,
+				MixedLatencyNote: "Mixed latency is shown per operation; no combined p50 is derived from per-op quantiles.",
+				Metrics: &PhaseMetrics{
+					SuccessCount:     1000,
+					FailureCount:     12,
+					DataBytes:        2499805184,
+					ThroughputAvgOps: 33.5,
+					BandwidthAvgMBps: 80.4,
+					DurationSeconds:  30,
+					DurationHuman:    "30s",
+					ObjectSizeHuman:  "4.00 MiB",
+				},
+				OperationBreakdown: []OperationBreakdown{
+					{Operation: "READ", ConfiguredShare: &configuredRead, ActualShare: &actualRead, ActualOps: 450, Metrics: PhaseMetrics{SuccessCount: 445, FailureCount: 5, DataBytes: 1866465280, ThroughputAvgOps: 14.8, BandwidthAvgMBps: 59.3, LatencyMedianMs: 6.2}},
+					{Operation: "STAT", ConfiguredShare: &configuredStat, ActualShare: &actualStat, ActualOps: 302, Metrics: PhaseMetrics{SuccessCount: 301, FailureCount: 1, DataBytes: 0, ThroughputAvgOps: 10.0, BandwidthAvgMBps: 0, LatencyMedianMs: 3.1}},
+					{Operation: "CREATE", ConfiguredShare: &configuredCreate, ActualShare: &actualCreate, ActualOps: 153, Metrics: PhaseMetrics{SuccessCount: 151, FailureCount: 2, DataBytes: 633339904, ThroughputAvgOps: 5.1, BandwidthAvgMBps: 21.1, LatencyMedianMs: 8.7}},
+					{Operation: "DELETE", ConfiguredShare: &configuredDelete, ActualShare: &actualDelete, ActualOps: 107, Metrics: PhaseMetrics{SuccessCount: 103, FailureCount: 4, DataBytes: 0, ThroughputAvgOps: 3.6, BandwidthAvgMBps: 0, LatencyMedianMs: 5.2}},
+				},
+			},
+		},
+		Totals: RunTotals{DurationHuman: "30s", DataBytes: 2499805184},
+	}
+}
+
 func mustContain(t *testing.T, s, sub string) {
 	t.Helper()
 	if !strings.Contains(s, sub) {

--- a/cli/internal/results/summary/render_test.go
+++ b/cli/internal/results/summary/render_test.go
@@ -225,6 +225,23 @@ func TestRendererCompactSnippetIncludesMixedOperationDetail(t *testing.T) {
 	mustContain(t, snippet, "Totals: duration 30s")
 }
 
+func TestRendererMixedBreakdownOmitsConfiguredDistributionWhenUnavailable(t *testing.T) {
+	t.Parallel()
+
+	summary := mixedSummaryFixture()
+	summary.Workload.MixedDistribution = MixedDistribution{}
+	for i := range summary.Steps[0].OperationBreakdown {
+		summary.Steps[0].OperationBreakdown[i].ConfiguredShare = nil
+	}
+
+	renderer := NewRenderer(RenderOptions{MaxWidth: 120})
+	report := renderer.FullReport(summary)
+	snippet := renderer.CompactSnippet(summary)
+
+	mustNotContain(t, report, "Configured distribution:")
+	mustNotContain(t, snippet, "cfg ")
+}
+
 func TestRendererConsoleSnippetKeepsMixedDetailWithElevatedCap(t *testing.T) {
 	t.Parallel()
 
@@ -270,10 +287,10 @@ func mixedSummaryFixture() *RunSummary {
 		},
 		Steps: []StepSummary{
 			{
-				StepID:          "mt-002-20260604.180001.000-mixed",
-				PhaseLabel:      "Mixed",
-				Operation:       "MIXED",
-				IsMixed:         true,
+				StepID:           "mt-002-20260604.180001.000-mixed",
+				PhaseLabel:       "Mixed",
+				Operation:        "MIXED",
+				IsMixed:          true,
 				MixedLatencyNote: "Mixed latency is shown per operation; no combined p50 is derived from per-op quantiles.",
 				Metrics: &PhaseMetrics{
 					SuccessCount:     1000,
@@ -301,5 +318,12 @@ func mustContain(t *testing.T, s, sub string) {
 	t.Helper()
 	if !strings.Contains(s, sub) {
 		t.Fatalf("expected %q to contain %q", s, sub)
+	}
+}
+
+func mustNotContain(t *testing.T, s, sub string) {
+	t.Helper()
+	if strings.Contains(s, sub) {
+		t.Fatalf("expected %q not to contain %q", s, sub)
 	}
 }

--- a/engine/core/spt-base/src/main/java/com/dell/spt/base/logging/MetricsCsvLogMessage.java
+++ b/engine/core/spt-base/src/main/java/com/dell/spt/base/logging/MetricsCsvLogMessage.java
@@ -18,6 +18,10 @@ import org.apache.logging.log4j.message.AsynchronouslyFormattable;
 @AsynchronouslyFormattable
 public final class MetricsCsvLogMessage extends LogMessageBase {
 
+	private static final double LOW_QUARTILE = 0.25;
+	private static final double MEDIAN = 0.5;
+	private static final double HIGH_QUARTILE = 0.75;
+
 	private final AllMetricsSnapshot snapshot;
 	private final OpType opType;
 	private final int concurrencyLimit;
@@ -77,11 +81,23 @@ public final class MetricsCsvLogMessage extends LogMessageBase {
 						.append(',')
 						.append(durationSnapshot.min())
 						.append(',')
+						.append(durationSnapshot.percentile(LOW_QUARTILE))
+						.append(',')
+						.append(durationSnapshot.percentile(MEDIAN))
+						.append(',')
+						.append(durationSnapshot.percentile(HIGH_QUARTILE))
+						.append(',')
 						.append(durationSnapshot.max())
 						.append(',')
 						.append(latencySnapshot.mean())
 						.append(',')
 						.append(latencySnapshot.min())
+						.append(',')
+						.append(latencySnapshot.percentile(LOW_QUARTILE))
+						.append(',')
+						.append(latencySnapshot.percentile(MEDIAN))
+						.append(',')
+						.append(latencySnapshot.percentile(HIGH_QUARTILE))
 						.append(',')
 						.append(latencySnapshot.max());
 	}

--- a/engine/core/spt-base/src/main/java/com/dell/spt/base/logging/MetricsTotalCsvLogMessage.java
+++ b/engine/core/spt-base/src/main/java/com/dell/spt/base/logging/MetricsTotalCsvLogMessage.java
@@ -46,12 +46,20 @@ public class MetricsTotalCsvLogMessage extends LogMessageBase {
 		this.ttfbs = ttfbQuantiles;
 	}
 
-	@Override
-	public final void formatTo(final StringBuilder strb) {
-		final String lineSep = System.lineSeparator();
-		// log4j2 supports file headers to avoid this, but we need a dynamic header based on the provided quantiles
-		// headers are printed every time formatTo is called because each time we call it for a new step, hence
-		// for a new file
+ 	@Override
+ 	public final void formatTo(final StringBuilder strb) {
+		formatTo(strb, true);
+	}
+
+	public final void formatTo(final StringBuilder strb, final boolean includeHeader) {
+		if (includeHeader) {
+			appendHeader(strb);
+			strb.append(System.lineSeparator());
+		}
+		appendValueRow(strb);
+	}
+
+	private void appendHeader(final StringBuilder strb) {
 		strb.append("DateTimeISO8601,OpType,Concurrency,NodeCount,ConcurrencyCurr,ConcurrencyMean,CountSucc,")
 						.append("CountFail,Size,StepDuration[s],DurationSum[s],TPAvg[op/s],TPLast[op/s],BWAvg[MB/s],")
 						.append("BWLast[MB/s],DurationAvg[us],DurationMin[us],");
@@ -63,7 +71,6 @@ public class MetricsTotalCsvLogMessage extends LogMessageBase {
 		}
 		strb.append("DurationMax[us],LatencyAvg[us],LatencyMin[us],");
 
-		// not like quantiles are different for duration and latency, but just to be precise
 		for (Double quantile : latencies.keySet()) {
 			strb.append("LatencyQ_")
 							.append(quantile)
@@ -75,9 +82,10 @@ public class MetricsTotalCsvLogMessage extends LogMessageBase {
 							.append(quantile)
 							.append("[us],");
 		}
-		strb.append("TtfbMax[us]")
-						.append(lineSep);
+		strb.append("TtfbMax[us]");
+	}
 
+	private void appendValueRow(final StringBuilder strb) {
 		final ConcurrencyMetricSnapshot concurrencySnapshot = snapshot.concurrencySnapshot();
 		final TimingMetricSnapshot durationSnapshot = snapshot.durationSnapshot();
 		final RateMetricSnapshot successCountSnapshot = snapshot.successSnapshot();

--- a/engine/core/spt-base/src/main/java/com/dell/spt/base/logging/MetricsTotalCsvLogMessage.java
+++ b/engine/core/spt-base/src/main/java/com/dell/spt/base/logging/MetricsTotalCsvLogMessage.java
@@ -46,8 +46,8 @@ public class MetricsTotalCsvLogMessage extends LogMessageBase {
 		this.ttfbs = ttfbQuantiles;
 	}
 
- 	@Override
- 	public final void formatTo(final StringBuilder strb) {
+	@Override
+	public final void formatTo(final StringBuilder strb) {
 		formatTo(strb, true);
 	}
 

--- a/engine/core/spt-base/src/main/java/com/dell/spt/base/metrics/MetricsManagerImpl.java
+++ b/engine/core/spt-base/src/main/java/com/dell/spt/base/metrics/MetricsManagerImpl.java
@@ -60,6 +60,7 @@ public class MetricsManagerImpl extends TaskBase implements MetricsManager {
 	// Used to emit opening/closing wrapper tags as explicit log events so that both
 	// CLI and jar-only users get well-formed XML (log4j2 header/footer had async timing issues).
 	private final Set<String> openResultXmlSteps = ConcurrentHashMap.newKeySet();
+	private final Set<String> openMetricsTotalCsvSteps = ConcurrentHashMap.newKeySet();
 
 	// Terminal entries retention for /metrics/json when idle
 	private final Map<ProgressKey, TerminalStepEntry> terminalByStepId = new ConcurrentHashMap<>();
@@ -250,10 +251,13 @@ public class MetricsManagerImpl extends TaskBase implements MetricsManager {
 							// due to unknown reasons writing to a csv.total is based on a flag and not on a metrics
 							// class instance. though this flag is only enabled for distributed context.
 							if (metricsCtx.sumPersistEnabled()) {
-								Loggers.METRICS_FILE_TOTAL.info(
-												new MetricsTotalCsvLogMessage(snapshot, metricsCtx.opType(),
-																metricsCtx.concurrencyLimit(), latencyQuantiles,
-																durationQuantiles, ttfbQuantiles));
+								final boolean includeHeader = openMetricsTotalCsvSteps.add(metricsCtx.loadStepId());
+								final MetricsTotalCsvLogMessage message = new MetricsTotalCsvLogMessage(
+												snapshot, metricsCtx.opType(), metricsCtx.concurrencyLimit(), latencyQuantiles,
+												durationQuantiles, ttfbQuantiles);
+								final StringBuilder csvOutput = new StringBuilder();
+								message.formatTo(csvOutput, includeHeader);
+								Loggers.METRICS_FILE_TOTAL.info(csvOutput.toString());
 							}
 						}
 						// console output
@@ -288,6 +292,7 @@ public class MetricsManagerImpl extends TaskBase implements MetricsManager {
 														ctx -> metricsCtx.loadStepId().equals(ctx.loadStepId()))) {
 							Loggers.METRICS_EXT_RESULTS_FILE.info("</result>");
 							openResultXmlSteps.remove(metricsCtx.loadStepId());
+							openMetricsTotalCsvSteps.remove(metricsCtx.loadStepId());
 						}
 
 						final PrometheusMetricsExporter exporter = distributedMetrics.remove(distributedMetricsCtx);

--- a/engine/core/spt-base/src/test/java/com/dell/spt/base/logging/MetricsCsvLogMessageTest.java
+++ b/engine/core/spt-base/src/test/java/com/dell/spt/base/logging/MetricsCsvLogMessageTest.java
@@ -1,0 +1,56 @@
+package com.dell.spt.base.logging;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.dell.spt.base.item.op.OpType;
+import com.dell.spt.base.metrics.MetricsConstants;
+import com.dell.spt.base.metrics.snapshot.AllMetricsSnapshot;
+import com.dell.spt.base.metrics.snapshot.ConcurrencyMetricSnapshotImpl;
+import com.dell.spt.base.metrics.snapshot.DistributedAllMetricsSnapshotImpl;
+import com.dell.spt.base.metrics.snapshot.RateMetricSnapshotImpl;
+import com.dell.spt.base.metrics.snapshot.TimingMetricSnapshotImpl;
+import java.io.StringReader;
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVParser;
+import org.junit.jupiter.api.Test;
+
+class MetricsCsvLogMessageTest {
+
+	private static final String INTERVAL_CSV_HEADER = "DateTimeISO8601,OpType,Concurrency,NodeCount,ConcurrencyCurr,ConcurrencyMean,CountSucc,CountFail,"
+					+ "Size,StepDuration[s],DurationSum[s],TPAvg[op/s],TPLast[op/s],BWAvg[MB/s],"
+					+ "BWLast[MB/s],DurationAvg[us],DurationMin[us],DurationLoQ[us],DurationMed[us],"
+					+ "DurationHiQ[us],DurationMax[us],LatencyAvg[us],LatencyMin[us],LatencyLoQ[us],"
+					+ "LatencyMed[us],LatencyHiQ[us],LatencyMax[us]";
+
+	@Test
+	void intervalCsvRowMatchesHeaderShapeAndColumns() throws Exception {
+		final AllMetricsSnapshot snapshot = new DistributedAllMetricsSnapshotImpl(
+						new TimingMetricSnapshotImpl(1000, 4, 100, 400, 250.0, MetricsConstants.METRIC_NAME_DUR),
+						new TimingMetricSnapshotImpl(100, 4, 10, 40, 25.0, MetricsConstants.METRIC_NAME_LAT),
+						new TimingMetricSnapshotImpl(0, 0, 0, 0, 0.0, MetricsConstants.METRIC_NAME_TTFB),
+						new ConcurrencyMetricSnapshotImpl(MetricsConstants.METRIC_NAME_CONC, 2, 1.5),
+						new RateMetricSnapshotImpl(0.0, 0.0, MetricsConstants.METRIC_NAME_FAIL, 0, 1000),
+						new RateMetricSnapshotImpl(4.0, 3.0, MetricsConstants.METRIC_NAME_SUCC, 4, 1000),
+						new RateMetricSnapshotImpl(4096.0, 2048.0, MetricsConstants.METRIC_NAME_BYTE, 4096, 1000),
+						3,
+						1000);
+		final MetricsCsvLogMessage message = new MetricsCsvLogMessage(snapshot, OpType.READ, 2);
+		final StringBuilder row = new StringBuilder();
+
+		message.formatTo(row);
+
+		try (final CSVParser parser = CSVFormat.DEFAULT.builder()
+						.setHeader()
+						.setSkipHeaderRecord(true)
+						.build()
+						.parse(new StringReader(INTERVAL_CSV_HEADER + System.lineSeparator() + row))) {
+			final var records = parser.getRecords();
+			assertEquals(1, records.size());
+			final var record = records.get(0);
+			assertEquals(parser.getHeaderMap().size(), record.size(), row.toString());
+			assertEquals("400", record.get("DurationMax[us]"));
+			assertEquals("25.0", record.get("LatencyAvg[us]"));
+			assertEquals("40", record.get("LatencyMax[us]"));
+		}
+	}
+}

--- a/engine/core/spt-base/src/test/java/com/dell/spt/base/metrics/MetricsManagerImplCsvTotalTest.java
+++ b/engine/core/spt-base/src/test/java/com/dell/spt/base/metrics/MetricsManagerImplCsvTotalTest.java
@@ -1,15 +1,16 @@
 package com.dell.spt.base.metrics;
 
 import static com.dell.spt.base.Constants.KEY_HOME_DIR;
+import static com.dell.spt.base.Constants.KEY_STEP_ID;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.dell.spt.base.concurrent.ServiceTaskExecutor;
 import com.dell.spt.base.item.op.OpType;
+import com.dell.spt.base.logging.Loggers;
 import com.dell.spt.base.logging.LogUtil;
 import com.dell.spt.base.metrics.context.DistributedMetricsContext;
 import com.dell.spt.base.metrics.snapshot.ConcurrencyMetricSnapshotImpl;
@@ -17,13 +18,20 @@ import com.dell.spt.base.metrics.snapshot.DistributedAllMetricsSnapshotImpl;
 import com.dell.spt.base.metrics.snapshot.RateMetricSnapshotImpl;
 import com.dell.spt.base.metrics.snapshot.TimingMetricSnapshotImpl;
 import com.github.akurilov.commons.system.SizeInBytes;
-import java.nio.file.Files;
+import java.io.StringReader;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVParser;
 import org.apache.logging.log4j.ThreadContext;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.config.Property;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -31,39 +39,55 @@ class MetricsManagerImplCsvTotalTest {
 
 	@Test
 	void writesSingleHeaderForMultipleOperationsInSameStep(@TempDir final Path tempDir) throws Exception {
+		final String stepId = "mixed-step-csv-total";
+		final CapturingAppender appender = new CapturingAppender(stepId);
+		appender.start();
+		final var loggerCtx = LoggerContext.getContext(false);
+		final var logger = loggerCtx.getLogger(Loggers.METRICS_FILE_TOTAL.getName());
+		logger.addAppender(appender);
 		ThreadContext.put(KEY_HOME_DIR, tempDir.toString());
 		try {
 			final MetricsManagerImpl mgr = new MetricsManagerImpl(ServiceTaskExecutor.VT_EXECUTOR);
-			final String stepId = "mixed-step-csv-total";
 			final DistributedMetricsContext readCtx = distributedContext(
-					stepId,
-					OpType.READ,
-					snapshot(11L, 45_056L, List.of(120L, 180L), List.of(210L, 260L), List.of(30L, 40L)),
-					-1);
+							stepId,
+							OpType.READ,
+							snapshot(11L, 45_056L, List.of(120L, 180L), List.of(210L, 260L), List.of(30L, 40L)));
+			final DistributedMetricsContext statCtx = distributedContext(
+							stepId,
+							OpType.STAT,
+							snapshot(5L, 0L, List.of(90L, 130L), List.of(120L, 180L), List.of()));
 			final DistributedMetricsContext createCtx = distributedContext(
-					stepId,
-					OpType.CREATE,
-					snapshot(7L, 28_672L, List.of(160L, 220L), List.of(250L, 300L), List.of()),
-					1);
+							stepId,
+							OpType.CREATE,
+							snapshot(7L, 28_672L, List.of(160L, 220L), List.of(250L, 300L), List.of()));
+			final DistributedMetricsContext deleteCtx = distributedContext(
+							stepId,
+							OpType.DELETE,
+							snapshot(3L, 0L, List.of(110L, 170L), List.of(140L, 210L), List.of()));
+			final List<DistributedMetricsContext> contexts = List.of(readCtx, statCtx, createCtx, deleteCtx);
+			configureSortOrder(contexts);
 
-			mgr.register(readCtx);
-			mgr.register(createCtx);
-			mgr.unregister(readCtx);
-			mgr.unregister(createCtx);
-			LogUtil.flushAll();
+			for (final DistributedMetricsContext ctx : contexts) {
+				mgr.register(ctx);
+			}
+			for (final DistributedMetricsContext ctx : contexts) {
+				mgr.unregister(ctx);
+			}
 
-			final Path csvPath = tempDir.resolve("log").resolve(stepId).resolve("metrics.total.csv");
-			assertTrue(Files.exists(csvPath), "expected metrics.total.csv at " + csvPath);
-
-			final List<String> lines = Files.readAllLines(csvPath);
+			final List<String> messages = awaitCsvMessages(appender, contexts.size());
+			final String csvContent = String.join(System.lineSeparator(), messages) + System.lineSeparator();
+			final List<String> lines = csvContent.lines().toList();
 			assertEquals(1L, lines.stream().filter(line -> line.startsWith("DateTimeISO8601,")).count(), lines.toString());
 
-			try (final var reader = Files.newBufferedReader(csvPath);
-						 final CSVParser parser = CSVFormat.DEFAULT.builder().setHeader().setSkipHeaderRecord(true).build().parse(reader)) {
+			try (final CSVParser parser = CSVFormat.DEFAULT.builder()
+							.setHeader()
+							.setSkipHeaderRecord(true)
+							.build()
+							.parse(new StringReader(csvContent))) {
 				final var records = parser.getRecords();
 				final int headerSize = parser.getHeaderMap().size();
-				assertEquals(2, records.size(), records.toString());
-				assertEquals(List.of("READ", "CREATE"), records.stream().map(record -> record.get("OpType")).toList());
+				assertEquals(contexts.size(), records.size(), records.toString());
+				assertEquals(List.of("READ", "STAT", "CREATE", "DELETE"), records.stream().map(record -> record.get("OpType")).toList());
 				for (final var record : records) {
 					assertEquals(headerSize, record.size(), record.toString());
 					assertNotEquals("DateTimeISO8601", record.get(0), record.toString());
@@ -71,14 +95,15 @@ class MetricsManagerImplCsvTotalTest {
 			}
 		} finally {
 			ThreadContext.remove(KEY_HOME_DIR);
+			logger.removeAppender(appender);
+			appender.stop();
 		}
 	}
 
 	private static DistributedMetricsContext distributedContext(
 					final String stepId,
 					final OpType opType,
-					final DistributedAllMetricsSnapshotImpl snapshot,
-					final int sortOrder) {
+					final DistributedAllMetricsSnapshotImpl snapshot) {
 		final DistributedMetricsContext ctx = mock(DistributedMetricsContext.class);
 		when(ctx.loadStepId()).thenReturn(stepId);
 		when(ctx.opType()).thenReturn(opType);
@@ -97,8 +122,60 @@ class MetricsManagerImplCsvTotalTest {
 		when(ctx.outputPeriodMillis()).thenReturn(0L);
 		when(ctx.thresholdStateEntered()).thenReturn(false);
 		when(ctx.thresholdStateExited()).thenReturn(false);
-		when(ctx.compareTo(any())).thenAnswer(invocation -> invocation.getArgument(0) == ctx ? 0 : sortOrder);
 		return ctx;
+	}
+
+	private static void configureSortOrder(final List<DistributedMetricsContext> contexts) {
+		final Map<DistributedMetricsContext, Integer> orderByContext = new IdentityHashMap<>();
+		for (int i = 0; i < contexts.size(); i++) {
+			orderByContext.put(contexts.get(i), i);
+		}
+		for (final DistributedMetricsContext ctx : contexts) {
+			when(ctx.compareTo(any())).thenAnswer(invocation -> {
+				final Integer left = orderByContext.get(ctx);
+				final Integer right = orderByContext.get(invocation.getArgument(0));
+				return Integer.compare(left == null ? -1 : left, right == null ? -1 : right);
+			});
+		}
+	}
+
+	private static List<String> awaitCsvMessages(final CapturingAppender appender, final int expectedDataRows) throws Exception {
+		AssertionError lastFailure = null;
+		for (int attempt = 0; attempt < 100; attempt++) {
+			LogUtil.flushAll();
+			final List<String> messages = appender.messages();
+			if (messages.size() >= expectedDataRows) {
+				return messages;
+			}
+			lastFailure = new AssertionError(
+							"metrics total CSV events not complete yet: expected " + expectedDataRows
+											+ " messages, got " + messages.size() + ": " + messages);
+			Thread.sleep(50);
+		}
+		throw lastFailure;
+	}
+
+	private static class CapturingAppender extends AbstractAppender {
+		private final String stepId;
+		private final List<String> captured = Collections.synchronizedList(new ArrayList<>());
+
+		CapturingAppender(final String stepId) {
+			super("testMetricsTotalCsvCapture", null, null, true, Property.EMPTY_ARRAY);
+			this.stepId = stepId;
+		}
+
+		@Override
+		public void append(final LogEvent event) {
+			if (stepId.equals(event.getContextData().getValue(KEY_STEP_ID))) {
+				captured.add(event.getMessage().getFormattedMessage());
+			}
+		}
+
+		List<String> messages() {
+			synchronized (captured) {
+				return List.copyOf(captured);
+			}
+		}
 	}
 
 	private static DistributedAllMetricsSnapshotImpl snapshot(
@@ -108,16 +185,16 @@ class MetricsManagerImplCsvTotalTest {
 					final List<Long> durationSamples,
 					final List<Long> ttfbSamples) {
 		return new DistributedAllMetricsSnapshotImpl(
-					TimingMetricSnapshotImpl.fromSamples(MetricsConstants.METRIC_NAME_DUR, durationSamples),
-					TimingMetricSnapshotImpl.fromSamples(MetricsConstants.METRIC_NAME_LAT, latencySamples),
-					ttfbSamples.isEmpty()
-							? new TimingMetricSnapshotImpl(0, 0, 0, 0, 0.0, MetricsConstants.METRIC_NAME_TTFB)
-							: TimingMetricSnapshotImpl.fromSamples(MetricsConstants.METRIC_NAME_TTFB, ttfbSamples),
-					new ConcurrencyMetricSnapshotImpl(MetricsConstants.METRIC_NAME_CONC, 4, 4.0),
-					new RateMetricSnapshotImpl(0.0, 0.0, MetricsConstants.METRIC_NAME_FAIL, 0, 1_000),
-					new RateMetricSnapshotImpl((double) successCount, (double) successCount, MetricsConstants.METRIC_NAME_SUCC, successCount, 1_000),
-					new RateMetricSnapshotImpl((double) byteCount, (double) byteCount, MetricsConstants.METRIC_NAME_BYTE, byteCount, 1_000),
-					1,
-					1_000);
+						TimingMetricSnapshotImpl.fromSamples(MetricsConstants.METRIC_NAME_DUR, durationSamples),
+						TimingMetricSnapshotImpl.fromSamples(MetricsConstants.METRIC_NAME_LAT, latencySamples),
+						ttfbSamples.isEmpty()
+										? new TimingMetricSnapshotImpl(0, 0, 0, 0, 0.0, MetricsConstants.METRIC_NAME_TTFB)
+										: TimingMetricSnapshotImpl.fromSamples(MetricsConstants.METRIC_NAME_TTFB, ttfbSamples),
+						new ConcurrencyMetricSnapshotImpl(MetricsConstants.METRIC_NAME_CONC, 4, 4.0),
+						new RateMetricSnapshotImpl(0.0, 0.0, MetricsConstants.METRIC_NAME_FAIL, 0, 1_000),
+						new RateMetricSnapshotImpl((double) successCount, (double) successCount, MetricsConstants.METRIC_NAME_SUCC, successCount, 1_000),
+						new RateMetricSnapshotImpl((double) byteCount, (double) byteCount, MetricsConstants.METRIC_NAME_BYTE, byteCount, 1_000),
+						1,
+						1_000);
 	}
 }

--- a/engine/core/spt-base/src/test/java/com/dell/spt/base/metrics/MetricsManagerImplCsvTotalTest.java
+++ b/engine/core/spt-base/src/test/java/com/dell/spt/base/metrics/MetricsManagerImplCsvTotalTest.java
@@ -1,0 +1,123 @@
+package com.dell.spt.base.metrics;
+
+import static com.dell.spt.base.Constants.KEY_HOME_DIR;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.dell.spt.base.concurrent.ServiceTaskExecutor;
+import com.dell.spt.base.item.op.OpType;
+import com.dell.spt.base.logging.LogUtil;
+import com.dell.spt.base.metrics.context.DistributedMetricsContext;
+import com.dell.spt.base.metrics.snapshot.ConcurrencyMetricSnapshotImpl;
+import com.dell.spt.base.metrics.snapshot.DistributedAllMetricsSnapshotImpl;
+import com.dell.spt.base.metrics.snapshot.RateMetricSnapshotImpl;
+import com.dell.spt.base.metrics.snapshot.TimingMetricSnapshotImpl;
+import com.github.akurilov.commons.system.SizeInBytes;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVParser;
+import org.apache.logging.log4j.ThreadContext;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class MetricsManagerImplCsvTotalTest {
+
+	@Test
+	void writesSingleHeaderForMultipleOperationsInSameStep(@TempDir final Path tempDir) throws Exception {
+		ThreadContext.put(KEY_HOME_DIR, tempDir.toString());
+		try {
+			final MetricsManagerImpl mgr = new MetricsManagerImpl(ServiceTaskExecutor.VT_EXECUTOR);
+			final String stepId = "mixed-step-csv-total";
+			final DistributedMetricsContext readCtx = distributedContext(
+					stepId,
+					OpType.READ,
+					snapshot(11L, 45_056L, List.of(120L, 180L), List.of(210L, 260L), List.of(30L, 40L)),
+					-1);
+			final DistributedMetricsContext createCtx = distributedContext(
+					stepId,
+					OpType.CREATE,
+					snapshot(7L, 28_672L, List.of(160L, 220L), List.of(250L, 300L), List.of()),
+					1);
+
+			mgr.register(readCtx);
+			mgr.register(createCtx);
+			mgr.unregister(readCtx);
+			mgr.unregister(createCtx);
+			LogUtil.flushAll();
+
+			final Path csvPath = tempDir.resolve("log").resolve(stepId).resolve("metrics.total.csv");
+			assertTrue(Files.exists(csvPath), "expected metrics.total.csv at " + csvPath);
+
+			final List<String> lines = Files.readAllLines(csvPath);
+			assertEquals(1L, lines.stream().filter(line -> line.startsWith("DateTimeISO8601,")).count(), lines.toString());
+
+			try (final var reader = Files.newBufferedReader(csvPath);
+						 final CSVParser parser = CSVFormat.DEFAULT.builder().setHeader().setSkipHeaderRecord(true).build().parse(reader)) {
+				final var records = parser.getRecords();
+				final int headerSize = parser.getHeaderMap().size();
+				assertEquals(2, records.size(), records.toString());
+				assertEquals(List.of("READ", "CREATE"), records.stream().map(record -> record.get("OpType")).toList());
+				for (final var record : records) {
+					assertEquals(headerSize, record.size(), record.toString());
+					assertNotEquals("DateTimeISO8601", record.get(0), record.toString());
+				}
+			}
+		} finally {
+			ThreadContext.remove(KEY_HOME_DIR);
+		}
+	}
+
+	private static DistributedMetricsContext distributedContext(
+					final String stepId,
+					final OpType opType,
+					final DistributedAllMetricsSnapshotImpl snapshot,
+					final int sortOrder) {
+		final DistributedMetricsContext ctx = mock(DistributedMetricsContext.class);
+		when(ctx.loadStepId()).thenReturn(stepId);
+		when(ctx.opType()).thenReturn(opType);
+		when(ctx.lastSnapshot()).thenReturn(snapshot);
+		when(ctx.quantileValues()).thenReturn(List.of(0.5, 0.9, 0.99, 0.999));
+		when(ctx.nodeCount()).thenReturn(1);
+		when(ctx.metadata()).thenReturn(Map.of(MetricsConstants.METADATA_LIMIT_OP_COUNT, snapshot.successSnapshot().count()));
+		when(ctx.concurrencyLimit()).thenReturn(4);
+		when(ctx.itemDataSize()).thenReturn(new SizeInBytes(4_096L));
+		when(ctx.startTimeStamp()).thenReturn(System.currentTimeMillis());
+		when(ctx.nodeAddrs()).thenReturn(List.of("127.0.0.1:1099"));
+		when(ctx.comment()).thenReturn("");
+		when(ctx.runId()).thenReturn(1L);
+		when(ctx.sumPersistEnabled()).thenReturn(true);
+		when(ctx.timingPersistEnabled()).thenReturn(false);
+		when(ctx.outputPeriodMillis()).thenReturn(0L);
+		when(ctx.thresholdStateEntered()).thenReturn(false);
+		when(ctx.thresholdStateExited()).thenReturn(false);
+		when(ctx.compareTo(any())).thenAnswer(invocation -> invocation.getArgument(0) == ctx ? 0 : sortOrder);
+		return ctx;
+	}
+
+	private static DistributedAllMetricsSnapshotImpl snapshot(
+					final long successCount,
+					final long byteCount,
+					final List<Long> latencySamples,
+					final List<Long> durationSamples,
+					final List<Long> ttfbSamples) {
+		return new DistributedAllMetricsSnapshotImpl(
+					TimingMetricSnapshotImpl.fromSamples(MetricsConstants.METRIC_NAME_DUR, durationSamples),
+					TimingMetricSnapshotImpl.fromSamples(MetricsConstants.METRIC_NAME_LAT, latencySamples),
+					ttfbSamples.isEmpty()
+							? new TimingMetricSnapshotImpl(0, 0, 0, 0, 0.0, MetricsConstants.METRIC_NAME_TTFB)
+							: TimingMetricSnapshotImpl.fromSamples(MetricsConstants.METRIC_NAME_TTFB, ttfbSamples),
+					new ConcurrencyMetricSnapshotImpl(MetricsConstants.METRIC_NAME_CONC, 4, 4.0),
+					new RateMetricSnapshotImpl(0.0, 0.0, MetricsConstants.METRIC_NAME_FAIL, 0, 1_000),
+					new RateMetricSnapshotImpl((double) successCount, (double) successCount, MetricsConstants.METRIC_NAME_SUCC, successCount, 1_000),
+					new RateMetricSnapshotImpl((double) byteCount, (double) byteCount, MetricsConstants.METRIC_NAME_BYTE, byteCount, 1_000),
+					1,
+					1_000);
+	}
+}


### PR DESCRIPTION
## Summary
- Fix mixed interval CSV rows so producer output matches the declared header shape.
- Treat metrics summary persistence disabled in seed steps as intentional, avoiding false artifact-health warnings.
- Improve mixed workload summaries with per-operation breakdowns, including compact console/TUI table output.
- Emit the final auto-results summary after shutdown completes to avoid report interleaving.

