### PR TITLE
Gate releases on published engine images

### DIFF
--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -9,11 +9,9 @@
 
 name: Publish Docker Image
 
-# Trigger on version tags only
-on:
-  push:
-    tags:
-      - 'v*'
+# Manual Docker image publishing. Tag-driven release Docker publishing is owned by
+# release-artifacts.yaml so GitHub Release publication can depend on the pushed image.
+'on':
   workflow_dispatch:
     inputs:
       version:
@@ -34,67 +32,8 @@ env:
   IMAGE_NAME: dell/storage-performance-tool
 
 jobs:
-  # Gate: ensure CI has passed for this commit before publishing
-  # For tag pushes, we verify the CI workflow succeeded for the tagged commit
-  verify-ci:
-    name: Verify CI Status
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check CI workflow status
-        if: github.event_name == 'push'
-        uses: actions/github-script@v9
-        with:
-          script: |
-            const sha = context.sha;
-            const ciCheckNames = ['Engine Build & Tests', 'Go Quality Suite'];
-            const maxAttempts = 60;
-            const intervalMs = 30000;
-
-            console.log(`Checking CI status for commit ${sha}`);
-            console.log(`Will poll up to ${maxAttempts} times (${maxAttempts * intervalMs / 1000}s) for: ${ciCheckNames.join(', ')}`);
-
-            for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-              const { data: checkRuns } = await github.rest.checks.listForRef({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                ref: sha,
-              });
-
-              const passed = new Set();
-              const pending = [];
-              for (const name of ciCheckNames) {
-                const run = checkRuns.check_runs.find(r => r.name === name);
-                if (!run) {
-                  pending.push(name);
-                  console.log(`Attempt ${attempt}/${maxAttempts}: "${name}" not found yet.`);
-                } else if (run.conclusion === 'success') {
-                  passed.add(name);
-                } else if (run.conclusion) {
-                  core.setFailed(`CI check "${name}" failed (conclusion: ${run.conclusion}). Cannot publish image.`);
-                  return;
-                } else {
-                  pending.push(name);
-                  console.log(`Attempt ${attempt}/${maxAttempts}: "${name}" still in progress...`);
-                }
-              }
-
-              if (passed.size === ciCheckNames.length) {
-                console.log(`All CI checks passed: ${[...passed].join(', ')}`);
-                return;
-              }
-
-              console.log(`Attempt ${attempt}/${maxAttempts}: ${passed.size}/${ciCheckNames.length} passed, waiting on: ${pending.join(', ')}`);
-
-              if (attempt < maxAttempts) {
-                await new Promise(r => setTimeout(r, intervalMs));
-              }
-            }
-
-            core.setFailed(`CI checks did not complete within ${maxAttempts * intervalMs / 1000}s. Re-run this workflow after CI passes.`);
-
   prepare:
     name: Prepare Version
-    needs: verify-ci
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.version.outputs.version }}
@@ -248,8 +187,8 @@ jobs:
           context: engine/bundle
           file: engine/bundle/Dockerfile
           platforms: linux/amd64,linux/arm64
-          # Push on tag events, or on workflow_dispatch if dry_run is false
-          push: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && !inputs.dry_run) }}
+          # Manual workflow dispatch pushes unless dry_run is true.
+          push: ${{ !inputs.dry_run }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |

--- a/.github/workflows/release-artifacts.yaml
+++ b/.github/workflows/release-artifacts.yaml
@@ -19,15 +19,79 @@ concurrency:
   group: release-artifacts-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: dell/storage-performance-tool
+
 jobs:
+  verify-ci:
+    name: Verify CI Status
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check CI workflow status
+        if: github.event_name == 'push'
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const sha = context.sha;
+            const ciCheckNames = ['Engine Build & Tests', 'Go Quality Suite'];
+            const maxAttempts = 60;
+            const intervalMs = 30000;
+
+            console.log(`Checking CI status for commit ${sha}`);
+            console.log(`Will poll up to ${maxAttempts} times (${maxAttempts * intervalMs / 1000}s) for: ${ciCheckNames.join(', ')}`);
+
+            for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+              const { data: checkRuns } = await github.rest.checks.listForRef({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: sha,
+              });
+
+              const passed = new Set();
+              const pending = [];
+              for (const name of ciCheckNames) {
+                const run = checkRuns.check_runs.find(r => r.name === name);
+                if (!run) {
+                  pending.push(name);
+                  console.log(`Attempt ${attempt}/${maxAttempts}: "${name}" not found yet.`);
+                } else if (run.conclusion === 'success') {
+                  passed.add(name);
+                } else if (run.conclusion) {
+                  core.setFailed(`CI check "${name}" failed (conclusion: ${run.conclusion}). Cannot publish release.`);
+                  return;
+                } else {
+                  pending.push(name);
+                  console.log(`Attempt ${attempt}/${maxAttempts}: "${name}" still in progress...`);
+                }
+              }
+
+              if (passed.size === ciCheckNames.length) {
+                console.log(`All CI checks passed: ${[...passed].join(', ')}`);
+                return;
+              }
+
+              console.log(`Attempt ${attempt}/${maxAttempts}: ${passed.size}/${ciCheckNames.length} passed, waiting on: ${pending.join(', ')}`);
+
+              if (attempt < maxAttempts) {
+                await new Promise(r => setTimeout(r, intervalMs));
+              }
+            }
+
+            core.setFailed(`CI checks did not complete within ${maxAttempts * intervalMs / 1000}s. Re-run this workflow after CI passes.`);
+
   prepare-version:
     name: Prepare Version
