### PR TITLE
Track TTFB for read and list operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 ### Added
 
 - **Replay archived workloads documentation** — added public user documentation for `spt replay`, including source archive requirements, environment remapping behavior, supported safe file-preparation transformations, generate-only inspection, distributed replay guidance, limitations, and troubleshooting.
+- **READ/LIST TTFB reporting** — Time to First Byte is now tracked for body-returning READ and LIST operations, including local filesystem reads and AWS SDK S3 LIST responses. Live/headless metrics and final summaries report TTFB only when samples are available, avoiding misleading mixed-workload or non-body-operation TTFB values.
 
 ## [5.10.4] - 2026-06-01
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The Dell **Storage Performance Tool (SPT)** is an open-source benchmark suite pu
 
 - spin up realistic object workloads in minutes;
 - orchestrate single-node or distributed runs without handcrafting scripts;
-- monitor live latency/throughput in an interactive terminal UI or headless CI logs;
+- monitor live throughput and latency in an interactive terminal UI or headless CI logs, with TTFB reported for READ/LIST samples when available;
 - reuse the same configuration flow for both mock runs and production endpoints.
 
 SPT packages two tightly integrated components:
@@ -140,7 +140,7 @@ For the full CLI reference (all flags, workload types, distributed options, RDMA
 - **S3 Multipart Upload** -- upload large objects in parallel parts with automatic abort on failure, per-part retry (up to 3 attempts), and per-part checksum support. Enable with `--part-size`.
 - **S3 Checksum Validation** -- compute and send checksums on write requests with `--checksum` (`crc32`, `crc32c`, `sha1`, `sha256`, `crc64-nvme`). When combined with multipart upload, checksums are applied per part. Supported by the Netty, AWS SDK, and RDMA drivers.
 - **Data Compressibility & Deduplication Controls** -- shape generated object data for storage-efficiency benchmarks with `--object-data-compressibility` (0-100% target compressibility) and `--object-data-dedupable=false` (per-4KB anti-dedupe stamping).
-- **Interactive & Headless** -- flip between a terminal UI for live monitoring and headless mode for CI/CD.
+- **Interactive & Headless** -- flip between a terminal UI for live monitoring and headless mode for CI/CD, with TTFB shown for READ/LIST samples when available.
 - **Distributed Runs** – preflight checks, node orchestration, and attachment support are built into the CLI.
 - **Scenario Generation** – the CLI generates scenario files on the fly for the engine, sparing users from manual scripting.
 - **Replay Archived Workloads** – import archived SPT or legacy Mongoose artifacts from a result-folder URL and replay the equivalent S3 workload against your current target configuration.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The Dell **Storage Performance Tool (SPT)** is an open-source benchmark suite pu
 
 - spin up realistic object workloads in minutes;
 - orchestrate single-node or distributed runs without handcrafting scripts;
-- monitor live throughput and latency in an interactive terminal UI or headless CI logs, with TTFB reported for READ/LIST samples when available;
+- monitor live throughput and latency in an interactive terminal UI or headless CI logs;
 - reuse the same configuration flow for both mock runs and production endpoints.
 
 SPT packages two tightly integrated components:
@@ -140,7 +140,7 @@ For the full CLI reference (all flags, workload types, distributed options, RDMA
 - **S3 Multipart Upload** -- upload large objects in parallel parts with automatic abort on failure, per-part retry (up to 3 attempts), and per-part checksum support. Enable with `--part-size`.
 - **S3 Checksum Validation** -- compute and send checksums on write requests with `--checksum` (`crc32`, `crc32c`, `sha1`, `sha256`, `crc64-nvme`). When combined with multipart upload, checksums are applied per part. Supported by the Netty, AWS SDK, and RDMA drivers.
 - **Data Compressibility & Deduplication Controls** -- shape generated object data for storage-efficiency benchmarks with `--object-data-compressibility` (0-100% target compressibility) and `--object-data-dedupable=false` (per-4KB anti-dedupe stamping).
-- **Interactive & Headless** -- flip between a terminal UI for live monitoring and headless mode for CI/CD, with TTFB shown for READ/LIST samples when available.
+- **Interactive & Headless** -- flip between a terminal UI for live monitoring and headless mode for CI/CD.
 - **Distributed Runs** – preflight checks, node orchestration, and attachment support are built into the CLI.
 - **Scenario Generation** – the CLI generates scenario files on the fly for the engine, sparing users from manual scripting.
 - **Replay Archived Workloads** – import archived SPT or legacy Mongoose artifacts from a result-folder URL and replay the equivalent S3 workload against your current target configuration.

--- a/cli/README.md
+++ b/cli/README.md
@@ -65,7 +65,7 @@ Authentication defaults to Signature Version 4. Add `--auth-version 2` only when
 - **Dual Execution Modes**:
   - **Interactive TUI**: Built-in terminal interface for monitoring benchmark progress
   - **Headless Mode**: Non-interactive mode for CI/CD, scripting, and automated environments
-- **Real-time Performance Visualization**: Dual synchronized ASCII bar charts showing ops/sec and latency
+- **Real-time Performance Visualization**: Dual synchronized ASCII bar charts showing ops/sec and latency, with headless output and final summaries also reporting TTFB for READ/LIST samples when available
 - **Historical Data Navigation**: Interactive time-based navigation through performance samples
 - **Auto-Detection**: Automatically switches to headless mode when no TTY is available
 - **Trace File Support**: Comprehensive output capture for debugging and analysis
@@ -566,7 +566,7 @@ When run in a terminal with TTY support, spt displays an interactive interface w
 
 Auto Results and Shutdown
 - `--auto-results` (default: true): automatically discovers step IDs, waits for terminal state via `/status` + idle JSON, then fetches artifacts (preferring per-step `/logs/<stepId>/index.json`).
-- When auto-results completes successfully, `spt` now writes a human-readable summary alongside the fetched artifacts (`spt_<runID>_results_summary.txt`) and prints a shortened version to the console. The summary pulls from the same metrics `.csv` files, `spt_run_params.json`, and the copied scenario file so the bundle stays self-contained.
+- When auto-results completes successfully, `spt` now writes a human-readable summary alongside the fetched artifacts (`spt_<runID>_results_summary.txt`) and prints a shortened version to the console. The summary pulls from the same metrics `.csv` files, `spt_run_params.json`, and the copied scenario file so the bundle stays self-contained; READ/LIST rows include `TTFB P50` when samples are available.
 - `--results-dir`: directory where fetched artifacts and a manifest `index.json` are saved.
 - `--label`: prefix for the output directory name and step ID prefix used in filenames.
 - `--shutdown-on-complete` (default: true): after a successful fetch, POST `/shutdown` to all Spt hosts and wait for `/status` to linger in a terminal state.
@@ -624,8 +624,10 @@ When no TTY is available (CI/CD environments, Docker containers, etc.), spt auto
 [2025-08-06 14:23:46] [DOCKER] Container started: abc123def456
 [2025-08-06 14:23:47] [SPT] Spt v5.0.2 starting...
 [2025-08-06 14:23:48] [METRICS] ops/sec=45 latency=1024µs type=CREATE success=100 concurrency=8.0
-[2025-08-06 14:23:49] [METRICS] ops/sec=52 latency=956µs type=CREATE success=156 concurrency=8.0
+[2025-08-06 14:23:49] [METRICS] ops/sec=52 latency=956µs ttfb=430µs type=READ success=156 concurrency=8.0
 ```
+
+The `ttfb` field is emitted only for samples that include Time to First Byte data, currently READ and LIST operation metrics.
 
 **Trace Files:**
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -65,7 +65,7 @@ Authentication defaults to Signature Version 4. Add `--auth-version 2` only when
 - **Dual Execution Modes**:
   - **Interactive TUI**: Built-in terminal interface for monitoring benchmark progress
   - **Headless Mode**: Non-interactive mode for CI/CD, scripting, and automated environments
-- **Real-time Performance Visualization**: Dual synchronized ASCII bar charts showing ops/sec and latency, with headless output and final summaries also reporting TTFB for READ/LIST samples when available
+- **Real-time Performance Visualization**: Dual synchronized ASCII bar charts showing ops/sec and latency
 - **Historical Data Navigation**: Interactive time-based navigation through performance samples
 - **Auto-Detection**: Automatically switches to headless mode when no TTY is available
 - **Trace File Support**: Comprehensive output capture for debugging and analysis
@@ -566,7 +566,7 @@ When run in a terminal with TTY support, spt displays an interactive interface w
 
 Auto Results and Shutdown
 - `--auto-results` (default: true): automatically discovers step IDs, waits for terminal state via `/status` + idle JSON, then fetches artifacts (preferring per-step `/logs/<stepId>/index.json`).
-- When auto-results completes successfully, `spt` now writes a human-readable summary alongside the fetched artifacts (`spt_<runID>_results_summary.txt`) and prints a shortened version to the console. The summary pulls from the same metrics `.csv` files, `spt_run_params.json`, and the copied scenario file so the bundle stays self-contained; READ/LIST rows include `TTFB P50` when samples are available.
+- When auto-results completes successfully, `spt` now writes a human-readable summary alongside the fetched artifacts (`spt_<runID>_results_summary.txt`) and prints a shortened version to the console. The summary pulls from the same metrics `.csv` files, `spt_run_params.json`, and the copied scenario file so the bundle stays self-contained.
 - `--results-dir`: directory where fetched artifacts and a manifest `index.json` are saved.
 - `--label`: prefix for the output directory name and step ID prefix used in filenames.
 - `--shutdown-on-complete` (default: true): after a successful fetch, POST `/shutdown` to all Spt hosts and wait for `/status` to linger in a terminal state.

--- a/cli/docs/SPT_SYNTAX.md
+++ b/cli/docs/SPT_SYNTAX.md
@@ -231,6 +231,8 @@ Set any operation weight to `0` to exclude it. For example, `--get-distrib 60 --
 
 By default, `spt run` launches an interactive TUI. Use `--headless` for CI or unattended runs.
 
+Live metrics include throughput, latency, duration, and progress. Time to First Byte (TTFB) is reported for READ and LIST samples when the engine records first response body bytes; headless text/JSON output omits the TTFB field when it is unavailable.
+
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--headless` | `false` | Force headless (non-interactive) mode |

--- a/cli/internal/results/summary/render.go
+++ b/cli/internal/results/summary/render.go
@@ -27,6 +27,7 @@ const (
 	defaultSnippetLineCap = 40
 	headerIOPSAvg         = "IOPS Avg"
 	headerLatencyP50      = "Latency P50"
+	headerTTFBP50         = "TTFB P50"
 	headerBandwidthAvg    = "Bandwidth Avg"
 )
 
@@ -207,7 +208,7 @@ func (r *Renderer) renderPerformance(b *strings.Builder, summary *RunSummary) {
 }
 
 func (r *Renderer) performanceTable(summary *RunSummary) string {
-	headers := []string{"Phase", "Object Size", "Success", "Data Moved", headerIOPSAvg, headerLatencyP50, headerBandwidthAvg}
+	headers := []string{"Phase", "Object Size", "Success", "Data Moved", headerIOPSAvg, headerLatencyP50, headerTTFBP50, headerBandwidthAvg}
 	isList := strings.EqualFold(summary.Workload.Type, workloadTypeList)
 	if isList {
 		headers[4] = "Ops/s Avg"
@@ -229,14 +230,15 @@ func (r *Renderer) performanceTable(summary *RunSummary) string {
 			formatBytesHuman(m.DataBytes),
 			formatNumber(m.ThroughputAvgOps, "ops/s"),
 			mixedLatencyCell(step, m),
+			mixedTTFBCell(step, m),
 			formatNumber(m.BandwidthAvgMBps, "MB/s"),
 		}
 		rows = append(rows, row)
 	}
 	if len(rows) == 0 {
-		rows = append(rows, []string{"—", "—", "—", "—", "—", "—", "—"})
+		rows = append(rows, []string{"—", "—", "—", "—", "—", "—", "—", "—"})
 	}
-	return renderUnicodeTable(headers, rows, []Alignment{AlignLeft, AlignLeft, AlignRight, AlignRight, AlignRight, AlignRight, AlignRight})
+	return renderUnicodeTable(headers, rows, []Alignment{AlignLeft, AlignLeft, AlignRight, AlignRight, AlignRight, AlignRight, AlignRight, AlignRight})
 }
 
 func (r *Renderer) renderCompactMixedBreakdowns(b *strings.Builder, summary *RunSummary) {
@@ -262,7 +264,7 @@ func (r *Renderer) renderCompactMixedBreakdowns(b *strings.Builder, summary *Run
 		if mixedStepCount > 1 && step.StepID != "" {
 			fmt.Fprintf(b, "Step: %s\n", step.StepID)
 		}
-		headers := []string{"Operation", "Configured", "Actual Ops", headerIOPSAvg, headerLatencyP50}
+		headers := []string{"Operation", "Configured", "Actual Ops", headerIOPSAvg, headerLatencyP50, headerTTFBP50}
 		rows := make([][]string, 0, len(step.OperationBreakdown))
 		for _, op := range step.OperationBreakdown {
 			rows = append(rows, []string{
@@ -271,9 +273,10 @@ func (r *Renderer) renderCompactMixedBreakdowns(b *strings.Builder, summary *Run
 				formatActualOps(op.ActualShare, op.ActualOps),
 				formatNumber(op.Metrics.ThroughputAvgOps, "ops/s"),
 				formatNumber(op.Metrics.LatencyMedianMs, "ms"),
+				formatTTFBNumber(op.Metrics.TTFBMedianMs),
 			})
 		}
-		b.WriteString(renderUnicodeTable(headers, rows, []Alignment{AlignLeft, AlignRight, AlignRight, AlignRight, AlignRight}))
+		b.WriteString(renderUnicodeTable(headers, rows, []Alignment{AlignLeft, AlignRight, AlignRight, AlignRight, AlignRight, AlignRight}))
 		b.WriteByte('\n')
 	}
 }
@@ -291,7 +294,7 @@ func (r *Renderer) renderMixedBreakdowns(b *strings.Builder, summary *RunSummary
 		if configured := configuredDistributionText(summary.Workload.MixedDistribution); configured != "" {
 			fmt.Fprintf(b, "Configured distribution: %s\n", configured)
 		}
-		headers := []string{"Operation", "Configured", "Actual Ops", "Success", "Failure", "Data Moved", headerIOPSAvg, headerBandwidthAvg, headerLatencyP50}
+		headers := []string{"Operation", "Configured", "Actual Ops", "Success", "Failure", "Data Moved", headerIOPSAvg, headerBandwidthAvg, headerLatencyP50, headerTTFBP50}
 		rows := make([][]string, 0, len(step.OperationBreakdown))
 		for _, op := range step.OperationBreakdown {
 			rows = append(rows, []string{
@@ -304,9 +307,10 @@ func (r *Renderer) renderMixedBreakdowns(b *strings.Builder, summary *RunSummary
 				formatNumber(op.Metrics.ThroughputAvgOps, "ops/s"),
 				formatNumber(op.Metrics.BandwidthAvgMBps, "MB/s"),
 				formatNumber(op.Metrics.LatencyMedianMs, "ms"),
+				formatTTFBNumber(op.Metrics.TTFBMedianMs),
 			})
 		}
-		b.WriteString(renderUnicodeTable(headers, rows, []Alignment{AlignLeft, AlignRight, AlignRight, AlignRight, AlignRight, AlignRight, AlignRight, AlignRight, AlignRight}))
+		b.WriteString(renderUnicodeTable(headers, rows, []Alignment{AlignLeft, AlignRight, AlignRight, AlignRight, AlignRight, AlignRight, AlignRight, AlignRight, AlignRight, AlignRight}))
 		b.WriteString("\n\n")
 	}
 }
@@ -461,6 +465,20 @@ func mixedLatencyCell(step StepSummary, metrics *PhaseMetrics) string {
 		return "see ops"
 	}
 	return formatNumber(metrics.LatencyHeadlineMs, "ms")
+}
+
+func mixedTTFBCell(step StepSummary, metrics *PhaseMetrics) string {
+	if step.IsMixed {
+		return "see ops"
+	}
+	return formatTTFBNumber(metrics.TTFBMedianMs)
+}
+
+func formatTTFBNumber(value float64) string {
+	if value <= 0 {
+		return "—"
+	}
+	return formatNumber(value, "ms")
 }
 
 func configuredDistributionText(dist MixedDistribution) string {

--- a/cli/internal/results/summary/render_test.go
+++ b/cli/internal/results/summary/render_test.go
@@ -39,6 +39,7 @@ func TestRendererFullReportIncludesSections(t *testing.T) {
 					DataBytes:         2620391424,
 					ThroughputAvgOps:  334.6964,
 					LatencyHeadlineMs: 79.9,
+					TTFBMedianMs:      12.3,
 					BandwidthAvgMBps:  334.6964,
 					ObjectSizeHuman:   "1.00 MiB",
 				},
@@ -70,6 +71,8 @@ func TestRendererFullReportIncludesSections(t *testing.T) {
 	mustContain(t, report, "Run Totals")
 	mustContain(t, report, "Create")
 	mustContain(t, report, "Delete")
+	mustContain(t, report, "TTFB P50")
+	mustContain(t, report, "12.3 ms")
 
 	lines := strings.Split(report, "\n")
 	if len(lines) < 10 {

--- a/cli/tui/headless/runner.go
+++ b/cli/tui/headless/runner.go
@@ -582,9 +582,10 @@ func (r *HeadlessRunner) output(category, format string, args ...interface{}) {
 
 // outputMetrics outputs parsed metrics in human-readable format
 func (r *HeadlessRunner) outputMetrics(metric tui.PerformanceMetric) {
-	r.output("METRICS", "ops/sec=%d latency=%dµs type=%s success=%d concurrency=%.1f",
+	r.output("METRICS", "ops/sec=%d latency=%dµs ttfb=%dµs type=%s success=%d concurrency=%.1f",
 		metric.OpsPerSec,
 		metric.MeanLatency,
+		metric.MeanTTFB,
 		metric.OpType,
 		metric.SuccessCount,
 		metric.ConcurrencyMean,
@@ -594,10 +595,11 @@ func (r *HeadlessRunner) outputMetrics(metric tui.PerformanceMetric) {
 // outputMetricsJSON outputs parsed metrics in JSON format
 func (r *HeadlessRunner) outputMetricsJSON(metric tui.PerformanceMetric) {
 	timestamp := time.Now().Format("2006-01-02T15:04:05.000Z")
-	jsonLine := fmt.Sprintf(`{"timestamp":"%s","type":"metrics","data":{"ops_per_sec":%d,"latency_us":%d,"operation_type":"%s","success_count":%d,"failed_count":%d,"concurrency":%.1f}}`,
+	jsonLine := fmt.Sprintf(`{"timestamp":"%s","type":"metrics","data":{"ops_per_sec":%d,"latency_us":%d,"ttfb_us":%d,"operation_type":"%s","success_count":%d,"failed_count":%d,"concurrency":%.1f}}`,
 		timestamp,
 		metric.OpsPerSec,
 		metric.MeanLatency,
+		metric.MeanTTFB,
 		metric.OpType,
 		metric.SuccessCount,
 		metric.FailedCount,

--- a/cli/tui/headless/runner.go
+++ b/cli/tui/headless/runner.go
@@ -582,29 +582,39 @@ func (r *HeadlessRunner) output(category, format string, args ...interface{}) {
 
 // outputMetrics outputs parsed metrics in human-readable format
 func (r *HeadlessRunner) outputMetrics(metric tui.PerformanceMetric) {
-	r.output("METRICS", "ops/sec=%d latency=%dµs ttfb=%dµs type=%s success=%d concurrency=%.1f",
-		metric.OpsPerSec,
-		metric.MeanLatency,
-		metric.MeanTTFB,
-		metric.OpType,
-		metric.SuccessCount,
-		metric.ConcurrencyMean,
-	)
+	format := "ops/sec=%d latency=%dµs type=%s success=%d concurrency=%.1f"
+	args := []interface{}{metric.OpsPerSec, metric.MeanLatency, metric.OpType, metric.SuccessCount, metric.ConcurrencyMean}
+	if metric.HasTTFB {
+		format = "ops/sec=%d latency=%dµs ttfb=%dµs type=%s success=%d concurrency=%.1f"
+		args = []interface{}{metric.OpsPerSec, metric.MeanLatency, metric.MeanTTFB, metric.OpType, metric.SuccessCount, metric.ConcurrencyMean}
+	}
+	r.output("METRICS", format, args...)
 }
 
 // outputMetricsJSON outputs parsed metrics in JSON format
 func (r *HeadlessRunner) outputMetricsJSON(metric tui.PerformanceMetric) {
 	timestamp := time.Now().Format("2006-01-02T15:04:05.000Z")
-	jsonLine := fmt.Sprintf(`{"timestamp":"%s","type":"metrics","data":{"ops_per_sec":%d,"latency_us":%d,"ttfb_us":%d,"operation_type":"%s","success_count":%d,"failed_count":%d,"concurrency":%.1f}}`,
+	jsonLine := fmt.Sprintf(`{"timestamp":"%s","type":"metrics","data":{"ops_per_sec":%d,"latency_us":%d,"operation_type":"%s","success_count":%d,"failed_count":%d,"concurrency":%.1f}}`,
 		timestamp,
 		metric.OpsPerSec,
 		metric.MeanLatency,
-		metric.MeanTTFB,
 		metric.OpType,
 		metric.SuccessCount,
 		metric.FailedCount,
 		metric.ConcurrencyMean,
 	)
+	if metric.HasTTFB {
+		jsonLine = fmt.Sprintf(`{"timestamp":"%s","type":"metrics","data":{"ops_per_sec":%d,"latency_us":%d,"ttfb_us":%d,"operation_type":"%s","success_count":%d,"failed_count":%d,"concurrency":%.1f}}`,
+			timestamp,
+			metric.OpsPerSec,
+			metric.MeanLatency,
+			metric.MeanTTFB,
+			metric.OpType,
+			metric.SuccessCount,
+			metric.FailedCount,
+			metric.ConcurrencyMean,
+		)
+	}
 
 	fmt.Println(jsonLine)
 

--- a/cli/tui/headless/runner_test.go
+++ b/cli/tui/headless/runner_test.go
@@ -246,6 +246,92 @@ func TestHeadlessRunner_MetricsOutput(t *testing.T) {
 	runner.outputMetricsJSON(testMetric)
 }
 
+func TestHeadlessRunner_MetricsOutputOmitsUnavailableTTFB(t *testing.T) {
+	mockDocker := &tui.MockDockerManager{}
+	tmpDir := t.TempDir()
+	traceFile := filepath.Join(tmpDir, "metrics_trace.log")
+
+	runner, err := NewHeadlessRunner(mockDocker, HeadlessOptions{TraceFile: traceFile})
+	if err != nil {
+		t.Fatalf("Failed to create runner: %v", err)
+	}
+	defer runner.Close()
+
+	runner.outputMetrics(tui.PerformanceMetric{
+		OpsPerSec:       45,
+		MeanLatency:     1024,
+		OpType:          "CREATE",
+		SuccessCount:    100,
+		ConcurrencyMean: 8.0,
+	})
+
+	content, err := os.ReadFile(traceFile)
+	if err != nil {
+		t.Fatalf("Failed to read trace file: %v", err)
+	}
+	if strings.Contains(string(content), "ttfb=") {
+		t.Fatalf("headless metrics output must omit unavailable TTFB, got %q", string(content))
+	}
+}
+
+func TestHeadlessRunner_MetricsJSONOmitsUnavailableTTFB(t *testing.T) {
+	mockDocker := &tui.MockDockerManager{}
+	tmpDir := t.TempDir()
+	traceFile := filepath.Join(tmpDir, "json_trace.log")
+
+	runner, err := NewHeadlessRunner(mockDocker, HeadlessOptions{TraceFile: traceFile, JSONMode: true})
+	if err != nil {
+		t.Fatalf("Failed to create runner: %v", err)
+	}
+	defer runner.Close()
+
+	runner.outputMetricsJSON(tui.PerformanceMetric{
+		OpsPerSec:       45,
+		MeanLatency:     1024,
+		OpType:          "CREATE",
+		SuccessCount:    100,
+		ConcurrencyMean: 8.0,
+	})
+
+	content, err := os.ReadFile(traceFile)
+	if err != nil {
+		t.Fatalf("Failed to read trace file: %v", err)
+	}
+	if strings.Contains(string(content), "ttfb_us") {
+		t.Fatalf("headless JSON metrics output must omit unavailable TTFB, got %q", string(content))
+	}
+}
+
+func TestHeadlessRunner_MetricsOutputIncludesAvailableTTFB(t *testing.T) {
+	mockDocker := &tui.MockDockerManager{}
+	tmpDir := t.TempDir()
+	traceFile := filepath.Join(tmpDir, "metrics_trace.log")
+
+	runner, err := NewHeadlessRunner(mockDocker, HeadlessOptions{TraceFile: traceFile})
+	if err != nil {
+		t.Fatalf("Failed to create runner: %v", err)
+	}
+	defer runner.Close()
+
+	runner.outputMetrics(tui.PerformanceMetric{
+		OpsPerSec:       45,
+		MeanLatency:     1024,
+		MeanTTFB:        512,
+		HasTTFB:         true,
+		OpType:          "READ",
+		SuccessCount:    100,
+		ConcurrencyMean: 8.0,
+	})
+
+	content, err := os.ReadFile(traceFile)
+	if err != nil {
+		t.Fatalf("Failed to read trace file: %v", err)
+	}
+	if !strings.Contains(string(content), "ttfb=512µs") {
+		t.Fatalf("headless metrics output should include available TTFB, got %q", string(content))
+	}
+}
+
 func TestHeadlessRunner_MixedMetricsPerOpOutput(t *testing.T) {
 	mockDocker := &tui.MockDockerManager{}
 

--- a/cli/tui/json_metrics_test.go
+++ b/cli/tui/json_metrics_test.go
@@ -651,6 +651,7 @@ func TestJSONMetricsPerformanceMetricStructure(t *testing.T) {
 	step.Bandwidth.BytesRateLast = 104_857_600.0
 	step.Timing.LatencyMeanUs = 1850.0
 	step.Timing.DurationMeanUs = 2250.0
+	step.Timing.TTFB = &JSONTimingStat{Count: 10, MeanUs: 950.0}
 	step.Concurrency.Current = 12
 	step.Concurrency.Mean = 11.8
 	jsonData := marshalSteps(t, []JSONMetricsStep{step})
@@ -686,6 +687,7 @@ func TestJSONMetricsPerformanceMetricStructure(t *testing.T) {
 		"MBPerSec":                 int64(104), // Converted from 104857600.0 / 1_000_000
 		"MeanLatency":              int64(1850),
 		"MeanDuration":             int64(2250),
+		"MeanTTFB":                 int64(950),
 		"CompletionPercent":        float64(step.CompletionPercent),
 		"OverallCompletionPercent": float64(step.OverallCompletion),
 		"Unbounded":                false,
@@ -771,6 +773,10 @@ func TestJSONMetricsPerformanceMetricStructure(t *testing.T) {
 			if metricValue.MeanDuration != expectedValue.(int64) {
 				t.Errorf("Field %s: expected %v, got %v", fieldName, expectedValue, metricValue.MeanDuration)
 			}
+		case "MeanTTFB":
+			if metricValue.MeanTTFB != expectedValue.(int64) {
+				t.Errorf("Field %s: expected %v, got %v", fieldName, expectedValue, metricValue.MeanTTFB)
+			}
 		case "CompletionPercent":
 			if metricValue.CompletionPercent != expectedValue.(float64) {
 				t.Errorf("Field %s: expected %v, got %.1f", fieldName, expectedValue, metricValue.CompletionPercent)
@@ -822,6 +828,7 @@ func TestSchema3TimingPrefersLatencyP50(t *testing.T) {
 	step.Timing.DurationMeanUs = 20_000
 	step.Timing.Latency = &JSONTimingStat{Count: 3, MeanUs: 10_000, P50Us: 2_500}
 	step.Timing.Duration = &JSONTimingStat{Count: 3, MeanUs: 20_000, P50Us: 3_500}
+	step.Timing.TTFB = &JSONTimingStat{Count: 3, MeanUs: 4_000, P50Us: 750}
 
 	client := NewSptAPIClient("http://test")
 	metrics, err := client.ParseJSONMetrics(marshalSteps(t, []JSONMetricsStep{step}))
@@ -836,6 +843,9 @@ func TestSchema3TimingPrefersLatencyP50(t *testing.T) {
 	}
 	if metrics[0].MeanDuration != 3_500 {
 		t.Fatalf("expected schema-v3 duration display value to use p50, got %d", metrics[0].MeanDuration)
+	}
+	if metrics[0].MeanTTFB != 750 {
+		t.Fatalf("expected schema-v3 TTFB display value to use p50, got %d", metrics[0].MeanTTFB)
 	}
 }
 
@@ -901,28 +911,28 @@ func TestAggregateByOpType_FourOps(t *testing.T) {
 	metrics := []*PerformanceMetric{
 		{
 			OpType: "READ", OpsPerSec: 4000, MBPerSec: 4,
-			MeanLatency: 900, MeanDuration: 950,
+			MeanLatency: 900, MeanDuration: 950, MeanTTFB: 300,
 			SuccessCount: 240000, FailedCount: 2,
 			ConcurrencyCurrent: 5, ConcurrencyMean: 4.5,
 			StepID: "mixed-1", TestState: 2, StepTime: 60.0,
 		},
 		{
 			OpType: "CREATE", OpsPerSec: 20, MBPerSec: 1,
-			MeanLatency: 2500, MeanDuration: 2800,
+			MeanLatency: 2500, MeanDuration: 2800, MeanTTFB: 700,
 			SuccessCount: 1200, FailedCount: 0,
 			ConcurrencyCurrent: 1, ConcurrencyMean: 0.1,
 			StepID: "mixed-1", TestState: 2, StepTime: 60.0,
 		},
 		{
 			OpType: "DELETE", OpsPerSec: 18, MBPerSec: 0,
-			MeanLatency: 1300, MeanDuration: 1500,
+			MeanLatency: 1300, MeanDuration: 1500, MeanTTFB: 450,
 			SuccessCount: 1080, FailedCount: 0,
 			ConcurrencyCurrent: 1, ConcurrencyMean: 0.04,
 			StepID: "mixed-1", TestState: 2, StepTime: 60.0,
 		},
 		{
 			OpType: "STAT", OpsPerSec: 1400, MBPerSec: 0,
-			MeanLatency: 1500, MeanDuration: 1650,
+			MeanLatency: 1500, MeanDuration: 1650, MeanTTFB: 500,
 			SuccessCount: 84000, FailedCount: 5,
 			ConcurrencyCurrent: 2, ConcurrencyMean: 1.4,
 			StepID: "mixed-1", TestState: 2, StepTime: 60.0,
@@ -986,6 +996,9 @@ func TestAggregateByOpType_FourOps(t *testing.T) {
 	// Just verify it's between the min and max input latencies.
 	if combined.MeanLatency < 900 || combined.MeanLatency > 2500 {
 		t.Errorf("weighted MeanLatency %d outside expected range [900, 2500]", combined.MeanLatency)
+	}
+	if combined.MeanTTFB < 300 || combined.MeanTTFB > 700 {
+		t.Errorf("weighted MeanTTFB %d outside expected range [300, 700]", combined.MeanTTFB)
 	}
 }
 

--- a/cli/tui/json_metrics_test.go
+++ b/cli/tui/json_metrics_test.go
@@ -688,6 +688,7 @@ func TestJSONMetricsPerformanceMetricStructure(t *testing.T) {
 		"MeanLatency":              int64(1850),
 		"MeanDuration":             int64(2250),
 		"MeanTTFB":                 int64(950),
+		"HasTTFB":                  true,
 		"CompletionPercent":        float64(step.CompletionPercent),
 		"OverallCompletionPercent": float64(step.OverallCompletion),
 		"Unbounded":                false,
@@ -777,6 +778,10 @@ func TestJSONMetricsPerformanceMetricStructure(t *testing.T) {
 			if metricValue.MeanTTFB != expectedValue.(int64) {
 				t.Errorf("Field %s: expected %v, got %v", fieldName, expectedValue, metricValue.MeanTTFB)
 			}
+		case "HasTTFB":
+			if metricValue.HasTTFB != expectedValue.(bool) {
+				t.Errorf("Field %s: expected %v, got %v", fieldName, expectedValue, metricValue.HasTTFB)
+			}
 		case "CompletionPercent":
 			if metricValue.CompletionPercent != expectedValue.(float64) {
 				t.Errorf("Field %s: expected %v, got %.1f", fieldName, expectedValue, metricValue.CompletionPercent)
@@ -847,6 +852,51 @@ func TestSchema3TimingPrefersLatencyP50(t *testing.T) {
 	if metrics[0].MeanTTFB != 750 {
 		t.Fatalf("expected schema-v3 TTFB display value to use p50, got %d", metrics[0].MeanTTFB)
 	}
+	if !metrics[0].HasTTFB {
+		t.Fatal("expected schema-v3 TTFB sample to be marked available")
+	}
+}
+
+func TestParseJSONMetricsMarksMissingTTFBUnavailable(t *testing.T) {
+	step := newTestStep()
+	step.MetricsSchema = 3
+	step.Timing.TTFB = nil
+
+	client := NewSptAPIClient("http://test")
+	metrics, err := client.ParseJSONMetrics(marshalSteps(t, []JSONMetricsStep{step}))
+	if err != nil {
+		t.Fatalf("ParseJSONMetrics failed: %v", err)
+	}
+	if len(metrics) != 1 {
+		t.Fatalf("expected 1 metric, got %d", len(metrics))
+	}
+	if metrics[0].HasTTFB {
+		t.Fatal("expected missing TTFB sample to be marked unavailable")
+	}
+	if metrics[0].MeanTTFB != 0 {
+		t.Fatalf("expected unavailable TTFB value to remain zero internally, got %d", metrics[0].MeanTTFB)
+	}
+}
+
+func TestParseJSONMetricsMarksNullCountTTFBUnavailable(t *testing.T) {
+	step := newTestStep()
+	step.MetricsSchema = 3
+	step.Timing.TTFB = &JSONTimingStat{Count: 0, MeanUs: 950.0, P50Us: 900}
+
+	client := NewSptAPIClient("http://test")
+	metrics, err := client.ParseJSONMetrics(marshalSteps(t, []JSONMetricsStep{step}))
+	if err != nil {
+		t.Fatalf("ParseJSONMetrics failed: %v", err)
+	}
+	if len(metrics) != 1 {
+		t.Fatalf("expected 1 metric, got %d", len(metrics))
+	}
+	if metrics[0].HasTTFB {
+		t.Fatal("expected zero-count TTFB sample to be marked unavailable")
+	}
+	if metrics[0].MeanTTFB != 0 {
+		t.Fatalf("expected zero-count TTFB value to remain zero internally, got %d", metrics[0].MeanTTFB)
+	}
 }
 
 func TestParseJSONMetricsPrefersLatestSample(t *testing.T) {
@@ -911,7 +961,7 @@ func TestAggregateByOpType_FourOps(t *testing.T) {
 	metrics := []*PerformanceMetric{
 		{
 			OpType: "READ", OpsPerSec: 4000, MBPerSec: 4,
-			MeanLatency: 900, MeanDuration: 950, MeanTTFB: 300,
+			MeanLatency: 900, MeanDuration: 950, MeanTTFB: 300, HasTTFB: true,
 			SuccessCount: 240000, FailedCount: 2,
 			ConcurrencyCurrent: 5, ConcurrencyMean: 4.5,
 			StepID: "mixed-1", TestState: 2, StepTime: 60.0,
@@ -997,8 +1047,29 @@ func TestAggregateByOpType_FourOps(t *testing.T) {
 	if combined.MeanLatency < 900 || combined.MeanLatency > 2500 {
 		t.Errorf("weighted MeanLatency %d outside expected range [900, 2500]", combined.MeanLatency)
 	}
-	if combined.MeanTTFB < 300 || combined.MeanTTFB > 700 {
-		t.Errorf("weighted MeanTTFB %d outside expected range [300, 700]", combined.MeanTTFB)
+	if combined.HasTTFB {
+		t.Error("mixed READ/CREATE/DELETE/STAT aggregate must not publish a blended TTFB")
+	}
+	if combined.MeanTTFB != 0 {
+		t.Errorf("mixed aggregate TTFB should remain unset internally, got %d", combined.MeanTTFB)
+	}
+}
+
+func TestAggregateByOpTypeAggregatesSameOpTTFB(t *testing.T) {
+	metrics := []*PerformanceMetric{
+		{OpType: "READ", OpsPerSec: 100, MeanLatency: 1000, MeanDuration: 1200, MeanTTFB: 200, HasTTFB: true},
+		{OpType: "READ", OpsPerSec: 300, MeanLatency: 2000, MeanDuration: 2200, MeanTTFB: 400, HasTTFB: true},
+	}
+
+	combined, _ := AggregateByOpType(metrics)
+	if combined == nil {
+		t.Fatal("combined aggregate must not be nil")
+	}
+	if !combined.HasTTFB {
+		t.Fatal("expected same-op READ aggregate TTFB to be available")
+	}
+	if combined.MeanTTFB != 350 {
+		t.Fatalf("expected ops-weighted TTFB 350, got %d", combined.MeanTTFB)
 	}
 }
 

--- a/cli/tui/metrics.go
+++ b/cli/tui/metrics.go
@@ -33,7 +33,8 @@ type PerformanceMetric struct {
 	OpsPerSec          int64   // Last Rate [op/s] - primary chart metric
 	MBPerSec           int64   // Last Rate [MB/s] - secondary chart metric
 	MeanLatency        int64   // Display latency [us]; schema 3 prefers p50 with mean fallback
-	MeanDuration       int64   // Mean Duration [us]
+	MeanDuration       int64   // Display duration [us]; schema 3 prefers p50 with mean fallback
+	MeanTTFB           int64   // Display TTFB [us]; schema 3 prefers p50 with mean fallback
 	FailureIncrement   int64   // Incremental failures since last sample
 
 	MetricsSchema int

--- a/cli/tui/metrics.go
+++ b/cli/tui/metrics.go
@@ -34,7 +34,8 @@ type PerformanceMetric struct {
 	MBPerSec           int64   // Last Rate [MB/s] - secondary chart metric
 	MeanLatency        int64   // Display latency [us]; schema 3 prefers p50 with mean fallback
 	MeanDuration       int64   // Display duration [us]; schema 3 prefers p50 with mean fallback
-	MeanTTFB           int64   // Display TTFB [us]; schema 3 prefers p50 with mean fallback
+	MeanTTFB           int64   // Display TTFB [us]
+	HasTTFB            bool    // Whether TTFB was present in the metrics sample
 	FailureIncrement   int64   // Incremental failures since last sample
 
 	MetricsSchema int

--- a/cli/tui/metrics_aggregator.go
+++ b/cli/tui/metrics_aggregator.go
@@ -92,6 +92,10 @@ func (ma *MetricsAggregator) sumWorkerMetrics(nodeMetrics map[string]*Performanc
 		totalLatencyWeight   int64
 		totalDurationWeight  int64
 		totalTTFBWeight      int64
+		metricCount          int
+		ttfbMetricCount      int
+		firstTTFBOpType      string
+		allSameTTFBOpType    = true
 		completionSum        float64
 		completionWeight     float64
 		overallCompletionSum float64
@@ -112,6 +116,12 @@ func (ma *MetricsAggregator) sumWorkerMetrics(nodeMetrics map[string]*Performanc
 			continue
 		}
 
+		metricCount++
+		if firstTTFBOpType == "" {
+			firstTTFBOpType = metric.OpType
+		} else if !strings.EqualFold(firstTTFBOpType, metric.OpType) {
+			allSameTTFBOpType = false
+		}
 		result.OpsPerSec += metric.OpsPerSec
 		result.MBPerSec += metric.MBPerSec
 		result.SuccessCount += metric.SuccessCount
@@ -125,10 +135,13 @@ func (ma *MetricsAggregator) sumWorkerMetrics(nodeMetrics map[string]*Performanc
 		}
 		result.MeanLatency += metric.MeanLatency * opsWeight
 		result.MeanDuration += metric.MeanDuration * opsWeight
-		result.MeanTTFB += metric.MeanTTFB * opsWeight
 		totalLatencyWeight += opsWeight
 		totalDurationWeight += opsWeight
-		totalTTFBWeight += opsWeight
+		if metric.HasTTFB {
+			result.MeanTTFB += metric.MeanTTFB * opsWeight
+			totalTTFBWeight += opsWeight
+			ttfbMetricCount++
+		}
 
 		if !metric.Unbounded {
 			allUnbounded = false
@@ -186,8 +199,12 @@ func (ma *MetricsAggregator) sumWorkerMetrics(nodeMetrics map[string]*Performanc
 		result.MeanLatency /= totalLatencyWeight
 		result.MeanDuration /= totalDurationWeight
 	}
-	if totalTTFBWeight > 0 {
+	if totalTTFBWeight > 0 && ttfbMetricCount == metricCount && allSameTTFBOpType && isTTFBEligibleOpType(firstTTFBOpType) {
 		result.MeanTTFB /= totalTTFBWeight
+		result.HasTTFB = true
+	} else {
+		result.MeanTTFB = 0
+		result.HasTTFB = false
 	}
 
 	if completionWeight > 0 {
@@ -288,11 +305,16 @@ func clampPercentage(v float64) float64 {
 	return v
 }
 
+func isTTFBEligibleOpType(opType string) bool {
+	return strings.EqualFold(opType, "READ") || strings.EqualFold(opType, "LIST")
+}
+
 // AggregateByOpType groups a slice of metrics by OpType and produces a combined
 // aggregate plus a per-op-type map. For non-mixed workloads (single metric) the
 // aggregate is the metric itself and the map has one entry. For mixed workloads
 // the aggregate sums additive fields (ops/s, MB/s, counts) across op types and
-// uses ops-weighted averages for latency/duration/TTFB.
+// uses ops-weighted averages for latency/duration. Combined TTFB is populated only
+// when every contributor has TTFB for the same READ or LIST operation type.
 func AggregateByOpType(metrics []*PerformanceMetric) (combined *PerformanceMetric, perOp map[string]*PerformanceMetric) {
 	if len(metrics) == 0 {
 		return nil, nil
@@ -310,7 +332,9 @@ func AggregateByOpType(metrics []*PerformanceMetric) (combined *PerformanceMetri
 	// Build combined aggregate by summing additive fields.
 	var agg PerformanceMetric
 	var totalLatencyWeight, totalDurationWeight, totalTTFBWeight int64
+	var ttfbMetricCount int
 	first := metrics[0]
+	allSameTTFBOpType := true
 
 	// Copy identity fields from the first (latest) metric.
 	agg.StepID = first.StepID
@@ -329,6 +353,9 @@ func AggregateByOpType(metrics []*PerformanceMetric) (combined *PerformanceMetri
 	agg.SptTimestamp = first.SptTimestamp
 
 	for _, m := range metrics {
+		if !strings.EqualFold(first.OpType, m.OpType) {
+			allSameTTFBOpType = false
+		}
 		agg.OpsPerSec += m.OpsPerSec
 		agg.MBPerSec += m.MBPerSec
 		agg.SuccessCount += m.SuccessCount
@@ -342,10 +369,13 @@ func AggregateByOpType(metrics []*PerformanceMetric) (combined *PerformanceMetri
 		}
 		agg.MeanLatency += m.MeanLatency * w
 		agg.MeanDuration += m.MeanDuration * w
-		agg.MeanTTFB += m.MeanTTFB * w
 		totalLatencyWeight += w
 		totalDurationWeight += w
-		totalTTFBWeight += w
+		if m.HasTTFB {
+			agg.MeanTTFB += m.MeanTTFB * w
+			totalTTFBWeight += w
+			ttfbMetricCount++
+		}
 
 		if m.TestState > agg.TestState {
 			agg.TestState = m.TestState
@@ -364,8 +394,12 @@ func AggregateByOpType(metrics []*PerformanceMetric) (combined *PerformanceMetri
 		agg.MeanLatency /= totalLatencyWeight
 		agg.MeanDuration /= totalDurationWeight
 	}
-	if totalTTFBWeight > 0 {
+	if totalTTFBWeight > 0 && ttfbMetricCount == len(metrics) && allSameTTFBOpType && isTTFBEligibleOpType(first.OpType) {
 		agg.MeanTTFB /= totalTTFBWeight
+		agg.HasTTFB = true
+	} else {
+		agg.MeanTTFB = 0
+		agg.HasTTFB = false
 	}
 
 	// Completion: use the first metric's values (all ops in a mixed step

--- a/cli/tui/metrics_aggregator.go
+++ b/cli/tui/metrics_aggregator.go
@@ -91,6 +91,7 @@ func (ma *MetricsAggregator) sumWorkerMetrics(nodeMetrics map[string]*Performanc
 	var (
 		totalLatencyWeight   int64
 		totalDurationWeight  int64
+		totalTTFBWeight      int64
 		completionSum        float64
 		completionWeight     float64
 		overallCompletionSum float64
@@ -124,8 +125,10 @@ func (ma *MetricsAggregator) sumWorkerMetrics(nodeMetrics map[string]*Performanc
 		}
 		result.MeanLatency += metric.MeanLatency * opsWeight
 		result.MeanDuration += metric.MeanDuration * opsWeight
+		result.MeanTTFB += metric.MeanTTFB * opsWeight
 		totalLatencyWeight += opsWeight
 		totalDurationWeight += opsWeight
+		totalTTFBWeight += opsWeight
 
 		if !metric.Unbounded {
 			allUnbounded = false
@@ -182,6 +185,9 @@ func (ma *MetricsAggregator) sumWorkerMetrics(nodeMetrics map[string]*Performanc
 	if totalLatencyWeight > 0 {
 		result.MeanLatency /= totalLatencyWeight
 		result.MeanDuration /= totalDurationWeight
+	}
+	if totalTTFBWeight > 0 {
+		result.MeanTTFB /= totalTTFBWeight
 	}
 
 	if completionWeight > 0 {
@@ -286,7 +292,7 @@ func clampPercentage(v float64) float64 {
 // aggregate plus a per-op-type map. For non-mixed workloads (single metric) the
 // aggregate is the metric itself and the map has one entry. For mixed workloads
 // the aggregate sums additive fields (ops/s, MB/s, counts) across op types and
-// uses ops-weighted averages for latency/duration.
+// uses ops-weighted averages for latency/duration/TTFB.
 func AggregateByOpType(metrics []*PerformanceMetric) (combined *PerformanceMetric, perOp map[string]*PerformanceMetric) {
 	if len(metrics) == 0 {
 		return nil, nil
@@ -303,7 +309,7 @@ func AggregateByOpType(metrics []*PerformanceMetric) (combined *PerformanceMetri
 
 	// Build combined aggregate by summing additive fields.
 	var agg PerformanceMetric
-	var totalLatencyWeight, totalDurationWeight int64
+	var totalLatencyWeight, totalDurationWeight, totalTTFBWeight int64
 	first := metrics[0]
 
 	// Copy identity fields from the first (latest) metric.
@@ -336,8 +342,10 @@ func AggregateByOpType(metrics []*PerformanceMetric) (combined *PerformanceMetri
 		}
 		agg.MeanLatency += m.MeanLatency * w
 		agg.MeanDuration += m.MeanDuration * w
+		agg.MeanTTFB += m.MeanTTFB * w
 		totalLatencyWeight += w
 		totalDurationWeight += w
+		totalTTFBWeight += w
 
 		if m.TestState > agg.TestState {
 			agg.TestState = m.TestState
@@ -355,6 +363,9 @@ func AggregateByOpType(metrics []*PerformanceMetric) (combined *PerformanceMetri
 	if totalLatencyWeight > 0 {
 		agg.MeanLatency /= totalLatencyWeight
 		agg.MeanDuration /= totalDurationWeight
+	}
+	if totalTTFBWeight > 0 {
+		agg.MeanTTFB /= totalTTFBWeight
 	}
 
 	// Completion: use the first metric's values (all ops in a mixed step

--- a/cli/tui/metrics_aggregator_test.go
+++ b/cli/tui/metrics_aggregator_test.go
@@ -95,9 +95,13 @@ func TestMetricsAggregatorAggregatesMultipleNodes(t *testing.T) {
 func TestMetricsAggregatorAggregatesTTFB(t *testing.T) {
 	aggregator := NewMetricsAggregator()
 	node1 := newNodeMetric(1000, 100, 500, 5, 50, 70, 10, 8)
+	node1.OpType = "READ"
 	node1.MeanTTFB = 20
+	node1.HasTTFB = true
 	node2 := newNodeMetric(1500, 150, 900, 2, 40, 60, 12, 9)
+	node2.OpType = "READ"
 	node2.MeanTTFB = 30
+	node2.HasTTFB = true
 
 	aggregated := aggregator.Aggregate(map[string]*PerformanceMetric{"node1": node1, "node2": node2})
 	if aggregated == nil {
@@ -105,6 +109,30 @@ func TestMetricsAggregatorAggregatesTTFB(t *testing.T) {
 	}
 	if aggregated.MeanTTFB != 26 {
 		t.Errorf("expected weighted TTFB 26, got %d", aggregated.MeanTTFB)
+	}
+	if !aggregated.HasTTFB {
+		t.Error("expected aggregated TTFB to be marked available")
+	}
+}
+
+func TestMetricsAggregatorDoesNotAggregatePartialTTFB(t *testing.T) {
+	aggregator := NewMetricsAggregator()
+	node1 := newNodeMetric(1000, 100, 500, 5, 50, 70, 10, 8)
+	node1.OpType = "READ"
+	node1.MeanTTFB = 20
+	node1.HasTTFB = true
+	node2 := newNodeMetric(1500, 150, 900, 2, 40, 60, 12, 9)
+	node2.OpType = "CREATE"
+
+	aggregated := aggregator.Aggregate(map[string]*PerformanceMetric{"node1": node1, "node2": node2})
+	if aggregated == nil {
+		t.Fatal("expected aggregated metric")
+	}
+	if aggregated.HasTTFB {
+		t.Error("expected mixed READ/CREATE aggregate TTFB to be unavailable")
+	}
+	if aggregated.MeanTTFB != 0 {
+		t.Errorf("expected unavailable aggregate TTFB value 0, got %d", aggregated.MeanTTFB)
 	}
 }
 

--- a/cli/tui/metrics_aggregator_test.go
+++ b/cli/tui/metrics_aggregator_test.go
@@ -92,6 +92,22 @@ func TestMetricsAggregatorAggregatesMultipleNodes(t *testing.T) {
 	}
 }
 
+func TestMetricsAggregatorAggregatesTTFB(t *testing.T) {
+	aggregator := NewMetricsAggregator()
+	node1 := newNodeMetric(1000, 100, 500, 5, 50, 70, 10, 8)
+	node1.MeanTTFB = 20
+	node2 := newNodeMetric(1500, 150, 900, 2, 40, 60, 12, 9)
+	node2.MeanTTFB = 30
+
+	aggregated := aggregator.Aggregate(map[string]*PerformanceMetric{"node1": node1, "node2": node2})
+	if aggregated == nil {
+		t.Fatal("expected aggregated metric")
+	}
+	if aggregated.MeanTTFB != 26 {
+		t.Errorf("expected weighted TTFB 26, got %d", aggregated.MeanTTFB)
+	}
+}
+
 func TestMetricsAggregatorOpCountCompletion(t *testing.T) {
 	aggregator := NewMetricsAggregator()
 	node1 := newNodeMetric(100, 0, 1000, 0, 0, 0, 0, 0)

--- a/cli/tui/spt_api.go
+++ b/cli/tui/spt_api.go
@@ -550,7 +550,11 @@ func (c *SptAPIClient) ParseJSONMetrics(data string) ([]*PerformanceMetric, erro
 func stepToMetric(step *JSONMetricsStep, scope string, sampleTimestamp time.Time) *PerformanceMetric {
 	latencyUs := displayTimingUs(step.MetricsSchema, step.Timing.LatencyMeanUs, step.Timing.Latency)
 	durationUs := displayTimingUs(step.MetricsSchema, step.Timing.DurationMeanUs, step.Timing.Duration)
-	ttfbUs := displayStatTimingUs(step.Timing.TTFB)
+	hasTTFB := step.Timing.TTFB != nil && step.Timing.TTFB.Count > 0
+	ttfbUs := float64(0)
+	if hasTTFB {
+		ttfbUs = displayStatTimingUs(step.Timing.TTFB)
+	}
 	metric := &PerformanceMetric{
 		Timestamp:                time.UnixMilli(step.Timestamp),
 		SampleTimestamp:          sampleTimestamp,
@@ -568,6 +572,7 @@ func stepToMetric(step *JSONMetricsStep, scope string, sampleTimestamp time.Time
 		MeanLatency:              int64(math.Round(latencyUs)),                    // Schema 3 prefers p50.
 		MeanDuration:             int64(math.Round(durationUs)),
 		MeanTTFB:                 int64(math.Round(ttfbUs)),
+		HasTTFB:                  hasTTFB,
 		CompletionPercent:        float64(step.CompletionPercent),
 		OverallCompletionPercent: float64(step.OverallCompletion),
 		Unbounded:                step.Unbounded,
@@ -594,10 +599,8 @@ func stepToMetric(step *JSONMetricsStep, scope string, sampleTimestamp time.Time
 }
 
 func displayTimingUs(schema int, legacyMeanUs float64, stat *JSONTimingStat) float64 {
-	if schema >= 3 {
-		if statUs := displayStatTimingUs(stat); statUs > 0 {
-			return statUs
-		}
+	if schema >= 3 && stat != nil && stat.P50Us > 0 {
+		return float64(stat.P50Us)
 	}
 	return legacyMeanUs
 }

--- a/cli/tui/spt_api.go
+++ b/cli/tui/spt_api.go
@@ -548,14 +548,9 @@ func (c *SptAPIClient) ParseJSONMetrics(data string) ([]*PerformanceMetric, erro
 
 // stepToMetric converts a validated JSONMetricsStep into a PerformanceMetric.
 func stepToMetric(step *JSONMetricsStep, scope string, sampleTimestamp time.Time) *PerformanceMetric {
-	latencyUs := step.Timing.LatencyMeanUs
-	if step.MetricsSchema >= 3 && step.Timing.Latency != nil && step.Timing.Latency.P50Us > 0 {
-		latencyUs = float64(step.Timing.Latency.P50Us)
-	}
-	durationUs := step.Timing.DurationMeanUs
-	if step.MetricsSchema >= 3 && step.Timing.Duration != nil && step.Timing.Duration.P50Us > 0 {
-		durationUs = float64(step.Timing.Duration.P50Us)
-	}
+	latencyUs := displayTimingUs(step.MetricsSchema, step.Timing.LatencyMeanUs, step.Timing.Latency)
+	durationUs := displayTimingUs(step.MetricsSchema, step.Timing.DurationMeanUs, step.Timing.Duration)
+	ttfbUs := displayStatTimingUs(step.Timing.TTFB)
 	metric := &PerformanceMetric{
 		Timestamp:                time.UnixMilli(step.Timestamp),
 		SampleTimestamp:          sampleTimestamp,
@@ -572,6 +567,7 @@ func stepToMetric(step *JSONMetricsStep, scope string, sampleTimestamp time.Time
 		MBPerSec:                 int64(step.Bandwidth.BytesRateLast / 1_000_000), // Convert bytes to MB
 		MeanLatency:              int64(math.Round(latencyUs)),                    // Schema 3 prefers p50.
 		MeanDuration:             int64(math.Round(durationUs)),
+		MeanTTFB:                 int64(math.Round(ttfbUs)),
 		CompletionPercent:        float64(step.CompletionPercent),
 		OverallCompletionPercent: float64(step.OverallCompletion),
 		Unbounded:                step.Unbounded,
@@ -595,6 +591,28 @@ func stepToMetric(step *JSONMetricsStep, scope string, sampleTimestamp time.Time
 	}
 
 	return metric
+}
+
+func displayTimingUs(schema int, legacyMeanUs float64, stat *JSONTimingStat) float64 {
+	if schema >= 3 {
+		if statUs := displayStatTimingUs(stat); statUs > 0 {
+			return statUs
+		}
+	}
+	return legacyMeanUs
+}
+
+func displayStatTimingUs(stat *JSONTimingStat) float64 {
+	if stat == nil {
+		return 0
+	}
+	if stat.P50Us > 0 {
+		return float64(stat.P50Us)
+	}
+	if stat.MeanUs > 0 {
+		return stat.MeanUs
+	}
+	return 0
 }
 
 func parseSampleTimestamp(raw string) (time.Time, error) {

--- a/engine/core/spt-base/doc/usage/output/README.md
+++ b/engine/core/spt-base/doc/usage/output/README.md
@@ -249,6 +249,12 @@ LatencyLoQ[us]  | Low quartile of the operations latency distribution
 LatencyMed[us]  | Median of the operations latency distribution
 LatencyHiQ[us]  | High quartile of the operations latency distribution
 LatencyMax[us]  | Maximum operation latency
+TtfbAvg[us]     | Total average Time to First Byte for operations with response body samples
+TtfbMin[us]     | Minimum Time to First Byte
+TtfbQ_*[us]     | Configured Time to First Byte quantiles, emitted with the configured quantile value in the field name
+TtfbMax[us]     | Maximum Time to First Byte
+
+Time to First Byte is populated for body-returning operations when first response body bytes are observed, currently READ and LIST. Non-body operations and empty/no-body samples do not contribute TTFB values.
 
 Again, spt only uses 2^10 (1024) multiplier. So 1MB is 1_048_576 bytes.
 
@@ -297,11 +303,14 @@ Console summary metrics output has YAML format for the better readability:
     Med:                       115
     HiQ:                       2683
     Max:                       216495
+  Time To First Byte [us]:
+    N/A
 ```
 
 * The console summary is displayed only on the entry node. It's not displayed on the additional nodes in the distributed mode.
 * The equation (CONFIGURED_CURRENCY_LEVEL * DRIVER_COUNT * ELAPSED_TIME / OPERATIONS_DURATION_SUM) may be used as efficiency estimate.
 * *Mean* rates are calculated as current total count of items/bytes divided by current elapsed time.
+* `Time To First Byte [us]` is reported when the load step has TTFB samples; otherwise it is shown as `N/A`.
 * *Last* rates are calculated as [exponentially decaying moving average](https://en.wikipedia.org/wiki/Moving_average#Exponential_moving_average) where
 
   ![alpha](http://i.piccy.info/i9/c211a78abdaeec65da61020c5dc83008/1485332899/627/722110/CodeCogsEqn.png)

--- a/engine/core/spt-base/src/test/java/com/dell/spt/base/load/step/local/context/LoadStepContextImplTest.java
+++ b/engine/core/spt-base/src/test/java/com/dell/spt/base/load/step/local/context/LoadStepContextImplTest.java
@@ -269,22 +269,22 @@ public class LoadStepContextImplTest {
 						testConfig.configVal("load"),
 						false);
 
-		final ListOperation<PathItemImpl> listOp = new ListOperationImpl<>(0, OpType.LIST, new PathItemImpl("prefix"), null);
-		listOp.reset();
-		listOp.startRequest();
-		listOp.finishRequest();
-		listOp.startResponse();
-		listOp.startDataResponse();
-		listOp.finishResponse();
-		listOp.status(Operation.Status.SUCC);
-		listOp.objectsListed(3);
-		listOp.bytesListed(123);
-		listOp.countBytesDone(123);
+		@SuppressWarnings("unchecked")
+		final ListOperation<PathItemImpl> listOp = mock(ListOperation.class);
+		when(listOp.status()).thenReturn(Operation.Status.SUCC);
+		when(listOp.type()).thenReturn(OpType.LIST);
+		when(listOp.duration()).thenReturn(200L);
+		when(listOp.latency()).thenReturn(25L);
+		when(listOp.reqTimeDone()).thenReturn(1_000L);
+		when(listOp.respDataTimeStart()).thenReturn(1_123L);
+		when(listOp.objectsListed()).thenReturn(3);
+		when(listOp.bytesListed()).thenReturn(123L);
+		when(listOp.options()).thenReturn(ListOptions.DEFAULT);
 
 		assertTrue(stepCtx.put((Operation) listOp));
 		assertEquals(3L, trackingCtx.successCount.get());
 		assertEquals(123L, trackingCtx.byteCount.get());
-		assertTrue(trackingCtx.arrayTtfb.get() > 0L);
+		assertEquals(123L, trackingCtx.arrayTtfb.get());
 	}
 
 	@Test

--- a/engine/core/spt-base/src/test/java/com/dell/spt/base/load/step/local/context/LoadStepContextImplTest.java
+++ b/engine/core/spt-base/src/test/java/com/dell/spt/base/load/step/local/context/LoadStepContextImplTest.java
@@ -258,6 +258,36 @@ public class LoadStepContextImplTest {
 	}
 
 	@Test
+	public void markListSuccessRecordsTimeToFirstByte() throws Exception {
+		testConfig.val("load-op-recycle-mode", false);
+		final MetricsContext<AllMetricsSnapshot> metrics = buildMetricsCtx("listTtfb");
+		final TrackingMetricsContext trackingCtx = new TrackingMetricsContext(metrics);
+		final LoadStepContextImpl<Item, Operation<Item>> stepCtx = new LoadStepContextImpl<>(
+						"step-list-ttfb", (LoadGenerator<Item, Operation<Item>>) generator,
+						(DummyStorageDriverMock<Item, Operation<Item>>) (DummyStorageDriverMock) mockDriver,
+						trackingCtx,
+						testConfig.configVal("load"),
+						false);
+
+		final ListOperation<PathItemImpl> listOp = new ListOperationImpl<>(0, OpType.LIST, new PathItemImpl("prefix"), null);
+		listOp.reset();
+		listOp.startRequest();
+		listOp.finishRequest();
+		listOp.startResponse();
+		listOp.startDataResponse();
+		listOp.finishResponse();
+		listOp.status(Operation.Status.SUCC);
+		listOp.objectsListed(3);
+		listOp.bytesListed(123);
+		listOp.countBytesDone(123);
+
+		assertTrue(stepCtx.put((Operation) listOp));
+		assertEquals(3L, trackingCtx.successCount.get());
+		assertEquals(123L, trackingCtx.byteCount.get());
+		assertTrue(trackingCtx.arrayTtfb.get() > 0L);
+	}
+
+	@Test
 	void readTtfbEqualToDurationIsRecorded() throws Exception {
 		testConfig.val("load-op-recycle-mode", false);
 		final TrackingMetricsContext trackingCtx = new TrackingMetricsContext(buildMetricsCtx("read-ttfb-equal"));
@@ -442,6 +472,7 @@ public class LoadStepContextImplTest {
 		final AtomicLong successCount = new AtomicLong();
 		final AtomicLong byteCount = new AtomicLong();
 		final AtomicLong singleTtfb = new AtomicLong();
+		final AtomicLong arrayTtfb = new AtomicLong();
 
 		TrackingMetricsContext(final MetricsContext<AllMetricsSnapshot> delegate) {
 			this.delegate = delegate;
@@ -514,6 +545,9 @@ public class LoadStepContextImplTest {
 						final long[] ttfbValues) {
 			successCount.addAndGet(count);
 			byteCount.addAndGet(bytes);
+			if (ttfbValues != null && ttfbValues.length > 0) {
+				arrayTtfb.set(ttfbValues[0]);
+			}
 			delegate.markSucc(count, bytes, durationValues, latencyValues, ttfbValues);
 		}
 

--- a/engine/extensions/storage-drivers/implementations/s3-aws/README.md
+++ b/engine/extensions/storage-drivers/implementations/s3-aws/README.md
@@ -61,7 +61,7 @@ The driver uses `S3AsyncClient` with CompletableFuture for all S3 operations:
 - `putObject()` - Uses `AsyncRequestBody` for uploads
 - `readObject()` - Uses `AsyncResponseTransformer.toBytes()` for downloads
 - `deleteObject()` - Async delete operation
-- `listObjects()` - Async list operation with pagination
+- `listObjects()` - Async list operation with pagination and first response body byte timing for LIST TTFB metrics
 
 ### Blocking Compatibility
 

--- a/engine/extensions/storage-drivers/implementations/s3-aws/src/main/java/com/dell/spt/storage/driver/coop/aws/s3/S3AwsStorageDriver.java
+++ b/engine/extensions/storage-drivers/implementations/s3-aws/src/main/java/com/dell/spt/storage/driver/coop/aws/s3/S3AwsStorageDriver.java
@@ -66,6 +66,7 @@ public class S3AwsStorageDriver<I extends Item, O extends Operation<I>> extends 
 
 	private static final Logger LOG = LoggerFactory.getLogger(S3AwsStorageDriver.class);
 	static final ExecutionAttribute<ListOperation<? extends PathItem>> LIST_TTFB_OPERATION_ATTRIBUTE = new ExecutionAttribute<>("sptListTtfbOperation");
+	private static final ExecutionInterceptor LIST_TTFB_INTERCEPTOR = new ListTtfbExecutionInterceptor();
 	private static final SdkPlugin LIST_TTFB_SDK_PLUGIN = new ListTtfbSdkPlugin();
 
 	// S3 API constants for multipart upload
@@ -897,7 +898,7 @@ public class S3AwsStorageDriver<I extends Item, O extends Operation<I>> extends 
 	static final class ListTtfbSdkPlugin implements SdkPlugin {
 		@Override
 		public void configureClient(final SdkServiceClientConfiguration.Builder builder) {
-			builder.overrideConfiguration(b -> b.addExecutionInterceptor(new ListTtfbExecutionInterceptor()));
+			builder.overrideConfiguration(b -> b.addExecutionInterceptor(LIST_TTFB_INTERCEPTOR));
 		}
 	}
 

--- a/engine/extensions/storage-drivers/implementations/s3-aws/src/main/java/com/dell/spt/storage/driver/coop/aws/s3/S3AwsStorageDriver.java
+++ b/engine/extensions/storage-drivers/implementations/s3-aws/src/main/java/com/dell/spt/storage/driver/coop/aws/s3/S3AwsStorageDriver.java
@@ -27,16 +27,27 @@ import java.nio.ByteBuffer;
 import java.nio.file.Path;
 import java.io.IOException;
 import java.util.Locale;
+import java.util.Optional;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
 
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
 import software.amazon.awssdk.core.exception.ApiCallAttemptTimeoutException;
 import software.amazon.awssdk.core.exception.ApiCallTimeoutException;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.core.async.AsyncRequestBody;
 import software.amazon.awssdk.core.async.AsyncResponseTransformer;
+import software.amazon.awssdk.core.SdkPlugin;
+import software.amazon.awssdk.core.SdkServiceClientConfiguration;
+import software.amazon.awssdk.core.interceptor.Context;
+import software.amazon.awssdk.core.interceptor.ExecutionAttribute;
+import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
+import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.model.*;
 import software.amazon.awssdk.services.s3.model.ChecksumAlgorithm;
@@ -54,6 +65,8 @@ public class S3AwsStorageDriver<I extends Item, O extends Operation<I>> extends 
 				implements ListDiscoveryProbe {
 
 	private static final Logger LOG = LoggerFactory.getLogger(S3AwsStorageDriver.class);
+	static final ExecutionAttribute<ListOperation<? extends PathItem>> LIST_TTFB_OPERATION_ATTRIBUTE =
+					new ExecutionAttribute<>("sptListTtfbOperation");
 
 	// S3 API constants for multipart upload
 	private static final String KEY_UPLOAD_ID = "uploadId";
@@ -752,7 +765,10 @@ public class S3AwsStorageDriver<I extends Item, O extends Operation<I>> extends 
 
 		ListObjectsV2Request.Builder reqBuilder = ListObjectsV2Request.builder()
 						.bucket(targetBucket)
-						.maxKeys(maxKeys);
+						.maxKeys(maxKeys)
+						.overrideConfiguration(b -> b
+										.putExecutionAttribute(LIST_TTFB_OPERATION_ATTRIBUTE, listOp)
+										.addPlugin(new ListTtfbSdkPlugin()));
 
 		// Prefix from the item name (the framework sets item name as the listing prefix)
 		final var prefix = op.item().name();
@@ -780,7 +796,6 @@ public class S3AwsStorageDriver<I extends Item, O extends Operation<I>> extends 
 
 		return s3AsyncClient.listObjectsV2(reqBuilder.build())
 						.thenAccept(resp -> {
-							markListDataResponseStart(listOp);
 							int objectCount = 0;
 							long bytesTotal = 0;
 							String firstKey = null;
@@ -820,13 +835,66 @@ public class S3AwsStorageDriver<I extends Item, O extends Operation<I>> extends 
 						});
 	}
 
-	private void markListDataResponseStart(final ListOperation<? extends PathItem> op) {
+	private static void markListDataResponseStart(final ListOperation<? extends PathItem> op) {
 		if (op.respDataTimeStart() == 0) {
 			try {
 				op.startDataResponse();
 			} catch (final IllegalStateException e) {
 				LOG.debug("{}: failed to mark LIST data response start", op, e);
 			}
+		}
+	}
+
+	static Publisher<ByteBuffer> wrapListDataResponsePublisher(
+					final Publisher<ByteBuffer> delegate,
+					final ListOperation<? extends PathItem> op) {
+		final AtomicBoolean firstBodyBytesObserved = new AtomicBoolean(false);
+		return subscriber -> delegate.subscribe(new Subscriber<>() {
+			@Override
+			public void onSubscribe(final Subscription subscription) {
+				subscriber.onSubscribe(subscription);
+			}
+
+			@Override
+			public void onNext(final ByteBuffer byteBuffer) {
+				if (byteBuffer != null
+								&& byteBuffer.remaining() > 0
+								&& firstBodyBytesObserved.compareAndSet(false, true)) {
+					markListDataResponseStart(op);
+				}
+				subscriber.onNext(byteBuffer);
+			}
+
+			@Override
+			public void onError(final Throwable throwable) {
+				subscriber.onError(throwable);
+			}
+
+			@Override
+			public void onComplete() {
+				subscriber.onComplete();
+			}
+		});
+	}
+
+	static final class ListTtfbExecutionInterceptor implements ExecutionInterceptor {
+		@Override
+		public Optional<Publisher<ByteBuffer>> modifyAsyncHttpResponseContent(
+						final Context.ModifyHttpResponse context,
+						final ExecutionAttributes executionAttributes) {
+			final ListOperation<? extends PathItem> op = executionAttributes.getAttribute(LIST_TTFB_OPERATION_ATTRIBUTE);
+			if (op == null) {
+				return context.responsePublisher();
+			}
+			return context.responsePublisher()
+							.map(publisher -> wrapListDataResponsePublisher(publisher, op));
+		}
+	}
+
+	static final class ListTtfbSdkPlugin implements SdkPlugin {
+		@Override
+		public void configureClient(final SdkServiceClientConfiguration.Builder builder) {
+			builder.overrideConfiguration(b -> b.addExecutionInterceptor(new ListTtfbExecutionInterceptor()));
 		}
 	}
 

--- a/engine/extensions/storage-drivers/implementations/s3-aws/src/main/java/com/dell/spt/storage/driver/coop/aws/s3/S3AwsStorageDriver.java
+++ b/engine/extensions/storage-drivers/implementations/s3-aws/src/main/java/com/dell/spt/storage/driver/coop/aws/s3/S3AwsStorageDriver.java
@@ -65,8 +65,7 @@ public class S3AwsStorageDriver<I extends Item, O extends Operation<I>> extends 
 				implements ListDiscoveryProbe {
 
 	private static final Logger LOG = LoggerFactory.getLogger(S3AwsStorageDriver.class);
-	static final ExecutionAttribute<ListOperation<? extends PathItem>> LIST_TTFB_OPERATION_ATTRIBUTE =
-					new ExecutionAttribute<>("sptListTtfbOperation");
+	static final ExecutionAttribute<ListOperation<? extends PathItem>> LIST_TTFB_OPERATION_ATTRIBUTE = new ExecutionAttribute<>("sptListTtfbOperation");
 
 	// S3 API constants for multipart upload
 	private static final String KEY_UPLOAD_ID = "uploadId";

--- a/engine/extensions/storage-drivers/implementations/s3-aws/src/main/java/com/dell/spt/storage/driver/coop/aws/s3/S3AwsStorageDriver.java
+++ b/engine/extensions/storage-drivers/implementations/s3-aws/src/main/java/com/dell/spt/storage/driver/coop/aws/s3/S3AwsStorageDriver.java
@@ -66,7 +66,7 @@ public class S3AwsStorageDriver<I extends Item, O extends Operation<I>> extends 
 
 	private static final Logger LOG = LoggerFactory.getLogger(S3AwsStorageDriver.class);
 	static final ExecutionAttribute<ListOperation<? extends PathItem>> LIST_TTFB_OPERATION_ATTRIBUTE = new ExecutionAttribute<>("sptListTtfbOperation");
-	private static final ExecutionInterceptor LIST_TTFB_INTERCEPTOR = new ListTtfbExecutionInterceptor();
+	static final ExecutionInterceptor LIST_TTFB_INTERCEPTOR = new ListTtfbExecutionInterceptor();
 	private static final SdkPlugin LIST_TTFB_SDK_PLUGIN = new ListTtfbSdkPlugin();
 
 	// S3 API constants for multipart upload

--- a/engine/extensions/storage-drivers/implementations/s3-aws/src/main/java/com/dell/spt/storage/driver/coop/aws/s3/S3AwsStorageDriver.java
+++ b/engine/extensions/storage-drivers/implementations/s3-aws/src/main/java/com/dell/spt/storage/driver/coop/aws/s3/S3AwsStorageDriver.java
@@ -66,6 +66,7 @@ public class S3AwsStorageDriver<I extends Item, O extends Operation<I>> extends 
 
 	private static final Logger LOG = LoggerFactory.getLogger(S3AwsStorageDriver.class);
 	static final ExecutionAttribute<ListOperation<? extends PathItem>> LIST_TTFB_OPERATION_ATTRIBUTE = new ExecutionAttribute<>("sptListTtfbOperation");
+	private static final SdkPlugin LIST_TTFB_SDK_PLUGIN = new ListTtfbSdkPlugin();
 
 	// S3 API constants for multipart upload
 	private static final String KEY_UPLOAD_ID = "uploadId";
@@ -767,7 +768,7 @@ public class S3AwsStorageDriver<I extends Item, O extends Operation<I>> extends 
 						.maxKeys(maxKeys)
 						.overrideConfiguration(b -> b
 										.putExecutionAttribute(LIST_TTFB_OPERATION_ATTRIBUTE, listOp)
-										.addPlugin(new ListTtfbSdkPlugin()));
+										.addPlugin(LIST_TTFB_SDK_PLUGIN));
 
 		// Prefix from the item name (the framework sets item name as the listing prefix)
 		final var prefix = op.item().name();
@@ -831,6 +832,9 @@ public class S3AwsStorageDriver<I extends Item, O extends Operation<I>> extends 
 								listOp.startAfter(lastKey);
 							}
 							listOp.countBytesDone(listOp.bytesListed());
+							if (listOp.respDataTimeStart() == 0) {
+								LOG.debug("{}: LIST completed before first body byte was observed; TTFB unavailable", listOp);
+							}
 						});
 	}
 

--- a/engine/extensions/storage-drivers/implementations/s3-aws/src/test/java/com/dell/spt/storage/driver/coop/aws/s3/S3AwsStorageDriverTest.java
+++ b/engine/extensions/storage-drivers/implementations/s3-aws/src/test/java/com/dell/spt/storage/driver/coop/aws/s3/S3AwsStorageDriverTest.java
@@ -42,6 +42,7 @@ import software.amazon.awssdk.core.ResponseInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.lang.reflect.Field;
+import java.nio.ByteBuffer;
 import java.time.Instant;
 import java.util.Collections;
 import java.util.List;
@@ -49,6 +50,10 @@ import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -889,7 +894,7 @@ public class S3AwsStorageDriverTest {
 
 		@SuppressWarnings("unchecked")
 		@Test
-		void listStartsDataResponseTimingWhenResponseArrives() throws Exception {
+		void listRequestCarriesDataResponseTimingAttribute() throws Exception {
 			ListOperation<PathItem> op = mock(ListOperation.class);
 			PathItem item = mock(PathItem.class);
 			when(op.type()).thenReturn(OpType.LIST);
@@ -897,7 +902,6 @@ public class S3AwsStorageDriverTest {
 			when(item.name()).thenReturn("");
 			when(op.item()).thenReturn(item);
 			when(op.options()).thenReturn(ListOptions.DEFAULT);
-			when(op.respDataTimeStart()).thenReturn(0L);
 
 			when(mockS3Client.listObjectsV2(any(ListObjectsV2Request.class)))
 							.thenReturn(CompletableFuture.completedFuture(buildListResponse(
@@ -906,7 +910,56 @@ public class S3AwsStorageDriverTest {
 
 			drv.execute((Operation<Item>) (Operation<?>) op).join();
 
-			verify(op).startDataResponse();
+			ArgumentCaptor<ListObjectsV2Request> cap = ArgumentCaptor.forClass(ListObjectsV2Request.class);
+			verify(mockS3Client).listObjectsV2(cap.capture());
+			assertTrue(cap.getValue().overrideConfiguration().isPresent());
+			assertSame(
+							op,
+							cap.getValue().overrideConfiguration().get()
+										.executionAttributes()
+										.getAttribute(S3AwsStorageDriver.LIST_TTFB_OPERATION_ATTRIBUTE));
+			assertFalse(cap.getValue().overrideConfiguration().get().plugins().isEmpty());
+			verify(op, never()).startDataResponse();
+		}
+
+		@SuppressWarnings("unchecked")
+		@Test
+		void wrappedListResponsePublisherStartsDataResponseOnFirstNonEmptyBodyBytes() {
+			ListOperation<PathItem> op = mock(ListOperation.class);
+			when(op.respDataTimeStart()).thenReturn(0L);
+			Publisher<ByteBuffer> publisher = subscriber -> {
+				subscriber.onSubscribe(new Subscription() {
+					@Override
+					public void request(final long n) {}
+
+					@Override
+					public void cancel() {}
+				});
+				subscriber.onNext(ByteBuffer.allocate(0));
+				subscriber.onNext(ByteBuffer.wrap(new byte[]{1}));
+				subscriber.onNext(ByteBuffer.wrap(new byte[]{2}));
+				subscriber.onComplete();
+			};
+
+			S3AwsStorageDriver.wrapListDataResponsePublisher(publisher, op).subscribe(new Subscriber<>() {
+				@Override
+				public void onSubscribe(final Subscription subscription) {
+					subscription.request(Long.MAX_VALUE);
+				}
+
+				@Override
+				public void onNext(final ByteBuffer byteBuffer) {}
+
+				@Override
+				public void onError(final Throwable throwable) {
+					fail(throwable);
+				}
+
+				@Override
+				public void onComplete() {}
+			});
+
+			verify(op, times(1)).startDataResponse();
 		}
 
 		@SuppressWarnings("unchecked")

--- a/engine/extensions/storage-drivers/implementations/s3-aws/src/test/java/com/dell/spt/storage/driver/coop/aws/s3/S3AwsStorageDriverTest.java
+++ b/engine/extensions/storage-drivers/implementations/s3-aws/src/test/java/com/dell/spt/storage/driver/coop/aws/s3/S3AwsStorageDriverTest.java
@@ -38,8 +38,11 @@ import software.amazon.awssdk.services.s3.model.ChecksumAlgorithm;
 import software.amazon.awssdk.core.async.AsyncRequestBody;
 import software.amazon.awssdk.core.async.AsyncResponseTransformer;
 import software.amazon.awssdk.core.ResponseInputStream;
+import software.amazon.awssdk.core.SdkServiceClientConfiguration;
+import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
 import software.amazon.awssdk.core.interceptor.Context;
 import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
+import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -50,6 +53,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Consumer;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
@@ -1095,6 +1099,70 @@ public class S3AwsStorageDriverTest {
 							.modifyAsyncHttpResponseContent(context, new ExecutionAttributes());
 
 			assertSame(expected, actual);
+		}
+
+		@SuppressWarnings("unchecked")
+		@Test
+		void listTtfbExecutionInterceptorWrapsWhenAttributePresent() {
+			ListOperation<PathItem> op = mock(ListOperation.class);
+			when(op.respDataTimeStart()).thenReturn(0L);
+			Publisher<ByteBuffer> publisher = subscriber -> {
+				subscriber.onSubscribe(new Subscription() {
+					@Override
+					public void request(final long n) {}
+
+					@Override
+					public void cancel() {}
+				});
+				subscriber.onNext(ByteBuffer.wrap(new byte[]{1}));
+				subscriber.onComplete();
+			};
+			Context.ModifyHttpResponse context = mock(Context.ModifyHttpResponse.class);
+			when(context.responsePublisher()).thenReturn(Optional.of(publisher));
+			ExecutionAttributes attrs = new ExecutionAttributes()
+							.putAttribute(S3AwsStorageDriver.LIST_TTFB_OPERATION_ATTRIBUTE, op);
+
+			Optional<Publisher<ByteBuffer>> wrapped = new S3AwsStorageDriver.ListTtfbExecutionInterceptor()
+							.modifyAsyncHttpResponseContent(context, attrs);
+
+			assertTrue(wrapped.isPresent());
+			assertNotSame(publisher, wrapped.get());
+			wrapped.get().subscribe(new Subscriber<>() {
+				@Override
+				public void onSubscribe(final Subscription subscription) {
+					subscription.request(Long.MAX_VALUE);
+				}
+
+				@Override
+				public void onNext(final ByteBuffer byteBuffer) {}
+
+				@Override
+				public void onError(final Throwable throwable) {
+					fail(throwable);
+				}
+
+				@Override
+				public void onComplete() {}
+			});
+
+			verify(op, times(1)).startDataResponse();
+		}
+
+		@SuppressWarnings("unchecked")
+		@Test
+		void listTtfbSdkPluginRegistersSingletonInterceptor() {
+			SdkServiceClientConfiguration.Builder serviceBuilder = mock(SdkServiceClientConfiguration.Builder.class);
+			ClientOverrideConfiguration.Builder overrideBuilder = mock(ClientOverrideConfiguration.Builder.class);
+			when(overrideBuilder.addExecutionInterceptor(any(ExecutionInterceptor.class))).thenReturn(overrideBuilder);
+			ArgumentCaptor<Consumer<ClientOverrideConfiguration.Builder>> consumerCaptor = ArgumentCaptor.forClass(Consumer.class);
+
+			new S3AwsStorageDriver.ListTtfbSdkPlugin().configureClient(serviceBuilder);
+
+			verify(serviceBuilder).overrideConfiguration(consumerCaptor.capture());
+			consumerCaptor.getValue().accept(overrideBuilder);
+			ArgumentCaptor<ExecutionInterceptor> interceptorCaptor = ArgumentCaptor.forClass(ExecutionInterceptor.class);
+			verify(overrideBuilder).addExecutionInterceptor(interceptorCaptor.capture());
+			assertSame(S3AwsStorageDriver.LIST_TTFB_INTERCEPTOR, interceptorCaptor.getValue());
 		}
 
 		@SuppressWarnings("unchecked")

--- a/engine/extensions/storage-drivers/implementations/s3-aws/src/test/java/com/dell/spt/storage/driver/coop/aws/s3/S3AwsStorageDriverTest.java
+++ b/engine/extensions/storage-drivers/implementations/s3-aws/src/test/java/com/dell/spt/storage/driver/coop/aws/s3/S3AwsStorageDriverTest.java
@@ -38,6 +38,8 @@ import software.amazon.awssdk.services.s3.model.ChecksumAlgorithm;
 import software.amazon.awssdk.core.async.AsyncRequestBody;
 import software.amazon.awssdk.core.async.AsyncResponseTransformer;
 import software.amazon.awssdk.core.ResponseInputStream;
+import software.amazon.awssdk.core.interceptor.Context;
+import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -47,9 +49,12 @@ import java.time.Instant;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
@@ -962,6 +967,134 @@ public class S3AwsStorageDriverTest {
 			});
 
 			verify(op, times(1)).startDataResponse();
+		}
+
+		@SuppressWarnings("unchecked")
+		@Test
+		void wrappedListResponsePublisherDoesNotStartOnEmptyBodyBuffers() {
+			ListOperation<PathItem> op = mock(ListOperation.class);
+			when(op.respDataTimeStart()).thenReturn(0L);
+			Publisher<ByteBuffer> publisher = subscriber -> {
+				subscriber.onSubscribe(new Subscription() {
+					@Override
+					public void request(final long n) {}
+
+					@Override
+					public void cancel() {}
+				});
+				subscriber.onNext(ByteBuffer.allocate(0));
+				subscriber.onComplete();
+			};
+
+			S3AwsStorageDriver.wrapListDataResponsePublisher(publisher, op).subscribe(new Subscriber<>() {
+				@Override
+				public void onSubscribe(final Subscription subscription) {
+					subscription.request(Long.MAX_VALUE);
+				}
+
+				@Override
+				public void onNext(final ByteBuffer byteBuffer) {}
+
+				@Override
+				public void onError(final Throwable throwable) {
+					fail(throwable);
+				}
+
+				@Override
+				public void onComplete() {}
+			});
+
+			verify(op, never()).startDataResponse();
+		}
+
+		@SuppressWarnings("unchecked")
+		@Test
+		void wrappedListResponsePublisherPropagatesError() {
+			ListOperation<PathItem> op = mock(ListOperation.class);
+			RuntimeException expected = new RuntimeException("boom");
+			Publisher<ByteBuffer> publisher = subscriber -> {
+				subscriber.onSubscribe(new Subscription() {
+					@Override
+					public void request(final long n) {}
+
+					@Override
+					public void cancel() {}
+				});
+				subscriber.onError(expected);
+			};
+			AtomicReference<Throwable> observed = new AtomicReference<>();
+
+			S3AwsStorageDriver.wrapListDataResponsePublisher(publisher, op).subscribe(new Subscriber<>() {
+				@Override
+				public void onSubscribe(final Subscription subscription) {
+					subscription.request(Long.MAX_VALUE);
+				}
+
+				@Override
+				public void onNext(final ByteBuffer byteBuffer) {}
+
+				@Override
+				public void onError(final Throwable throwable) {
+					observed.set(throwable);
+				}
+
+				@Override
+				public void onComplete() {}
+			});
+
+			assertSame(expected, observed.get());
+		}
+
+		@SuppressWarnings("unchecked")
+		@Test
+		void wrappedListResponsePublisherPropagatesComplete() {
+			ListOperation<PathItem> op = mock(ListOperation.class);
+			Publisher<ByteBuffer> publisher = subscriber -> {
+				subscriber.onSubscribe(new Subscription() {
+					@Override
+					public void request(final long n) {}
+
+					@Override
+					public void cancel() {}
+				});
+				subscriber.onComplete();
+			};
+			AtomicBoolean completed = new AtomicBoolean(false);
+
+			S3AwsStorageDriver.wrapListDataResponsePublisher(publisher, op).subscribe(new Subscriber<>() {
+				@Override
+				public void onSubscribe(final Subscription subscription) {
+					subscription.request(Long.MAX_VALUE);
+				}
+
+				@Override
+				public void onNext(final ByteBuffer byteBuffer) {}
+
+				@Override
+				public void onError(final Throwable throwable) {
+					fail(throwable);
+				}
+
+				@Override
+				public void onComplete() {
+					completed.set(true);
+				}
+			});
+
+			assertTrue(completed.get());
+		}
+
+		@Test
+		void listTtfbExecutionInterceptorNoOpsWithoutAttribute() {
+			Publisher<ByteBuffer> publisher = subscriber -> {};
+			Optional<Publisher<ByteBuffer>> expected = Optional.of(publisher);
+			Context.ModifyHttpResponse context = mock(Context.ModifyHttpResponse.class);
+			when(context.responsePublisher()).thenReturn(expected);
+
+			Optional<Publisher<ByteBuffer>> actual = new S3AwsStorageDriver.ListTtfbExecutionInterceptor()
+							.modifyAsyncHttpResponseContent(context, new ExecutionAttributes());
+
+			assertSame(expected, actual);
 		}
 
 		@SuppressWarnings("unchecked")

--- a/engine/extensions/storage-drivers/implementations/s3-aws/src/test/java/com/dell/spt/storage/driver/coop/aws/s3/S3AwsStorageDriverTest.java
+++ b/engine/extensions/storage-drivers/implementations/s3-aws/src/test/java/com/dell/spt/storage/driver/coop/aws/s3/S3AwsStorageDriverTest.java
@@ -916,8 +916,8 @@ public class S3AwsStorageDriverTest {
 			assertSame(
 							op,
 							cap.getValue().overrideConfiguration().get()
-										.executionAttributes()
-										.getAttribute(S3AwsStorageDriver.LIST_TTFB_OPERATION_ATTRIBUTE));
+											.executionAttributes()
+											.getAttribute(S3AwsStorageDriver.LIST_TTFB_OPERATION_ATTRIBUTE));
 			assertFalse(cap.getValue().overrideConfiguration().get().plugins().isEmpty());
 			verify(op, never()).startDataResponse();
 		}
@@ -936,8 +936,10 @@ public class S3AwsStorageDriverTest {
 					public void cancel() {}
 				});
 				subscriber.onNext(ByteBuffer.allocate(0));
-				subscriber.onNext(ByteBuffer.wrap(new byte[]{1}));
-				subscriber.onNext(ByteBuffer.wrap(new byte[]{2}));
+				subscriber.onNext(ByteBuffer.wrap(new byte[]{1
+				}));
+				subscriber.onNext(ByteBuffer.wrap(new byte[]{2
+				}));
 				subscriber.onComplete();
 			};
 

--- a/engine/extensions/storage-drivers/implementations/s3-aws/src/test/java/com/dell/spt/storage/driver/coop/aws/s3/S3AwsStorageDriverTest.java
+++ b/engine/extensions/storage-drivers/implementations/s3-aws/src/test/java/com/dell/spt/storage/driver/coop/aws/s3/S3AwsStorageDriverTest.java
@@ -1114,7 +1114,8 @@ public class S3AwsStorageDriverTest {
 					@Override
 					public void cancel() {}
 				});
-				subscriber.onNext(ByteBuffer.wrap(new byte[]{1}));
+				subscriber.onNext(ByteBuffer.wrap(new byte[]{1
+				}));
 				subscriber.onComplete();
 			};
 			Context.ModifyHttpResponse context = mock(Context.ModifyHttpResponse.class);

--- a/engine/extensions/storage-drivers/protocols/fs/README.md
+++ b/engine/extensions/storage-drivers/protocols/fs/README.md
@@ -20,6 +20,7 @@ additional VFS layer. The measured rates may be:
         * random byte ranges
         * fixed byte ranges
         * content verification
+        * first byte timing for READ TTFB metrics
     * `update`
         * full (overwrite)
         * random byte ranges

--- a/engine/extensions/storage-drivers/protocols/fs/src/main/java/com/dell/spt/storage/driver/coop/nio/fs/FileIoHelper.java
+++ b/engine/extensions/storage-drivers/protocols/fs/src/main/java/com/dell/spt/storage/driver/coop/nio/fs/FileIoHelper.java
@@ -51,6 +51,16 @@ public interface FileIoHelper {
 		return countBytesDone >= contentSize;
 	}
 
+	static void markDataResponseStartedOnRead(final DataOperation<?> op, final int bytesRead) {
+		if (bytesRead > 0 && op.respDataTimeStart() == 0 && op.reqTimeDone() > 0) {
+			try {
+				op.startDataResponse();
+			} catch (final IllegalStateException e) {
+				Loggers.MSG.debug("{}: failed to mark READ data response start", op, e);
+			}
+		}
+	}
+
 	static <I extends DataItem, O extends DataOperation<I>> boolean invokeReadAndVerify(
 					final I fileItem, final O op, final ReadableByteChannel srcChannel) throws DataSizeException, DataCorruptionException, IOException {
 		long countBytesDone = op.countBytesDone();
@@ -67,6 +77,7 @@ public interface FileIoHelper {
 					if (n < 0) {
 						throw new DataSizeException(contentSize, countBytesDone);
 					} else {
+						markDataResponseStartedOnRead(op, n);
 						inBuff.flip();
 						currRange.verify(inBuff);
 						currRange.position(currRange.position() + n);
@@ -84,6 +95,7 @@ public interface FileIoHelper {
 				if (n < 0) {
 					throw new DataSizeException(contentSize, countBytesDone);
 				} else {
+					markDataResponseStartedOnRead(op, n);
 					inBuff.flip();
 					fileItem.verify(inBuff);
 					fileItem.position(fileItem.position() + n);
@@ -130,6 +142,7 @@ public interface FileIoHelper {
 			if (n < 0) {
 				throw new DataSizeException(rangesSizeSum, countBytesDone);
 			} else {
+				markDataResponseStartedOnRead(op, n);
 				inBuff.flip();
 				try {
 					range2read.verify(inBuff);
@@ -207,6 +220,7 @@ public interface FileIoHelper {
 					// expected more data within the fixed range
 					throw new DataSizeException(fixedRangesSizeSum, rangeBytesDone);
 				} else {
+					markDataResponseStartedOnRead(op, m);
 					inBuff.flip();
 					try {
 						currRange.verify(inBuff);
@@ -248,6 +262,7 @@ public interface FileIoHelper {
 				fileItem.size(countBytesDone);
 				return true;
 			} else {
+				markDataResponseStartedOnRead(op, n);
 				countBytesDone += n;
 				op.countBytesDone(countBytesDone);
 			}
@@ -286,6 +301,7 @@ public interface FileIoHelper {
 				op.countBytesDone(countBytesDone);
 				return true;
 			}
+			markDataResponseStartedOnRead(op, n);
 			countBytesDone += n;
 			if (countBytesDone == currRangeSize && countBytesDone < rangesSizeSum) {
 				op.currRangeIdx(currRangeIdx + 1);
@@ -329,6 +345,7 @@ public interface FileIoHelper {
 					op.countBytesDone(countBytesDone);
 					return true;
 				}
+				markDataResponseStartedOnRead(op, n);
 				countBytesDone += n;
 				if (countBytesDone == rangeSize) {
 					op.currRangeIdx(currRangeIdx + 1);

--- a/engine/extensions/storage-drivers/protocols/fs/src/test/java/com/dell/spt/storage/driver/coop/nio/fs/FileIoHelperTest.java
+++ b/engine/extensions/storage-drivers/protocols/fs/src/test/java/com/dell/spt/storage/driver/coop/nio/fs/FileIoHelperTest.java
@@ -5,6 +5,7 @@ import com.dell.spt.base.item.DataItemImpl;
 import com.dell.spt.base.item.op.OpType;
 import com.dell.spt.base.item.op.Operation;
 import com.dell.spt.base.item.op.data.DataOperationImpl;
+import com.github.akurilov.commons.collection.Range;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -14,6 +15,7 @@ import java.nio.channels.ReadableByteChannel;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -113,6 +115,39 @@ public class FileIoHelperTest {
 		}
 		assertTrue(done);
 		assertEquals(data.length, op.countBytesDone());
+	}
+
+	@Test
+	public void invokeReadStartsDataResponseOnFirstBytes() throws IOException {
+		final byte[] data = new byte[]{1, 2, 3, 4, 5
+		};
+		final ReadableByteChannel ch = Channels.newChannel(new java.io.ByteArrayInputStream(data));
+
+		final DataItemImpl item = new DataItemImpl("x", 0, data.length);
+		final DataOperationImpl<DataItemImpl> op = new DataOperationImpl<>(0, OpType.READ, item, null, null, null, null, 0);
+		op.startRequest();
+		op.finishRequest();
+
+		assertTrue(FileIoHelper.invokeRead(item, op, ch));
+		assertEquals(data.length, op.countBytesDone());
+		assertTrue(op.respDataTimeStart() > 0);
+	}
+
+	@Test
+	public void invokeReadFixedRangesStartsDataResponseOnFirstBytes() throws IOException {
+		final Path src = Files.createTempFile("fs-fixed-read-", ".bin");
+		Files.write(src, new byte[]{1, 2, 3, 4, 5
+		});
+		final List<Range> ranges = List.of(new Range(1L, 3L, -1L));
+		final DataItemImpl item = new DataItemImpl("x", 0, 5);
+		final DataOperationImpl<DataItemImpl> op = new DataOperationImpl<>(0, OpType.READ, item, null, null, null, ranges, 0);
+		op.startRequest();
+		op.finishRequest();
+
+		try (final FileChannel ch = FileChannel.open(src, StandardOpenOption.READ)) {
+			assertTrue(FileIoHelper.invokeReadFixedRanges(item, op, ch, ranges));
+		}
+		assertTrue(op.respDataTimeStart() > 0);
 	}
 
 	@Test


### PR DESCRIPTION
## Summary
- Add Time to First Byte tracking for body-returning READ and LIST operations, including local filesystem READs and AWS SDK S3 LIST first-body-byte capture.
- Carry TTFB through CLI live/headless metrics, safe aggregation, and final summaries while omitting unavailable or misleading mixed-workload TTFB values.
- Add tests for TTFB propagation, AWS SDK LIST interceptor/plugin plumbing, publisher edge cases, CLI parsing/aggregation/rendering, and user-facing docs/changelog updates.