+    needs: verify-ci
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.version.outputs.version }}
       tag: ${{ steps.version.outputs.tag }}
       artifact-prefix: ${{ steps.version.outputs.prefix }}
       allow-snapshot: ${{ steps.snapshot.outputs.allow }}
+      major: ${{ steps.version.outputs.major }}
+      minor: ${{ steps.version.outputs.minor }}
+      is_prerelease: ${{ steps.version.outputs.is_prerelease }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -70,10 +134,20 @@ jobs:
             exit 1
           fi
 
+          base_version="${version%%-*}"
+          IFS='.' read -r major minor patch <<< "${base_version}"
+          is_prerelease="false"
+          if [[ "${version}" == *-* ]]; then
+            is_prerelease="true"
+          fi
+
           {
             echo "version=${version}"
             echo "tag=${tag_name}"
             echo "prefix=spt-${version}"
+            echo "major=${major}"
+            echo "minor=${minor}"
+            echo "is_prerelease=${is_prerelease}"
           } >> "${GITHUB_OUTPUT}"
 
       - name: Snapshot allowance
@@ -114,6 +188,9 @@ jobs:
       - name: Build multi-platform binaries
         run: make -C cli build-all VERSION=${{ needs.prepare-version.outputs.version }}
 
+      - name: Verify Linux ARM64 binary
+        run: test -s cli/build/spt-linux-arm64
+
       - name: Package binaries
         run: |
           set -euo pipefail
@@ -129,15 +206,21 @@ jobs:
           rm -f \
             "${cli_dir}/spt-${version}-linux-amd64" \
             "${cli_dir}/spt-${version}-linux-amd64.gz" \
+            "${cli_dir}/spt-${version}-linux-arm64" \
+            "${cli_dir}/spt-${version}-linux-arm64.gz" \
             "${cli_dir}/spt-${version}-darwin-amd64" \
             "${cli_dir}/spt-${version}-darwin-amd64.gz" \
             "${cli_dir}/spt-${version}-darwin-arm64" \
             "${cli_dir}/spt-${version}-darwin-arm64.gz" \
             "${cli_dir}/spt-${version}-windows-amd64.exe" \
-            "${cli_dir}/spt-${version}-windows-amd64.zip"
+            "${cli_dir}/spt-${version}-windows-amd64.zip" \
+            "${cli_dir}/SHA256SUMS"
 
           cp cli/build/spt-linux-amd64 "${cli_dir}/spt-${version}-linux-amd64"
           gzip -n "${cli_dir}/spt-${version}-linux-amd64"
+
+          cp cli/build/spt-linux-arm64 "${cli_dir}/spt-${version}-linux-arm64"
+          gzip -n "${cli_dir}/spt-${version}-linux-arm64"
 
           cp cli/build/spt-darwin-amd64 "${cli_dir}/spt-${version}-darwin-amd64"
           gzip -n "${cli_dir}/spt-${version}-darwin-amd64"
@@ -146,7 +229,15 @@ jobs:
           gzip -n "${cli_dir}/spt-${version}-darwin-arm64"
 
           cp cli/build/spt-windows-amd64.exe "${cli_dir}/spt-${version}-windows-amd64.exe"
-          (cd "${cli_dir}" && zip -q "spt-${version}-windows-amd64.zip" "spt-${version}-windows-amd64.exe")
+          python3 - "${cli_dir}" "spt-${version}-windows-amd64.exe" "spt-${version}-windows-amd64.zip" <<'PY'
+          import os
+          import sys
+          import zipfile
+
+          cli_dir, exe_name, zip_name = sys.argv[1:]
+          with zipfile.ZipFile(os.path.join(cli_dir, zip_name), "w", zipfile.ZIP_DEFLATED) as zf:
+              zf.write(os.path.join(cli_dir, exe_name), arcname=exe_name)
+          PY
           rm "${cli_dir}/spt-${version}-windows-amd64.exe"
 
           cat <<'EOF' > "${cli_dir}/README.txt"
@@ -154,10 +245,43 @@ jobs:
           https://github.com/dell/storage-performance-tool
 
           File naming: spt-<version>-<os>-<arch>.<ext>
-          - Linux   (amd64): gzip binary
+          - Linux   (amd64, arm64): gzip binaries
           - macOS   (amd64, arm64): gzip binaries
           - Windows (amd64): zip archive with .exe
           EOF
+
+          expected_assets=(
+            "spt-${version}-linux-amd64.gz"
+            "spt-${version}-linux-arm64.gz"
+            "spt-${version}-darwin-amd64.gz"
+            "spt-${version}-darwin-arm64.gz"
+            "spt-${version}-windows-amd64.zip"
+          )
+
+          for asset in "${expected_assets[@]}"; do
+            if [[ ! -s "${cli_dir}/${asset}" ]]; then
+              echo "Expected CLI asset ${asset} is missing or empty" >&2
+              exit 1
+            fi
+          done
+
+          (cd "${cli_dir}" && sha256sum "${expected_assets[@]}" > SHA256SUMS)
+
+          for asset in "${expected_assets[@]}"; do
+            count=$(awk -v file="${asset}" '{ name=$2; sub(/^\*/, "", name); if (name == file) count++ } END { print count + 0 }' "${cli_dir}/SHA256SUMS")
+            if [[ "${count}" != "1" ]]; then
+              echo "Expected exactly one SHA256SUMS entry for ${asset}; found ${count}" >&2
+              cat "${cli_dir}/SHA256SUMS" >&2
+              exit 1
+            fi
+          done
+
+          unexpected=$(awk '{ name=$2; sub(/^\*/, "", name); if (name !~ /\.(gz|zip)$/) print name }' "${cli_dir}/SHA256SUMS")
+          if [[ -n "${unexpected}" ]]; then
+            echo "SHA256SUMS contains unexpected non-archive entries:" >&2
+            echo "${unexpected}" >&2
+            exit 1
+          fi
 
       - name: Upload CLI artifacts
         if: ${{ !env.ACT }}
@@ -239,12 +363,164 @@ jobs:
           path: release/engine/**
           if-no-files-found: error
 
+  docker-image:
+    name: Build and Push Docker Image
+    needs: prepare-version
+    if: ${{ startsWith(github.ref, 'refs/tags/') }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            # Exact version tag: v5.0.2
+            type=semver,pattern=v{{version}},value=${{ needs.prepare-version.outputs.version }}
+            # Floating minor tag: v5.0 (only for stable releases)
+            type=semver,pattern=v{{major}}.{{minor}},value=${{ needs.prepare-version.outputs.version }},enable=${{ needs.prepare-version.outputs.is_prerelease == 'false' }}
+            # Floating major tag: v5 (only for stable releases)
+            type=semver,pattern=v{{major}},value=${{ needs.prepare-version.outputs.version }},enable=${{ needs.prepare-version.outputs.is_prerelease == 'false' }}
+            # Latest tag (only for stable releases)
+            type=raw,value=latest,enable=${{ needs.prepare-version.outputs.is_prerelease == 'false' }}
+          labels: |
+            org.opencontainers.image.title=Dell Storage Performance Tool
+            org.opencontainers.image.description=High-performance S3-compatible storage benchmarking tool
+            org.opencontainers.image.vendor=Dell Inc.
+
+      - name: Install JDK 21
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v6
+
+      - name: Install RDMA build dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends \
+            libibverbs-dev \
+            librdmacm-dev
+
+      - name: Build Engine distribution
+        working-directory: engine
+        run: ./gradlew :bundle:assembleDist --no-daemon
+
+      - name: Verify version alignment
+        shell: bash
+        run: |
+          set -euo pipefail
+          expected_version="${{ needs.prepare-version.outputs.version }}"
+
+          version_output=$(java -jar engine/bundle/build/dist/spt.jar --version 2>&1 || true)
+          echo "Raw version output: ${version_output}"
+
+          jar_version=$(echo "${version_output}" | grep -oE 'v?[0-9]+\.[0-9]+\.[0-9]+[^[:space:]]*' | sed 's/^v//' | head -1 || echo "unknown")
+
+          echo "Expected version: ${expected_version}"
+          echo "JAR version: ${jar_version}"
+
+          if [[ "${jar_version}" != "${expected_version}" ]]; then
+            echo "::error::Version mismatch! Tag/input version (${expected_version}) does not match JAR version (${jar_version})"
+            echo "Ensure VERSION file and Gradle version are updated before tagging."
+            exit 1
+          fi
+
+          echo "Version alignment verified: ${expected_version}"
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v7
+        with:
+          context: engine/bundle
+          file: engine/bundle/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            SPT_VERSION=${{ needs.prepare-version.outputs.version }}
+            SPT_RELEASE_VERSION=${{ needs.prepare-version.outputs.version }}
+          provenance: true
+          sbom: true
+          cache-from: type=gha,scope=spt-engine
+          cache-to: type=gha,mode=max,scope=spt-engine
+
+      - name: Verify pushed Docker manifest
+        env:
+          IMAGE_REF: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.prepare-version.outputs.tag }}
+        run: |
+          set -euo pipefail
+          docker buildx imagetools inspect "${IMAGE_REF}" --raw > manifest.json
+          python3 - <<'PY'
+          import json
+          import os
+          import sys
+
+          with open("manifest.json", encoding="utf-8") as fh:
+              manifest = json.load(fh)
+
+          platforms = set()
+          for entry in manifest.get("manifests", []):
+              platform = entry.get("platform") or {}
+              os_name = platform.get("os")
+              arch = platform.get("architecture")
+              if os_name and arch:
+                  platforms.add(f"{os_name}/{arch}")
+
+          required = {"linux/amd64", "linux/arm64"}
+          missing = sorted(required - platforms)
+          print(f"Manifest {os.environ['IMAGE_REF']} platforms: {sorted(platforms)}")
+          if missing:
+              print(f"Missing required platforms: {missing}", file=sys.stderr)
+              sys.exit(1)
+          PY
+
+      - name: Output image info
+        run: |
+          echo "## Docker Image Published" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Version:** ${{ needs.prepare-version.outputs.version }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Tags:**" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          echo "${{ steps.meta.outputs.tags }}" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Platforms:** linux/amd64, linux/arm64" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Supply Chain:**" >> "$GITHUB_STEP_SUMMARY"
+          echo "- SBOM attestation generated" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Provenance attestation generated" >> "$GITHUB_STEP_SUMMARY"
+
   publish-release:
     name: Publish GitHub Release
     needs:
       - prepare-version
       - cli-binaries
       - engine-bundle
+      - docker-image
     if: ${{ startsWith(github.ref, 'refs/tags/') }}
     runs-on: ubuntu-latest
     permissions:

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The top-level repository represents the SPT product. The `cli` and `engine` dire
 Pre-built `spt` binaries for Linux, macOS, and Windows are published with each [GitHub Release](https://github.com/dell/storage-performance-tool/releases). Download the latest release for your platform, extract, and run:
 
 ```bash
-# Example: Linux amd64
+# Example: Linux amd64 (use linux-arm64 on Arm systems)
 gunzip spt-*-linux-amd64.gz
 chmod +x spt-*-linux-amd64
 mv spt-*-linux-amd64 spt

--- a/cli/Makefile
+++ b/cli/Makefile
@@ -64,7 +64,7 @@ help:
 	@echo "  tidy         - Tidy Go module dependencies"
 	@echo "  run          - Build and run the application"
 	@echo "  build-all    - Build binaries for Linux, macOS, and Windows"
-	@echo "  build-linux  - Build Linux AMD64 binary"
+	@echo "  build-linux  - Build Linux AMD64 and ARM64 binaries"
 	@echo "  build-darwin - Build macOS AMD64 and ARM64 binaries"
 	@echo "  build-windows- Build Windows AMD64 binary"
 	@echo "  dev          - Development workflow: format, vet, test, build"
@@ -198,6 +198,7 @@ build-all: build-linux build-darwin build-windows
 build-linux:
 	@echo "Building for Linux..."
 	GOOS=linux GOARCH=amd64 $(GOCMD) build $(LDFLAGS) -o $(BUILD_DIR)/$(BINARY_NAME)-linux-amd64
+	GOOS=linux GOARCH=arm64 $(GOCMD) build $(LDFLAGS) -o $(BUILD_DIR)/$(BINARY_NAME)-linux-arm64
 
 build-darwin:
 	@echo "Building for macOS..."


### PR DESCRIPTION
## Summary
- move tag-driven Docker image publishing into the release artifacts workflow so GitHub Release publication depends on the pushed multi-arch engine image
- add linux/arm64 CLI release artifact packaging and checksum completeness validation for all CLI assets
- keep the Docker publish workflow as manual-only to avoid duplicate tag-triggered pushes
- update Makefile/README platform text for Linux arm64 binaries

#### Test plan
- [x] `yamllint .github/workflows/release-artifacts.yaml .github/workflows/docker-publish.yaml --config-file .yamllint.yaml`
- [x] `make -C cli build-all VERSION=5.10.4`
- [x] local packaging/checksum smoke test for all five CLI release assets
- [x] `git diff --check`
- [x] `make -C cli ci-local` through module tidy, verify, gofmt, vet, and build; optional golangci-lint failed on pre-existing complexity/nesting findings unrelated to this PR
- [ ] actionlint not run locally; not installed and only available here via Snap, which we avoided
