### PR TITLE
Add SPT CLI self-update command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Added
 
+- **SPT CLI self-update command** — added `spt update` for checking GitHub Releases and installing verified CLI release binaries. The command supports lightweight `--check` probes with distinct exit codes, prerelease selection, `--output` downloads, checksum verification, archive hardening, pre-download replace-access checks, and hardened GitHub transport. Windows running-binary replacement is intentionally disabled for now; use `--output` to download a verified Windows binary.
 - **Replay archived workloads documentation** — added public user documentation for `spt replay`, including source archive requirements, environment remapping behavior, supported safe file-preparation transformations, generate-only inspection, distributed replay guidance, limitations, and troubleshooting.
 - **READ/LIST TTFB reporting** — Time to First Byte is now tracked for body-returning READ and LIST operations, including local filesystem reads and AWS SDK S3 LIST responses. Live/headless metrics and final summaries report TTFB only when samples are available, avoiding misleading mixed-workload or non-body-operation TTFB values.
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ Pre-built `spt` binaries for Linux, macOS, and Windows are published with each [
 gunzip spt-*-linux-amd64.gz
 chmod +x spt-*-linux-amd64
 mv spt-*-linux-amd64 spt
+
+# Later, check for CLI updates
+./spt update --check
 ```
 
 ### Prerequisites

--- a/cli/README.md
+++ b/cli/README.md
@@ -330,6 +330,24 @@ These flags are available for all commands:
 - `--log-file string`: Specify log file path - default: "spt.log"
 - `--log-append`: Append to existing log file (default is to create new)
 
+#### `spt update`
+
+Checks GitHub Releases for newer SPT CLI binaries and can install a verified release binary.
+
+```bash
+spt update --check
+spt update --yes
+spt update --output /tmp/spt-release
+```
+
+Key behavior:
+
+- `--check` prints `current=<version> latest=<version> available=<true|false>` without downloading or writing files. Exit code `10` means a newer release is available; `0` means up to date.
+- Downloads are verified against the release `SHA256SUMS` file before any output file or running binary is replaced. This is integrity verification, not signed authenticity verification.
+- Local/dev builds (`dev`, `*-dev+<commit>`, `*-SNAPSHOT`) refuse running-binary self-update so local development binaries are not overwritten by a GitHub release. Use `--output <path>` to download a release binary separately.
+- `--pre` includes prerelease tags, `--timeout` controls GitHub requests, and `--token` can be used for GitHub API rate limits; prefer `SPT_GITHUB_TOKEN` or `GITHUB_TOKEN` over passing a token on the command line.
+- If `SPT_IMAGE` is set, self-update warns that engine runs will continue using that pinned image until the override is changed or removed.
+
 #### `spt run <type>`
 
 Executes a benchmark test with the specified workload type.

--- a/cli/README.md
+++ b/cli/README.md
@@ -345,6 +345,8 @@ Key behavior:
 - `--check` prints `current=<version> latest=<version> available=<true|false>` without downloading or writing files. Exit code `10` means a newer release is available; `0` means up to date.
 - Downloads are verified against the release `SHA256SUMS` file before any output file or running binary is replaced. This is integrity verification, not signed authenticity verification.
 - Local/dev builds (`dev`, `*-dev+<commit>`, `*-SNAPSHOT`) refuse running-binary self-update so local development binaries are not overwritten by a GitHub release. Use `--output <path>` to download a release binary separately.
+- Windows running-binary self-update is disabled for now; use `--output <path>` to download a verified Windows release binary.
+- Before downloading assets for running-binary replacement, `spt update` verifies that the resolved target can be replaced and reports whether to re-run with elevated privileges or use `--output`.
 - `--pre` includes prerelease tags, `--timeout` controls GitHub requests, and `--token` can be used for GitHub API rate limits; prefer `SPT_GITHUB_TOKEN` or `GITHUB_TOKEN` over passing a token on the command line.
 - If `SPT_IMAGE` is set, self-update warns that engine runs will continue using that pinned image until the override is changed or removed.
 

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -70,6 +70,7 @@ It provides a user-friendly interface to execute various benchmark tests (e.g., 
 	},
 }
 
+// ExitCodeError carries a specific process exit code for command failures.
 type ExitCodeError struct {
 	Code int
 	Msg  string

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -7,6 +7,7 @@ Copyright © 2025 Dell Technologies
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -69,13 +70,35 @@ It provides a user-friendly interface to execute various benchmark tests (e.g., 
 	},
 }
 
+type ExitCodeError struct {
+	Code int
+	Msg  string
+}
+
+func (e *ExitCodeError) Error() string {
+	return e.Msg
+}
+
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
-	err := rootCmd.Execute()
-	if err != nil {
-		os.Exit(1)
+	os.Exit(executeRoot())
+}
+
+func executeRoot() int {
+	return executeCommandCode(rootCmd)
+}
+
+func executeCommandCode(cmd *cobra.Command) int {
+	err := cmd.Execute()
+	if err == nil {
+		return 0
 	}
+	var exitErr *ExitCodeError
+	if errors.As(err, &exitErr) {
+		return exitErr.Code
+	}
+	return 1
 }
 
 // initializeLogger sets up the slog logger based on command-line flags

--- a/cli/cmd/update.go
+++ b/cli/cmd/update.go
@@ -118,6 +118,10 @@ func runUpdateCommand(cmd *cobra.Command, opts *updateOptions) error {
 	if err != nil {
 		return updateUserError(cmd, "failed to parse latest release tag %q: %v", latest.TagName, err)
 	}
+	assetName, err := updater.AssetNameForPlatform(latestVersion.String(), updateRuntimeGOOS(), updateRuntimeGOARCH())
+	if err != nil {
+		return updateUserError(cmd, "%v", err)
+	}
 	current := updateCurrentVersion()
 	currentVersion, currentVersionErr := updater.ParseVersion(current)
 	available := currentVersionErr == nil && updater.Available(currentVersion, latestVersion)
@@ -161,10 +165,6 @@ func runUpdateCommand(cmd *cobra.Command, opts *updateOptions) error {
 		return nil
 	}
 
-	assetName, err := updater.AssetNameForPlatform(latestVersion.String(), updateRuntimeGOOS(), updateRuntimeGOARCH())
-	if err != nil {
-		return updateUserError(cmd, "%v", err)
-	}
 	asset, err := updater.FindAsset(latest.Assets, assetName)
 	if err != nil {
 		return updateUserError(cmd, "%v", err)

--- a/cli/cmd/update.go
+++ b/cli/cmd/update.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bufio"
 	"context"
 	"errors"
 	"fmt"
@@ -34,8 +35,12 @@ var (
 	updateRuntimeGOOS     = func() string { return runtime.GOOS }
 	updateRuntimeGOARCH   = func() string { return runtime.GOARCH }
 	updateNewGitHubClient = func(timeout time.Duration, token string) updater.GitHubClient {
-		return updater.NewGitHubClient(timeout, token)
+		client := updater.NewGitHubClient(timeout, token)
+		client.UserAgent = "spt/" + buildinfo.Version
+		return client
 	}
+	updateVerifyReplaceAccess = updater.VerifyReplaceAccess
+	updateIsTerminalInput     = isTerminalInput
 )
 
 func newUpdateCommand() *cobra.Command {
@@ -64,7 +69,9 @@ func newUpdateCommand() *cobra.Command {
 func updatePreRun(cmd *cobra.Command) error {
 	config.LoadDotEnv()
 	if inheritedFlagChanged(cmd, "log-file") {
-		return initializeLogger()
+		if err := initializeLogger(); err != nil {
+			return updateUserError(cmd, "%v", err)
+		}
 	}
 	return nil
 }
@@ -111,6 +118,49 @@ func runUpdateCommand(cmd *cobra.Command, opts *updateOptions) error {
 	if err != nil {
 		return updateUserError(cmd, "failed to parse latest release tag %q: %v", latest.TagName, err)
 	}
+	current := updateCurrentVersion()
+	currentVersion, currentVersionErr := updater.ParseVersion(current)
+	available := currentVersionErr == nil && updater.UpdateAvailable(currentVersion, latestVersion)
+	if opts.check {
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "current=%s latest=%s available=%t\n", current, latestVersion.String(), available)
+		if available {
+			return &ExitCodeError{Code: 10}
+		}
+		return nil
+	}
+
+	target := ""
+	if opts.output == "" {
+		if currentVersionErr == nil && !available {
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "spt is already up to date: current=%s latest=%s\n", current, latestVersion.String())
+			return nil
+		}
+		if updateRuntimeGOOS() == "windows" {
+			return updateUserError(cmd, "running-binary self-update is not enabled on Windows yet; use --output <path> to download the verified release binary")
+		}
+		if ok, reason := updater.CanSelfUpdateCurrentBuild(current); !ok {
+			return updateUserError(cmd, "cannot self-update this build (%s): %s", current, reason)
+		}
+		exe, err := updateExecutable()
+		if err != nil {
+			return updateUserError(cmd, "failed to resolve current executable: %v", err)
+		}
+		target, err = updater.ResolveExecutableTarget(exe)
+		if err != nil {
+			return updateUserError(cmd, "failed to resolve executable target %s: %v", exe, err)
+		}
+		if err := updateVerifyReplaceAccess(target); err != nil {
+			return updateUserError(cmd, "cannot replace %s before downloading update: %v. Re-run with sufficient privileges (for example sudo) or use --output <path> to write the release binary elsewhere", target, err)
+		}
+		warnImageOverride(cmd)
+		if err := confirmUpdateIfNeeded(cmd, opts, latestVersion.String(), target, latest.HTMLURL, current); err != nil {
+			return err
+		}
+	} else if currentVersionErr == nil && !available {
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "spt is already up to date: current=%s latest=%s\n", current, latestVersion.String())
+		return nil
+	}
+
 	assetName, err := updater.AssetNameForPlatform(latestVersion.String(), updateRuntimeGOOS(), updateRuntimeGOARCH())
 	if err != nil {
 		return updateUserError(cmd, "%v", err)
@@ -120,31 +170,8 @@ func runUpdateCommand(cmd *cobra.Command, opts *updateOptions) error {
 		return updateUserError(cmd, "%v", err)
 	}
 	checksumAsset, err := updater.FindAsset(latest.Assets, updater.ChecksumAssetName)
-	if err != nil && !opts.check {
+	if err != nil {
 		return updateUserError(cmd, "%v", err)
-	}
-
-	current := updateCurrentVersion()
-	available := updateAvailableForCurrent(current, latestVersion)
-	if opts.check {
-		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "current=%s latest=%s available=%t\n", current, latestVersion.String(), available)
-		if available {
-			return &ExitCodeError{Code: 10}
-		}
-		return nil
-	}
-	if !available {
-		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "spt is already up to date: current=%s latest=%s\n", current, latestVersion.String())
-		return nil
-	}
-	if opts.output == "" {
-		if ok, reason := updater.CanSelfUpdateCurrentBuild(current); !ok {
-			return updateUserError(cmd, "cannot self-update this build (%s): %s", current, reason)
-		}
-		warnImageOverride(cmd)
-		if err := confirmUpdateIfNeeded(cmd, opts, latestVersion.String()); err != nil {
-			return err
-		}
 	}
 
 	assetBytes, err := client.DownloadAsset(ctx, asset)
@@ -173,27 +200,11 @@ func runUpdateCommand(cmd *cobra.Command, opts *updateOptions) error {
 		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Wrote spt %s to %s\n", latestVersion.String(), opts.output)
 		return nil
 	}
-	exe, err := updateExecutable()
-	if err != nil {
-		return updateUserError(cmd, "failed to resolve current executable: %v", err)
-	}
-	target, err := updater.ResolveExecutableTarget(exe)
-	if err != nil {
-		return updateUserError(cmd, "failed to resolve executable target %s: %v", exe, err)
-	}
 	if err := updater.ReplaceExecutable(target, binary); err != nil {
 		return updateUserError(cmd, "failed to replace %s: %v", target, err)
 	}
 	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Update complete: installed spt %s at %s. Re-run spt to use the new version.\n", latestVersion.String(), target)
 	return nil
-}
-
-func updateAvailableForCurrent(current string, latest updater.Version) bool {
-	currentVersion, err := updater.ParseVersion(current)
-	if err != nil {
-		return true
-	}
-	return updater.UpdateAvailable(currentVersion, latest)
 }
 
 func resolveUpdateToken(flagToken string) string {
@@ -212,18 +223,19 @@ func warnImageOverride(cmd *cobra.Command) {
 	}
 }
 
-func confirmUpdateIfNeeded(cmd *cobra.Command, opts *updateOptions, latest string) error {
+func confirmUpdateIfNeeded(cmd *cobra.Command, opts *updateOptions, latest, target, releaseURL, current string) error {
 	if opts.yes {
 		return nil
 	}
-	if !isTerminalInput(cmd.InOrStdin()) {
+	if !updateIsTerminalInput(cmd.InOrStdin()) {
 		return updateUserError(cmd, "non-interactive update requires --yes")
 	}
-	_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Install spt %s? [y/N] ", latest)
-	var answer string
-	if _, err := fmt.Fscan(cmd.InOrStdin(), &answer); err != nil {
-		return err
+	_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Update spt from %s to %s?\ntarget: %s\nrelease: %s\nProceed? [y/N] ", current, latest, target, releaseURL)
+	answer, err := bufio.NewReader(cmd.InOrStdin()).ReadString('\n')
+	if err != nil && !errors.Is(err, io.EOF) {
+		return updateUserError(cmd, "failed to read confirmation: %v", err)
 	}
+	answer = strings.TrimSpace(answer)
 	if !strings.EqualFold(answer, "y") && !strings.EqualFold(answer, "yes") {
 		return updateUserError(cmd, "update cancelled")
 	}

--- a/cli/cmd/update.go
+++ b/cli/cmd/update.go
@@ -1,0 +1,253 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/dell/storage-performance-tool/cli/internal/buildinfo"
+	"github.com/dell/storage-performance-tool/cli/internal/config"
+	"github.com/dell/storage-performance-tool/cli/internal/constants"
+	updater "github.com/dell/storage-performance-tool/cli/internal/update"
+	"github.com/spf13/cobra"
+)
+
+const defaultUpdateTimeout = 30 * time.Second
+
+type updateOptions struct {
+	check   bool
+	pre     bool
+	yes     bool
+	timeout time.Duration
+	output  string
+	token   string
+}
+
+var (
+	updateCurrentVersion  = func() string { return buildinfo.Version }
+	updateExecutable      = os.Executable
+	updateRuntimeGOOS     = func() string { return runtime.GOOS }
+	updateRuntimeGOARCH   = func() string { return runtime.GOARCH }
+	updateNewGitHubClient = func(timeout time.Duration, token string) updater.GitHubClient {
+		return updater.NewGitHubClient(timeout, token)
+	}
+)
+
+func newUpdateCommand() *cobra.Command {
+	opts := &updateOptions{timeout: defaultUpdateTimeout}
+	cmd := &cobra.Command{
+		Use:           "update",
+		Short:         "Check for and install SPT CLI updates",
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
+			return updatePreRun(cmd)
+		},
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runUpdateCommand(cmd, opts)
+		},
+	}
+	cmd.Flags().BoolVar(&opts.check, "check", false, "Check whether an update is available without downloading or writing files")
+	cmd.Flags().BoolVar(&opts.pre, "pre", false, "Consider prerelease tags")
+	cmd.Flags().BoolVarP(&opts.yes, "yes", "y", false, "Skip confirmation prompts")
+	cmd.Flags().DurationVar(&opts.timeout, "timeout", defaultUpdateTimeout, "Network timeout")
+	cmd.Flags().StringVar(&opts.output, "output", "", "Write the release binary to this path instead of replacing the running binary")
+	cmd.Flags().StringVar(&opts.token, "token", "", "GitHub token for API rate limits; prefer GITHUB_TOKEN or SPT_GITHUB_TOKEN")
+	return cmd
+}
+
+func updatePreRun(cmd *cobra.Command) error {
+	config.LoadDotEnv()
+	if inheritedFlagChanged(cmd, "log-file") {
+		return initializeLogger()
+	}
+	return nil
+}
+
+func inheritedFlagChanged(cmd *cobra.Command, name string) bool {
+	if f := cmd.Flags().Lookup(name); f != nil && f.Changed {
+		return true
+	}
+	if f := cmd.InheritedFlags().Lookup(name); f != nil && f.Changed {
+		return true
+	}
+	return false
+}
+
+func runUpdateCommand(cmd *cobra.Command, opts *updateOptions) error {
+	if opts.check && opts.output != "" {
+		return updateUserError(cmd, "--check cannot be combined with --output")
+	}
+	if opts.check && opts.yes {
+		return updateUserError(cmd, "--check cannot be combined with --yes")
+	}
+	if opts.timeout <= 0 {
+		return updateUserError(cmd, "--timeout must be positive")
+	}
+
+	ctx, cancel := context.WithTimeout(cmd.Context(), opts.timeout)
+	defer cancel()
+
+	token := resolveUpdateToken(opts.token)
+	client := updateNewGitHubClient(opts.timeout, token)
+	releases, err := client.ListReleases(ctx)
+	if err != nil {
+		return updateUserError(cmd, "failed to list GitHub releases: %v", err)
+	}
+	channel := updater.ChannelStable
+	if opts.pre {
+		channel = updater.ChannelPrerelease
+	}
+	latest, err := updater.SelectLatestRelease(releases, channel)
+	if err != nil {
+		return updateUserError(cmd, "failed to select latest release: %v", err)
+	}
+	latestVersion, err := latest.Version()
+	if err != nil {
+		return updateUserError(cmd, "failed to parse latest release tag %q: %v", latest.TagName, err)
+	}
+	assetName, err := updater.AssetNameForPlatform(latestVersion.String(), updateRuntimeGOOS(), updateRuntimeGOARCH())
+	if err != nil {
+		return updateUserError(cmd, "%v", err)
+	}
+	asset, err := updater.FindAsset(latest.Assets, assetName)
+	if err != nil {
+		return updateUserError(cmd, "%v", err)
+	}
+	checksumAsset, err := updater.FindAsset(latest.Assets, updater.ChecksumAssetName)
+	if err != nil && !opts.check {
+		return updateUserError(cmd, "%v", err)
+	}
+
+	current := updateCurrentVersion()
+	available := updateAvailableForCurrent(current, latestVersion)
+	if opts.check {
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "current=%s latest=%s available=%t\n", current, latestVersion.String(), available)
+		if available {
+			return &ExitCodeError{Code: 10}
+		}
+		return nil
+	}
+	if !available {
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "spt is already up to date: current=%s latest=%s\n", current, latestVersion.String())
+		return nil
+	}
+	if opts.output == "" {
+		if ok, reason := updater.CanSelfUpdateCurrentBuild(current); !ok {
+			return updateUserError(cmd, "cannot self-update this build (%s): %s", current, reason)
+		}
+		warnImageOverride(cmd)
+		if err := confirmUpdateIfNeeded(cmd, opts, latestVersion.String()); err != nil {
+			return err
+		}
+	}
+
+	assetBytes, err := client.DownloadAsset(ctx, asset)
+	if err != nil {
+		return updateUserError(cmd, "failed to download %s: %v", asset.Name, err)
+	}
+	checksumBytes, err := client.DownloadAsset(ctx, checksumAsset)
+	if err != nil {
+		return updateUserError(cmd, "failed to download %s: %v", checksumAsset.Name, err)
+	}
+	wantChecksum, err := updater.FindChecksum(checksumBytes, asset.Name)
+	if err != nil {
+		return updateUserError(cmd, "%v", err)
+	}
+	if err := updater.VerifyChecksum(assetBytes, wantChecksum); err != nil {
+		return updateUserError(cmd, "%v", err)
+	}
+	binary, err := updater.ExtractBinary(asset.Name, assetBytes)
+	if err != nil {
+		return updateUserError(cmd, "failed to extract %s: %v", asset.Name, err)
+	}
+	if opts.output != "" {
+		if err := updater.WriteFileAtomic(opts.output, binary, 0o755); err != nil {
+			return updateUserError(cmd, "failed to write %s: %v", opts.output, err)
+		}
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Wrote spt %s to %s\n", latestVersion.String(), opts.output)
+		return nil
+	}
+	exe, err := updateExecutable()
+	if err != nil {
+		return updateUserError(cmd, "failed to resolve current executable: %v", err)
+	}
+	target, err := updater.ResolveExecutableTarget(exe)
+	if err != nil {
+		return updateUserError(cmd, "failed to resolve executable target %s: %v", exe, err)
+	}
+	if err := updater.ReplaceExecutable(target, binary); err != nil {
+		return updateUserError(cmd, "failed to replace %s: %v", target, err)
+	}
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Update complete: installed spt %s at %s. Re-run spt to use the new version.\n", latestVersion.String(), target)
+	return nil
+}
+
+func updateAvailableForCurrent(current string, latest updater.Version) bool {
+	currentVersion, err := updater.ParseVersion(current)
+	if err != nil {
+		return true
+	}
+	return updater.UpdateAvailable(currentVersion, latest)
+}
+
+func resolveUpdateToken(flagToken string) string {
+	if strings.TrimSpace(flagToken) != "" {
+		return strings.TrimSpace(flagToken)
+	}
+	if v := strings.TrimSpace(os.Getenv(constants.EnvSptGitHubToken)); v != "" {
+		return v
+	}
+	return strings.TrimSpace(os.Getenv("GITHUB_TOKEN"))
+}
+
+func warnImageOverride(cmd *cobra.Command) {
+	if image := strings.TrimSpace(os.Getenv(constants.EnvSptImage)); image != "" {
+		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "warning: %s is set; engine runs will continue using %s until the override is changed or removed\n", constants.EnvSptImage, image)
+	}
+}
+
+func confirmUpdateIfNeeded(cmd *cobra.Command, opts *updateOptions, latest string) error {
+	if opts.yes {
+		return nil
+	}
+	if !isTerminalInput(cmd.InOrStdin()) {
+		return updateUserError(cmd, "non-interactive update requires --yes")
+	}
+	_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Install spt %s? [y/N] ", latest)
+	var answer string
+	if _, err := fmt.Fscan(cmd.InOrStdin(), &answer); err != nil {
+		return err
+	}
+	if !strings.EqualFold(answer, "y") && !strings.EqualFold(answer, "yes") {
+		return updateUserError(cmd, "update cancelled")
+	}
+	return nil
+}
+
+func isTerminalInput(r io.Reader) bool {
+	f, ok := r.(*os.File)
+	if !ok {
+		return false
+	}
+	info, err := f.Stat()
+	if err != nil {
+		return false
+	}
+	return info.Mode()&os.ModeCharDevice != 0
+}
+
+func updateUserError(cmd *cobra.Command, format string, args ...any) error {
+	msg := fmt.Sprintf(format, args...)
+	_, _ = fmt.Fprintln(cmd.ErrOrStderr(), msg)
+	return errors.New(msg)
+}
+
+func init() {
+	rootCmd.AddCommand(newUpdateCommand())
+}

--- a/cli/cmd/update.go
+++ b/cli/cmd/update.go
@@ -120,7 +120,7 @@ func runUpdateCommand(cmd *cobra.Command, opts *updateOptions) error {
 	}
 	current := updateCurrentVersion()
 	currentVersion, currentVersionErr := updater.ParseVersion(current)
-	available := currentVersionErr == nil && updater.UpdateAvailable(currentVersion, latestVersion)
+	available := currentVersionErr == nil && updater.Available(currentVersion, latestVersion)
 	if opts.check {
 		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "current=%s latest=%s available=%t\n", current, latestVersion.String(), available)
 		if available {

--- a/cli/cmd/update_feedback_test.go
+++ b/cli/cmd/update_feedback_test.go
@@ -42,6 +42,22 @@ func TestUpdateCheckDoesNotRequirePlatformAsset(t *testing.T) {
 	})
 }
 
+func TestUpdateCheckUnsupportedPlatformFails(t *testing.T) {
+	withCustomUpdateServer(t, customUpdateServerOptions{currentVersion: "5.10.4", goos: "linux", goarch: "386"}, func(_ *customUpdateServer) {
+		cmd := newUpdateCommand()
+		cmd.SetArgs([]string{"--check"})
+		var errOut bytes.Buffer
+		cmd.SetErr(&errOut)
+		err := cmd.Execute()
+		if err == nil {
+			t.Fatal("Execute() accepted unsupported check platform")
+		}
+		if !strings.Contains(errOut.String(), "unsupported platform linux/386") {
+			t.Fatalf("stderr = %q", errOut.String())
+		}
+	})
+}
+
 func TestUpdateCheckDevBuildReportsAvailableFalse(t *testing.T) {
 	withCustomUpdateServer(t, customUpdateServerOptions{currentVersion: "dev"}, func(_ *customUpdateServer) {
 		cmd := newUpdateCommand()
@@ -263,7 +279,7 @@ func withCustomUpdateServer(t *testing.T, opts customUpdateServerOptions, fn fun
 		return "amd64"
 	}
 	updateNewGitHubClient = func(timeout time.Duration, token string) updater.GitHubClient {
-		return updater.GitHubClient{HTTPClient: server.Client(), BaseURL: server.URL, Owner: updater.DefaultGitHubOwner, Repo: updater.DefaultGitHubRepo, Token: token, UserAgent: "spt/test"}
+		return updater.GitHubClient{HTTPClient: server.Client(), BaseURL: server.URL, Owner: updater.DefaultGitHubOwner, Repo: updater.DefaultGitHubRepo, Token: token, UserAgent: "spt/test", AllowInsecureLocalHTTP: true}
 	}
 	updateVerifyReplaceAccess = func(string) error { return nil }
 	defer func() {

--- a/cli/cmd/update_feedback_test.go
+++ b/cli/cmd/update_feedback_test.go
@@ -1,0 +1,308 @@
+package cmd
+
+import (
+	"bytes"
+	"compress/gzip"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	updater "github.com/dell/storage-performance-tool/cli/internal/update"
+)
+
+func TestUpdateCheckDoesNotRequirePlatformAsset(t *testing.T) {
+	withCustomUpdateServer(t, customUpdateServerOptions{
+		currentVersion: "5.10.4",
+		releaseAssets:  []updater.Asset{{Name: updater.ChecksumAssetName, BrowserDownloadURL: "https://example.com/SHA256SUMS"}},
+	}, func(_ *customUpdateServer) {
+		cmd := newUpdateCommand()
+		cmd.SetArgs([]string{"--check"})
+		var out bytes.Buffer
+		cmd.SetOut(&out)
+		cmd.SetErr(&bytes.Buffer{})
+		err := cmd.Execute()
+		var exitErr *ExitCodeError
+		if !errors.As(err, &exitErr) || exitErr.Code != 10 {
+			t.Fatalf("Execute() error = %v, want exit 10", err)
+		}
+		if !strings.Contains(out.String(), "available=true") {
+			t.Fatalf("stdout = %q", out.String())
+		}
+	})
+}
+
+func TestUpdateCheckDevBuildReportsAvailableFalse(t *testing.T) {
+	withCustomUpdateServer(t, customUpdateServerOptions{currentVersion: "dev"}, func(_ *customUpdateServer) {
+		cmd := newUpdateCommand()
+		cmd.SetArgs([]string{"--check"})
+		var out bytes.Buffer
+		cmd.SetOut(&out)
+		cmd.SetErr(&bytes.Buffer{})
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("Execute() error = %v, want nil for dev check", err)
+		}
+		if got := strings.TrimSpace(out.String()); got != "current=dev latest=5.10.5 available=false" {
+			t.Fatalf("stdout = %q", got)
+		}
+	})
+}
+
+func TestUpdateAlreadyUpToDateDoesNotDownload(t *testing.T) {
+	withCustomUpdateServer(t, customUpdateServerOptions{currentVersion: "5.10.5"}, func(s *customUpdateServer) {
+		cmd := newUpdateCommand()
+		cmd.SetArgs([]string{"--yes"})
+		var out bytes.Buffer
+		cmd.SetOut(&out)
+		cmd.SetErr(&bytes.Buffer{})
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("Execute() error = %v", err)
+		}
+		if s.assetDownloads != 0 {
+			t.Fatalf("assetDownloads = %d, want 0", s.assetDownloads)
+		}
+		if !strings.Contains(out.String(), "already up to date") {
+			t.Fatalf("stdout = %q", out.String())
+		}
+	})
+}
+
+func TestUpdateChecksumMismatchDoesNotReplace(t *testing.T) {
+	withCustomUpdateServer(t, customUpdateServerOptions{currentVersion: "5.10.4", badChecksum: true}, func(_ *customUpdateServer) {
+		target := filepath.Join(t.TempDir(), "spt")
+		if err := os.WriteFile(target, []byte("old"), 0o755); err != nil {
+			t.Fatalf("WriteFile target: %v", err)
+		}
+		withUpdateExecutable(t, target)
+
+		cmd := newUpdateCommand()
+		cmd.SetArgs([]string{"--yes"})
+		var errOut bytes.Buffer
+		cmd.SetErr(&errOut)
+		err := cmd.Execute()
+		if err == nil {
+			t.Fatal("Execute() accepted checksum mismatch")
+		}
+		got, readErr := os.ReadFile(target)
+		if readErr != nil {
+			t.Fatalf("ReadFile target: %v", readErr)
+		}
+		if string(got) != "old" {
+			t.Fatalf("target was replaced on checksum mismatch: %q", got)
+		}
+		if !strings.Contains(errOut.String(), "checksum mismatch") {
+			t.Fatalf("stderr = %q", errOut.String())
+		}
+	})
+}
+
+func TestUpdateReplaceAccessPrecheckRunsBeforeDownload(t *testing.T) {
+	withCustomUpdateServer(t, customUpdateServerOptions{currentVersion: "5.10.4"}, func(s *customUpdateServer) {
+		target := filepath.Join(t.TempDir(), "spt")
+		if err := os.WriteFile(target, []byte("old"), 0o755); err != nil {
+			t.Fatalf("WriteFile target: %v", err)
+		}
+		withUpdateExecutable(t, target)
+		oldVerify := updateVerifyReplaceAccess
+		updateVerifyReplaceAccess = func(string) error { return errors.New("permission denied") }
+		defer func() { updateVerifyReplaceAccess = oldVerify }()
+
+		cmd := newUpdateCommand()
+		cmd.SetArgs([]string{"--yes"})
+		var errOut bytes.Buffer
+		cmd.SetErr(&errOut)
+		err := cmd.Execute()
+		if err == nil {
+			t.Fatal("Execute() accepted inaccessible target")
+		}
+		if s.assetDownloads != 0 {
+			t.Fatalf("assetDownloads = %d, want 0 before access check failure", s.assetDownloads)
+		}
+		for _, want := range []string{"cannot replace", "use --output", "sudo"} {
+			if !strings.Contains(errOut.String(), want) {
+				t.Fatalf("stderr = %q missing %q", errOut.String(), want)
+			}
+		}
+	})
+}
+
+func TestUpdateBlocksWindowsSelfReplaceBeforeDownload(t *testing.T) {
+	withCustomUpdateServer(t, customUpdateServerOptions{currentVersion: "5.10.4", goos: "windows", goarch: "amd64"}, func(s *customUpdateServer) {
+		cmd := newUpdateCommand()
+		cmd.SetArgs([]string{"--yes"})
+		var errOut bytes.Buffer
+		cmd.SetErr(&errOut)
+		err := cmd.Execute()
+		if err == nil {
+			t.Fatal("Execute() accepted Windows self-replace")
+		}
+		if s.assetDownloads != 0 {
+			t.Fatalf("assetDownloads = %d, want 0", s.assetDownloads)
+		}
+		if !strings.Contains(errOut.String(), "use --output") {
+			t.Fatalf("stderr = %q", errOut.String())
+		}
+	})
+}
+
+func TestUpdateUnsupportedPlatformFailsAtCommandLevel(t *testing.T) {
+	withCustomUpdateServer(t, customUpdateServerOptions{currentVersion: "5.10.4", goos: "plan9", goarch: "mips"}, func(_ *customUpdateServer) {
+		cmd := newUpdateCommand()
+		cmd.SetArgs([]string{"--yes"})
+		var errOut bytes.Buffer
+		cmd.SetErr(&errOut)
+		err := cmd.Execute()
+		if err == nil {
+			t.Fatal("Execute() accepted unsupported platform")
+		}
+		if !strings.Contains(errOut.String(), "unsupported platform") {
+			t.Fatalf("stderr = %q", errOut.String())
+		}
+	})
+}
+
+func TestConfirmUpdateIfNeededReadsLine(t *testing.T) {
+	cases := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		{name: "empty defaults no", input: "\n", wantErr: true},
+		{name: "n cancels", input: "n\n", wantErr: true},
+		{name: "yes proceeds", input: "yes\n", wantErr: false},
+		{name: "y proceeds", input: "y\n", wantErr: false},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := newUpdateCommand()
+			cmd.SetIn(strings.NewReader(tt.input))
+			cmd.SetErr(&bytes.Buffer{})
+			oldIsTerminal := updateIsTerminalInput
+			updateIsTerminalInput = func(io.Reader) bool { return true }
+			defer func() { updateIsTerminalInput = oldIsTerminal }()
+			err := confirmUpdateIfNeeded(cmd, &updateOptions{}, "5.10.5", "/tmp/spt", "https://example.com/release", "5.10.4")
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("confirmUpdateIfNeeded error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+type customUpdateServerOptions struct {
+	currentVersion string
+	releaseAssets  []updater.Asset
+	badChecksum    bool
+	goos           string
+	goarch         string
+}
+
+type customUpdateServer struct {
+	server         *httptest.Server
+	assetDownloads int
+}
+
+func withCustomUpdateServer(t *testing.T, opts customUpdateServerOptions, fn func(*customUpdateServer)) {
+	t.Helper()
+	binary := []byte("release binary")
+	archive := gzipFeedbackBytes(t, binary)
+	sum := sha256.Sum256(archive)
+	if opts.badChecksum {
+		sum = sha256.Sum256([]byte("wrong"))
+	}
+	checksumLine := fmt.Sprintf("%s  spt-5.10.5-linux-amd64.gz\n", hex.EncodeToString(sum[:]))
+	state := &customUpdateServer{}
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	state.server = server
+	assets := opts.releaseAssets
+	if assets == nil {
+		assets = []updater.Asset{
+			{Name: "spt-5.10.5-linux-amd64.gz", BrowserDownloadURL: server.URL + "/assets/spt.gz", Size: int64(len(archive))},
+			{Name: updater.ChecksumAssetName, BrowserDownloadURL: server.URL + "/assets/SHA256SUMS", Size: int64(len(checksumLine))},
+		}
+	}
+	mux.HandleFunc("/repos/dell/storage-performance-tool/releases", func(w http.ResponseWriter, _ *http.Request) {
+		writeFeedbackJSON(t, w, []updater.Release{{TagName: "v5.10.5", HTMLURL: "https://github.com/dell/storage-performance-tool/releases/tag/v5.10.5", Assets: assets}})
+	})
+	mux.HandleFunc("/assets/spt.gz", func(w http.ResponseWriter, _ *http.Request) {
+		state.assetDownloads++
+		_, _ = w.Write(archive)
+	})
+	mux.HandleFunc("/assets/SHA256SUMS", func(w http.ResponseWriter, _ *http.Request) {
+		state.assetDownloads++
+		_, _ = w.Write([]byte(checksumLine))
+	})
+	defer server.Close()
+
+	oldVersion := updateCurrentVersion
+	oldGOOS := updateRuntimeGOOS
+	oldGOARCH := updateRuntimeGOARCH
+	oldClient := updateNewGitHubClient
+	oldVerify := updateVerifyReplaceAccess
+	updateCurrentVersion = func() string { return opts.currentVersion }
+	updateRuntimeGOOS = func() string {
+		if opts.goos != "" {
+			return opts.goos
+		}
+		return "linux"
+	}
+	updateRuntimeGOARCH = func() string {
+		if opts.goarch != "" {
+			return opts.goarch
+		}
+		return "amd64"
+	}
+	updateNewGitHubClient = func(timeout time.Duration, token string) updater.GitHubClient {
+		return updater.GitHubClient{HTTPClient: server.Client(), BaseURL: server.URL, Owner: updater.DefaultGitHubOwner, Repo: updater.DefaultGitHubRepo, Token: token, UserAgent: "spt/test"}
+	}
+	updateVerifyReplaceAccess = func(string) error { return nil }
+	defer func() {
+		updateCurrentVersion = oldVersion
+		updateRuntimeGOOS = oldGOOS
+		updateRuntimeGOARCH = oldGOARCH
+		updateNewGitHubClient = oldClient
+		updateVerifyReplaceAccess = oldVerify
+	}()
+
+	fn(state)
+}
+
+func withUpdateExecutable(t *testing.T, target string) {
+	t.Helper()
+	oldExecutable := updateExecutable
+	updateExecutable = func() (string, error) { return target, nil }
+	t.Cleanup(func() { updateExecutable = oldExecutable })
+}
+
+func gzipFeedbackBytes(t *testing.T, data []byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	zw := gzip.NewWriter(&buf)
+	if _, err := zw.Write(data); err != nil {
+		t.Fatalf("gzip write: %v", err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("gzip close: %v", err)
+	}
+	return buf.Bytes()
+}
+
+func writeFeedbackJSON(t *testing.T, w http.ResponseWriter, v any) {
+	t.Helper()
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		t.Fatalf("json encode: %v", err)
+	}
+}
+
+var _ = runtime.GOOS

--- a/cli/cmd/update_integration_test.go
+++ b/cli/cmd/update_integration_test.go
@@ -156,7 +156,7 @@ func withUpdateCommandTestHooks(t *testing.T, currentVersion string, fn func(*ht
 	updateRuntimeGOOS = func() string { return "linux" }
 	updateRuntimeGOARCH = func() string { return "amd64" }
 	updateNewGitHubClient = func(timeout time.Duration, token string) updater.GitHubClient {
-		return updater.GitHubClient{HTTPClient: server.Client(), BaseURL: server.URL, Owner: updater.DefaultGitHubOwner, Repo: updater.DefaultGitHubRepo, Token: token}
+		return updater.GitHubClient{HTTPClient: server.Client(), BaseURL: server.URL, Owner: updater.DefaultGitHubOwner, Repo: updater.DefaultGitHubRepo, Token: token, AllowInsecureLocalHTTP: true}
 	}
 	defer func() {
 		updateCurrentVersion = oldVersion

--- a/cli/cmd/update_integration_test.go
+++ b/cli/cmd/update_integration_test.go
@@ -1,0 +1,190 @@
+package cmd
+
+import (
+	"bytes"
+	"compress/gzip"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dell/storage-performance-tool/cli/internal/constants"
+	updater "github.com/dell/storage-performance-tool/cli/internal/update"
+)
+
+func TestUpdateCheckReportsAvailableWithoutDefaultLog(t *testing.T) {
+	withUpdateCommandTestHooks(t, "5.10.4", func(server *httptest.Server) {
+		dir := t.TempDir()
+		oldWD, err := os.Getwd()
+		if err != nil {
+			t.Fatalf("Getwd: %v", err)
+		}
+		if err := os.Chdir(dir); err != nil {
+			t.Fatalf("Chdir: %v", err)
+		}
+		defer os.Chdir(oldWD)
+
+		cmd := newUpdateCommand()
+		cmd.SetArgs([]string{"--check"})
+		var out, errOut bytes.Buffer
+		cmd.SetOut(&out)
+		cmd.SetErr(&errOut)
+		err = cmd.Execute()
+		var exitErr *ExitCodeError
+		if !errors.As(err, &exitErr) || exitErr.Code != 10 {
+			t.Fatalf("Execute() error = %v, want ExitCodeError 10", err)
+		}
+		if got := strings.TrimSpace(out.String()); got != "current=5.10.4 latest=5.10.5 available=true" {
+			t.Fatalf("stdout = %q", got)
+		}
+		if errOut.String() != "" {
+			t.Fatalf("stderr = %q", errOut.String())
+		}
+		if _, err := os.Stat(filepath.Join(dir, "spt.log")); !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("default spt.log was created or stat failed: %v", err)
+		}
+	})
+}
+
+func TestUpdateOutputDownloadsVerifiesAndWritesBinary(t *testing.T) {
+	withUpdateCommandTestHooks(t, "dev", func(server *httptest.Server) {
+		outPath := filepath.Join(t.TempDir(), "spt-release")
+		cmd := newUpdateCommand()
+		cmd.SetArgs([]string{"--output", outPath})
+		var out bytes.Buffer
+		cmd.SetOut(&out)
+		cmd.SetErr(&bytes.Buffer{})
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("Execute() error = %v", err)
+		}
+		got, err := os.ReadFile(outPath)
+		if err != nil {
+			t.Fatalf("ReadFile output: %v", err)
+		}
+		if string(got) != "release binary" {
+			t.Fatalf("output file = %q", got)
+		}
+		if !strings.Contains(out.String(), "Wrote spt 5.10.5") {
+			t.Fatalf("stdout = %q", out.String())
+		}
+	})
+}
+
+func TestUpdateRefusesDevBuildSelfReplace(t *testing.T) {
+	withUpdateCommandTestHooks(t, "5.10.4-dev+abc1234", func(server *httptest.Server) {
+		cmd := newUpdateCommand()
+		cmd.SetArgs([]string{"--yes"})
+		var errOut bytes.Buffer
+		cmd.SetErr(&errOut)
+		err := cmd.Execute()
+		if err == nil {
+			t.Fatal("Execute() accepted dev build self-replace")
+		}
+		if !strings.Contains(errOut.String(), "cannot self-update this build") {
+			t.Fatalf("stderr = %q", errOut.String())
+		}
+	})
+}
+
+func TestUpdateWarnsForImageOverrideWithYes(t *testing.T) {
+	withUpdateCommandTestHooks(t, "5.10.4", func(server *httptest.Server) {
+		t.Setenv(constants.EnvSptImage, "example.com/spt:pinned")
+		target := filepath.Join(t.TempDir(), "current-spt")
+		if err := os.WriteFile(target, []byte("old"), 0o755); err != nil {
+			t.Fatalf("WriteFile target: %v", err)
+		}
+		oldExecutable := updateExecutable
+		updateExecutable = func() (string, error) { return target, nil }
+		defer func() { updateExecutable = oldExecutable }()
+
+		cmd := newUpdateCommand()
+		cmd.SetArgs([]string{"--yes"})
+		var errOut bytes.Buffer
+		cmd.SetOut(&bytes.Buffer{})
+		cmd.SetErr(&errOut)
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("Execute() error = %v", err)
+		}
+		if !strings.Contains(errOut.String(), constants.EnvSptImage+" is set") {
+			t.Fatalf("stderr = %q", errOut.String())
+		}
+	})
+}
+
+func withUpdateCommandTestHooks(t *testing.T, currentVersion string, fn func(*httptest.Server)) {
+	t.Helper()
+	binary := []byte("release binary")
+	archive := gzipTestBytes(t, binary)
+	sum := sha256.Sum256(archive)
+	checksumLine := fmt.Sprintf("%s  spt-5.10.5-linux-amd64.gz\n", hex.EncodeToString(sum[:]))
+
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	mux.HandleFunc("/repos/dell/storage-performance-tool/releases", func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("per_page") != "100" {
+			t.Fatalf("per_page = %q", r.URL.Query().Get("per_page"))
+		}
+		writeUpdateJSON(t, w, []updater.Release{{
+			TagName: "v5.10.5",
+			Assets: []updater.Asset{
+				{Name: "spt-5.10.5-linux-amd64.gz", BrowserDownloadURL: server.URL + "/assets/spt.gz", Size: int64(len(archive))},
+				{Name: updater.ChecksumAssetName, BrowserDownloadURL: server.URL + "/assets/SHA256SUMS", Size: int64(len(checksumLine))},
+			},
+		}})
+	})
+	mux.HandleFunc("/assets/spt.gz", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(archive)
+	})
+	mux.HandleFunc("/assets/SHA256SUMS", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(checksumLine))
+	})
+	defer server.Close()
+
+	oldVersion := updateCurrentVersion
+	oldGOOS := updateRuntimeGOOS
+	oldGOARCH := updateRuntimeGOARCH
+	oldClient := updateNewGitHubClient
+	updateCurrentVersion = func() string { return currentVersion }
+	updateRuntimeGOOS = func() string { return "linux" }
+	updateRuntimeGOARCH = func() string { return "amd64" }
+	updateNewGitHubClient = func(timeout time.Duration, token string) updater.GitHubClient {
+		return updater.GitHubClient{HTTPClient: server.Client(), BaseURL: server.URL, Owner: updater.DefaultGitHubOwner, Repo: updater.DefaultGitHubRepo, Token: token}
+	}
+	defer func() {
+		updateCurrentVersion = oldVersion
+		updateRuntimeGOOS = oldGOOS
+		updateRuntimeGOARCH = oldGOARCH
+		updateNewGitHubClient = oldClient
+	}()
+
+	fn(server)
+}
+
+func gzipTestBytes(t *testing.T, data []byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	zw := gzip.NewWriter(&buf)
+	if _, err := zw.Write(data); err != nil {
+		t.Fatalf("gzip write: %v", err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("gzip close: %v", err)
+	}
+	return buf.Bytes()
+}
+
+func writeUpdateJSON(t *testing.T, w http.ResponseWriter, v any) {
+	t.Helper()
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		t.Fatalf("json encode: %v", err)
+	}
+}

--- a/cli/cmd/update_test.go
+++ b/cli/cmd/update_test.go
@@ -43,6 +43,30 @@ func TestUpdatePreRunDoesNotCreateDefaultLogFile(t *testing.T) {
 	}
 }
 
+func TestUpdatePreRunHonorsExplicitLogFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "update.log")
+	oldDebug, oldLevel, oldFile, oldAppend := debug, logLevel, logFile, logAppend
+	defer func() {
+		debug, logLevel, logFile, logAppend = oldDebug, oldLevel, oldFile, oldAppend
+	}()
+	debug = false
+	logLevel = "info"
+	logAppend = false
+
+	cmd := newUpdateCommand()
+	cmd.Flags().StringVar(&logFile, "log-file", "spt.log", "")
+	if err := cmd.Flags().Set("log-file", path); err != nil {
+		t.Fatalf("set log-file: %v", err)
+	}
+	if err := cmd.PersistentPreRunE(cmd, nil); err != nil {
+		t.Fatalf("update pre-run returned error: %v", err)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("explicit log file was not created: %v", err)
+	}
+}
+
 func TestUpdateRejectsCheckWithOutput(t *testing.T) {
 	cmd := newUpdateCommand()
 	cmd.SetArgs([]string{"--check", "--output", filepath.Join(t.TempDir(), "spt")})

--- a/cli/cmd/update_test.go
+++ b/cli/cmd/update_test.go
@@ -1,0 +1,72 @@
+package cmd
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestExecuteCommandCodeMapsExitCodeError(t *testing.T) {
+	cmd := &cobra.Command{
+		Use: "test",
+		RunE: func(*cobra.Command, []string) error {
+			return &ExitCodeError{Code: 10}
+		},
+	}
+	if got := executeCommandCode(cmd); got != 10 {
+		t.Fatalf("executeCommandCode = %d, want 10", got)
+	}
+}
+
+func TestUpdatePreRunDoesNotCreateDefaultLogFile(t *testing.T) {
+	dir := t.TempDir()
+	oldWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("Chdir: %v", err)
+	}
+	defer os.Chdir(oldWD)
+
+	cmd := newUpdateCommand()
+	if err := cmd.PersistentPreRunE(cmd, nil); err != nil {
+		t.Fatalf("update pre-run returned error: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "spt.log")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("default spt.log was created or stat failed: %v", err)
+	}
+}
+
+func TestUpdateRejectsCheckWithOutput(t *testing.T) {
+	cmd := newUpdateCommand()
+	cmd.SetArgs([]string{"--check", "--output", filepath.Join(t.TempDir(), "spt")})
+	var errBuf bytes.Buffer
+	cmd.SetErr(&errBuf)
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("update accepted --check with --output")
+	}
+	if !strings.Contains(errBuf.String(), "--check cannot be combined with --output") {
+		t.Fatalf("stderr = %q", errBuf.String())
+	}
+}
+
+func TestUpdateRejectsCheckWithYes(t *testing.T) {
+	cmd := newUpdateCommand()
+	cmd.SetArgs([]string{"--check", "--yes"})
+	var errBuf bytes.Buffer
+	cmd.SetErr(&errBuf)
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("update accepted --check with --yes")
+	}
+	if !strings.Contains(errBuf.String(), "--check cannot be combined with --yes") {
+		t.Fatalf("stderr = %q", errBuf.String())
+	}
+}

--- a/cli/docs/SPT_SYNTAX.md
+++ b/cli/docs/SPT_SYNTAX.md
@@ -972,7 +972,7 @@ current=5.10.4 latest=5.11.0 available=true
 | `tables` workload (S3 Tables / Iceberg) | Implemented |
 | `verify` command | Implemented |
 | `status` command | Implemented |
-| `update` command | Implemented |
+| `update` command | Implemented (`--output` only for Windows self-update) |
 | Post-test cleanup (`--cleanup`) | Implemented |
 | Auto-results retrieval | Implemented |
 | Save/reuse item lists (`--save-items` / `--items-file`) | Implemented |

--- a/cli/docs/SPT_SYNTAX.md
+++ b/cli/docs/SPT_SYNTAX.md
@@ -10,6 +10,7 @@ The command structure follows the `docker` CLI pattern (`command subcommand [opt
 - `spt replay`: Replay archived SPT or legacy Mongoose workload artifacts against a current S3 target.
 - `spt verify`: Validate nodes for distributed testing infrastructure readiness.
 - `spt status`: Inspect live readiness and metrics snapshots for running nodes.
+- `spt update`: Check for and install newer SPT CLI releases.
 - `spt results`: *(Stub — not yet implemented)* Manage past benchmark results.
 - `spt version`: Print build metadata (version, commit, build date).
 
@@ -911,6 +912,53 @@ Node status (port 9999)
 
 ---
 
+## Maintenance Command: `spt update`
+
+The `update` command checks GitHub Releases for newer SPT CLI binaries and can
+install a verified release binary. Release downloads are checked against the
+release `SHA256SUMS` file before any output file or running binary is replaced.
+This is integrity verification, not signed authenticity verification.
+
+### Syntax
+
+```bash
+spt update [--check] [--pre] [--yes] [--timeout 30s] [--output <path>] [--token <token>]
+```
+
+### Options
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--check` | `false` | Report current/latest CLI versions without downloading or writing files |
+| `--pre` | `false` | Include prerelease tags such as `-rc.1` when selecting the latest release |
+| `--yes`, `-y` | `false` | Skip the interactive confirmation prompt for self-replacement |
+| `--timeout` | `30s` | Network timeout for GitHub API and asset downloads |
+| `--output` | `""` | Write the release binary to an explicit path instead of replacing the running binary |
+| `--token` | `""` | GitHub token for rate limits/private assets; prefer `SPT_GITHUB_TOKEN` or `GITHUB_TOKEN` |
+
+### Exit Codes for `--check`
+
+| Exit code | Meaning |
+|-----------|---------|
+| `0` | Check succeeded and the CLI is already up to date |
+| `10` | Check succeeded and a newer release is available |
+| `1` | Check failed, for example due to network, rate-limit, parse, or unsupported-platform errors |
+
+`--check` prints one stable line, for example:
+
+```text
+current=5.10.4 latest=5.11.0 available=true
+```
+
+### Notes
+
+- Local/dev builds such as `dev`, `*-dev+<commit>`, and `*-SNAPSHOT` refuse running-binary self-update so local development binaries are not overwritten by a GitHub release.
+- Dev builds may still use `--output <path>` to download and verify a release binary without replacing themselves.
+- If `SPT_IMAGE` is set, self-update warns that engine runs will continue using the pinned image until the override is changed or removed.
+- `--check` does not query GHCR and does not create or truncate the default `spt.log`; an explicitly supplied `--log-file` is still honored.
+
+---
+
 ## Implementation Status
 
 | Feature | Status |
@@ -922,6 +970,7 @@ Node status (port 9999)
 | `tables` workload (S3 Tables / Iceberg) | Implemented |
 | `verify` command | Implemented |
 | `status` command | Implemented |
+| `update` command | Implemented |
 | Post-test cleanup (`--cleanup`) | Implemented |
 | Auto-results retrieval | Implemented |
 | Save/reuse item lists (`--save-items` / `--items-file`) | Implemented |

--- a/cli/docs/SPT_SYNTAX.md
+++ b/cli/docs/SPT_SYNTAX.md
@@ -954,6 +954,8 @@ current=5.10.4 latest=5.11.0 available=true
 
 - Local/dev builds such as `dev`, `*-dev+<commit>`, and `*-SNAPSHOT` refuse running-binary self-update so local development binaries are not overwritten by a GitHub release.
 - Dev builds may still use `--output <path>` to download and verify a release binary without replacing themselves.
+- Windows running-binary self-update is disabled for now; use `--output <path>` to download a verified Windows release binary.
+- Before downloading assets for running-binary replacement, `spt update` verifies that the resolved target can be replaced and reports whether to re-run with elevated privileges or use `--output`.
 - If `SPT_IMAGE` is set, self-update warns that engine runs will continue using the pinned image until the override is changed or removed.
 - `--check` does not query GHCR and does not create or truncate the default `spt.log`; an explicitly supplied `--log-file` is still honored.
 

--- a/cli/internal/constants/envvars.go
+++ b/cli/internal/constants/envvars.go
@@ -3,6 +3,7 @@ package constants
 // Environment variable keys used by spt
 const (
 	EnvSptImage       = "SPT_IMAGE"
+	EnvSptGitHubToken = "SPT_GITHUB_TOKEN" // #nosec G101 -- env var name only
 	EnvHosts          = "HOSTS"
 	EnvS3Endpoint     = "S3_ENDPOINT"
 	EnvS3AccessKey    = "S3_ACCESS_KEY" // #nosec G101 -- env var names only

--- a/cli/internal/update/archive.go
+++ b/cli/internal/update/archive.go
@@ -1,0 +1,93 @@
+package update
+
+import (
+	"archive/zip"
+	"bytes"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"path/filepath"
+	"strings"
+)
+
+const MaxDecompressedBinaryBytes = 250 * 1024 * 1024
+
+func ExtractBinary(assetName string, archiveBytes []byte) ([]byte, error) {
+	return extractBinaryWithLimit(assetName, archiveBytes, MaxDecompressedBinaryBytes)
+}
+
+func extractBinaryWithLimit(assetName string, archiveBytes []byte, maxBytes int64) ([]byte, error) {
+	switch {
+	case strings.HasSuffix(assetName, ".gz"):
+		return extractGzipBinary(archiveBytes, maxBytes)
+	case strings.HasSuffix(assetName, ".zip"):
+		return extractZipBinary(assetName, archiveBytes, maxBytes)
+	default:
+		return nil, fmt.Errorf("unsupported archive format for %q", assetName)
+	}
+}
+
+func extractGzipBinary(archiveBytes []byte, maxBytes int64) ([]byte, error) {
+	zr, err := gzip.NewReader(bytes.NewReader(archiveBytes))
+	if err != nil {
+		return nil, err
+	}
+	defer zr.Close()
+	return readBounded(zr, maxBytes)
+}
+
+func extractZipBinary(assetName string, archiveBytes []byte, maxBytes int64) ([]byte, error) {
+	zr, err := zip.NewReader(bytes.NewReader(archiveBytes), int64(len(archiveBytes)))
+	if err != nil {
+		return nil, err
+	}
+	expectedName, err := expectedZipMemberName(assetName)
+	if err != nil {
+		return nil, err
+	}
+	if len(zr.File) != 1 {
+		return nil, fmt.Errorf("zip archive must contain exactly one file")
+	}
+	entry := zr.File[0]
+	if !safeZipEntryName(entry.Name) || entry.Name != expectedName {
+		return nil, fmt.Errorf("zip archive contains unexpected entry %q", entry.Name)
+	}
+	r, err := entry.Open()
+	if err != nil {
+		return nil, err
+	}
+	defer r.Close()
+	return readBounded(r, maxBytes)
+}
+
+func expectedZipMemberName(assetName string) (string, error) {
+	base := strings.TrimSuffix(assetName, ".zip")
+	if base == assetName {
+		return "", fmt.Errorf("asset %q is not a zip archive", assetName)
+	}
+	return base + ".exe", nil
+}
+
+func safeZipEntryName(name string) bool {
+	if name == "" || name != filepath.Base(name) {
+		return false
+	}
+	if filepath.IsAbs(name) || strings.HasPrefix(name, "/") || strings.HasPrefix(name, `\`) {
+		return false
+	}
+	if strings.Contains(name, "..") || strings.ContainsAny(name, `/:\`) {
+		return false
+	}
+	return true
+}
+
+func readBounded(r io.Reader, maxBytes int64) ([]byte, error) {
+	data, err := io.ReadAll(io.LimitReader(r, maxBytes+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(data)) > maxBytes {
+		return nil, fmt.Errorf("decompressed binary exceeds size limit")
+	}
+	return data, nil
+}

--- a/cli/internal/update/archive.go
+++ b/cli/internal/update/archive.go
@@ -1,3 +1,4 @@
+// Package update implements release discovery, download, verification, and replacement helpers.
 package update
 
 import (
@@ -10,8 +11,10 @@ import (
 	"strings"
 )
 
+// MaxDecompressedBinaryBytes is the maximum extracted CLI binary size.
 const MaxDecompressedBinaryBytes = 250 * 1024 * 1024
 
+// ExtractBinary extracts a single CLI binary from a supported release archive.
 func ExtractBinary(assetName string, archiveBytes []byte) ([]byte, error) {
 	return extractBinaryWithLimit(assetName, archiveBytes, MaxDecompressedBinaryBytes)
 }
@@ -32,7 +35,7 @@ func extractGzipBinary(archiveBytes []byte, maxBytes int64) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer zr.Close()
+	defer func() { _ = zr.Close() }()
 	return readBounded(zr, maxBytes)
 }
 
@@ -56,7 +59,7 @@ func extractZipBinary(assetName string, archiveBytes []byte, maxBytes int64) ([]
 	if err != nil {
 		return nil, err
 	}
-	defer r.Close()
+	defer func() { _ = r.Close() }()
 	return readBounded(r, maxBytes)
 }
 

--- a/cli/internal/update/archive_test.go
+++ b/cli/internal/update/archive_test.go
@@ -1,0 +1,96 @@
+package update
+
+import (
+	"archive/zip"
+	"bytes"
+	"compress/gzip"
+	"testing"
+)
+
+func TestExtractGzipBinary(t *testing.T) {
+	data := []byte("new binary")
+	archive := gzipBytes(t, data)
+	got, err := ExtractBinary("spt-5.10.4-linux-amd64.gz", archive)
+	if err != nil {
+		t.Fatalf("ExtractBinary returned error: %v", err)
+	}
+	if !bytes.Equal(got, data) {
+		t.Fatalf("ExtractBinary = %q, want %q", got, data)
+	}
+}
+
+func TestExtractGzipBinaryRejectsDecompressedLimit(t *testing.T) {
+	archive := gzipBytes(t, []byte("0123456789"))
+	if _, err := extractBinaryWithLimit("spt-5.10.4-linux-amd64.gz", archive, 5); err == nil {
+		t.Fatal("extractBinaryWithLimit accepted oversized decompressed data")
+	}
+}
+
+func TestExtractZipBinary(t *testing.T) {
+	data := []byte("windows binary")
+	archive := zipBytes(t, map[string][]byte{"spt-5.10.4-windows-amd64.exe": data})
+	got, err := ExtractBinary("spt-5.10.4-windows-amd64.zip", archive)
+	if err != nil {
+		t.Fatalf("ExtractBinary returned error: %v", err)
+	}
+	if !bytes.Equal(got, data) {
+		t.Fatalf("ExtractBinary = %q, want %q", got, data)
+	}
+}
+
+func TestExtractZipBinaryRejectsUnexpectedNames(t *testing.T) {
+	tests := map[string]map[string][]byte{
+		"path traversal": {"../spt-5.10.4-windows-amd64.exe": []byte("x")},
+		"nested path":    {"dir/spt-5.10.4-windows-amd64.exe": []byte("x")},
+		"drive letter":   {"C:spt-5.10.4-windows-amd64.exe": []byte("x")},
+		"wrong name":     {"other.exe": []byte("x")},
+		"multiple files": {"spt-5.10.4-windows-amd64.exe": []byte("x"), "extra.exe": []byte("x")},
+	}
+
+	for name, files := range tests {
+		t.Run(name, func(t *testing.T) {
+			if _, err := ExtractBinary("spt-5.10.4-windows-amd64.zip", zipBytes(t, files)); err == nil {
+				t.Fatal("ExtractBinary accepted invalid zip")
+			}
+		})
+	}
+}
+
+func TestExtractZipBinaryRejectsDecompressedLimit(t *testing.T) {
+	archive := zipBytes(t, map[string][]byte{"spt-5.10.4-windows-amd64.exe": []byte("0123456789")})
+	if _, err := extractBinaryWithLimit("spt-5.10.4-windows-amd64.zip", archive, 5); err == nil {
+		t.Fatal("extractBinaryWithLimit accepted oversized zip entry")
+	}
+}
+
+func gzipBytes(t *testing.T, data []byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	zw := gzip.NewWriter(&buf)
+	if _, err := zw.Write(data); err != nil {
+		t.Fatalf("gzip write: %v", err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("gzip close: %v", err)
+	}
+	return buf.Bytes()
+}
+
+func zipBytes(t *testing.T, files map[string][]byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	for name, data := range files {
+		w, err := zw.Create(name)
+		if err != nil {
+			t.Fatalf("zip create: %v", err)
+		}
+		if _, err := w.Write(data); err != nil {
+			t.Fatalf("zip write: %v", err)
+		}
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("zip close: %v", err)
+	}
+	return buf.Bytes()
+}

--- a/cli/internal/update/artifact.go
+++ b/cli/internal/update/artifact.go
@@ -9,10 +9,13 @@ import (
 )
 
 const (
-	ChecksumAssetName       = "SHA256SUMS"
+	// ChecksumAssetName is the release asset containing SHA-256 digests.
+	ChecksumAssetName = "SHA256SUMS"
+	// MaxCompressedAssetBytes is the maximum release archive download size.
 	MaxCompressedAssetBytes = 100 * 1024 * 1024
 )
 
+// AssetNameForPlatform returns the expected release asset name for a platform.
 func AssetNameForPlatform(version, goos, goarch string) (string, error) {
 	suffix, ok := platformAssetSuffix(goos, goarch)
 	if !ok {
@@ -21,6 +24,7 @@ func AssetNameForPlatform(version, goos, goarch string) (string, error) {
 	return "spt-" + version + suffix, nil
 }
 
+// FindAsset finds a release asset by exact name.
 func FindAsset(assets []Asset, name string) (Asset, error) {
 	for _, asset := range assets {
 		if asset.Name == name {
@@ -30,6 +34,7 @@ func FindAsset(assets []Asset, name string) (Asset, error) {
 	return Asset{}, fmt.Errorf("release asset %q not found", name)
 }
 
+// FindChecksum returns the SHA-256 hex digest for assetName from SHA256SUMS data.
 func FindChecksum(contents []byte, assetName string) (string, error) {
 	scanner := bufio.NewScanner(strings.NewReader(string(contents)))
 	var found string
@@ -66,6 +71,7 @@ func FindChecksum(contents []byte, assetName string) (string, error) {
 	return strings.ToLower(found), nil
 }
 
+// VerifyChecksum checks that data matches the expected SHA-256 digest.
 func VerifyChecksum(data []byte, wantHex string) error {
 	sum := sha256.Sum256(data)
 	got := hex.EncodeToString(sum[:])

--- a/cli/internal/update/artifact.go
+++ b/cli/internal/update/artifact.go
@@ -1,0 +1,93 @@
+package update
+
+import (
+	"bufio"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"strings"
+)
+
+const (
+	ChecksumAssetName       = "SHA256SUMS"
+	MaxCompressedAssetBytes = 100 * 1024 * 1024
+)
+
+func AssetNameForPlatform(version, goos, goarch string) (string, error) {
+	suffix, ok := platformAssetSuffix(goos, goarch)
+	if !ok {
+		return "", fmt.Errorf("unsupported platform %s/%s", goos, goarch)
+	}
+	return "spt-" + version + suffix, nil
+}
+
+func FindAsset(assets []Asset, name string) (Asset, error) {
+	for _, asset := range assets {
+		if asset.Name == name {
+			return asset, nil
+		}
+	}
+	return Asset{}, fmt.Errorf("release asset %q not found", name)
+}
+
+func FindChecksum(contents []byte, assetName string) (string, error) {
+	scanner := bufio.NewScanner(strings.NewReader(string(contents)))
+	var found string
+	matches := 0
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		sum := fields[0]
+		name := strings.TrimPrefix(fields[1], "*")
+		if name != assetName {
+			continue
+		}
+		matches++
+		found = sum
+	}
+	if err := scanner.Err(); err != nil {
+		return "", err
+	}
+	if matches == 0 {
+		return "", fmt.Errorf("checksum for %q not found", assetName)
+	}
+	if matches > 1 {
+		return "", fmt.Errorf("checksum for %q appears %d times", assetName, matches)
+	}
+	if _, err := hex.DecodeString(found); err != nil || len(found) != sha256.Size*2 {
+		return "", fmt.Errorf("checksum for %q is not a SHA-256 hex digest", assetName)
+	}
+	return strings.ToLower(found), nil
+}
+
+func VerifyChecksum(data []byte, wantHex string) error {
+	sum := sha256.Sum256(data)
+	got := hex.EncodeToString(sum[:])
+	if !strings.EqualFold(got, wantHex) {
+		return fmt.Errorf("checksum mismatch: got %s, want %s", got, wantHex)
+	}
+	return nil
+}
+
+func platformAssetSuffix(goos, goarch string) (string, bool) {
+	switch goos + "/" + goarch {
+	case "linux/amd64":
+		return "-linux-amd64.gz", true
+	case "linux/arm64":
+		return "-linux-arm64.gz", true
+	case "darwin/amd64":
+		return "-darwin-amd64.gz", true
+	case "darwin/arm64":
+		return "-darwin-arm64.gz", true
+	case "windows/amd64":
+		return "-windows-amd64.zip", true
+	default:
+		return "", false
+	}
+}

--- a/cli/internal/update/artifact_test.go
+++ b/cli/internal/update/artifact_test.go
@@ -1,0 +1,73 @@
+package update
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"testing"
+)
+
+func TestAssetNameForPlatform(t *testing.T) {
+	tests := []struct {
+		goos   string
+		goarch string
+		want   string
+	}{
+		{"linux", "amd64", "spt-5.10.4-linux-amd64.gz"},
+		{"linux", "arm64", "spt-5.10.4-linux-arm64.gz"},
+		{"darwin", "amd64", "spt-5.10.4-darwin-amd64.gz"},
+		{"darwin", "arm64", "spt-5.10.4-darwin-arm64.gz"},
+		{"windows", "amd64", "spt-5.10.4-windows-amd64.zip"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.goos+"_"+tt.goarch, func(t *testing.T) {
+			got, err := AssetNameForPlatform("5.10.4", tt.goos, tt.goarch)
+			if err != nil {
+				t.Fatalf("AssetNameForPlatform returned error: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("asset = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAssetNameForPlatformRejectsUnsupported(t *testing.T) {
+	if _, err := AssetNameForPlatform("5.10.4", "linux", "386"); err == nil {
+		t.Fatal("AssetNameForPlatform accepted unsupported platform")
+	}
+}
+
+func TestFindChecksumExactBasename(t *testing.T) {
+	sums := []byte("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa  spt-5.10.4-linux-amd64.gz.extra\n" +
+		"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb *spt-5.10.4-linux-amd64.gz\n")
+	got, err := FindChecksum(sums, "spt-5.10.4-linux-amd64.gz")
+	if err != nil {
+		t.Fatalf("FindChecksum returned error: %v", err)
+	}
+	if got != "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" {
+		t.Fatalf("checksum = %q", got)
+	}
+}
+
+func TestFindChecksumRejectsMissingAndDuplicate(t *testing.T) {
+	if _, err := FindChecksum([]byte(""), "asset.gz"); err == nil {
+		t.Fatal("FindChecksum accepted missing checksum")
+	}
+
+	line := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa  asset.gz\n"
+	if _, err := FindChecksum([]byte(line+line), "asset.gz"); err == nil {
+		t.Fatal("FindChecksum accepted duplicate checksum")
+	}
+}
+
+func TestVerifyChecksum(t *testing.T) {
+	data := []byte("release asset bytes")
+	sum := sha256.Sum256(data)
+	if err := VerifyChecksum(data, fmt.Sprintf("%x", sum)); err != nil {
+		t.Fatalf("VerifyChecksum returned error: %v", err)
+	}
+	if err := VerifyChecksum(data, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"); err == nil {
+		t.Fatal("VerifyChecksum accepted wrong checksum")
+	}
+}

--- a/cli/internal/update/github.go
+++ b/cli/internal/update/github.go
@@ -14,12 +14,18 @@ import (
 )
 
 const (
+	// DefaultGitHubAPIBaseURL is the default GitHub REST API base URL.
 	DefaultGitHubAPIBaseURL = "https://api.github.com"
-	DefaultGitHubOwner      = "dell"
-	DefaultGitHubRepo       = "storage-performance-tool"
-	defaultMaxReleasePages  = 10
+	// DefaultGitHubOwner is the GitHub owner that publishes SPT releases.
+	DefaultGitHubOwner = "dell"
+	// DefaultGitHubRepo is the GitHub repository that publishes SPT releases.
+	DefaultGitHubRepo      = "storage-performance-tool"
+	githubAPIHost          = "api.github.com"
+	githubWebHost          = "github.com"
+	defaultMaxReleasePages = 10
 )
 
+// GitHubClient lists releases and downloads release assets from GitHub.
 type GitHubClient struct {
 	HTTPClient *http.Client
 	BaseURL    string
@@ -30,6 +36,7 @@ type GitHubClient struct {
 	MaxPages   int
 }
 
+// PageLimitError reports that GitHub release pagination exceeded the configured cap.
 type PageLimitError struct {
 	Limit int
 }
@@ -38,6 +45,7 @@ func (e *PageLimitError) Error() string {
 	return fmt.Sprintf("GitHub release pagination exceeded %d pages", e.Limit)
 }
 
+// NewGitHubClient returns a GitHub client with default SPT repository settings.
 func NewGitHubClient(timeout time.Duration, token string) GitHubClient {
 	return GitHubClient{
 		HTTPClient: &http.Client{Timeout: timeout},
@@ -48,6 +56,7 @@ func NewGitHubClient(timeout time.Duration, token string) GitHubClient {
 	}
 }
 
+// ListReleases returns all release pages needed for update selection.
 func (c GitHubClient) ListReleases(ctx context.Context) ([]Release, error) {
 	client := c.hardenedHTTPClient()
 	baseURL := strings.TrimRight(c.BaseURL, "/")
@@ -77,17 +86,17 @@ func (c GitHubClient) ListReleases(ctx context.Context) ([]Release, error) {
 			return nil, &PageLimitError{Limit: maxPages}
 		}
 		var releasePage []Release
-		resp, err := c.getJSON(ctx, client, pageURL, &releasePage)
+		headers, err := c.getJSON(ctx, client, pageURL, &releasePage)
 		if err != nil {
 			return nil, err
 		}
 		releases = append(releases, releasePage...)
-		pageURL = nextLink(resp.Header.Get("Link"))
+		pageURL = nextLink(headers.Get("Link"))
 	}
 	return releases, nil
 }
 
-func (c GitHubClient) getJSON(ctx context.Context, client *http.Client, rawURL string, out any) (*http.Response, error) {
+func (c GitHubClient) getJSON(ctx context.Context, client *http.Client, rawURL string, out any) (http.Header, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
 	if err != nil {
 		return nil, err
@@ -102,7 +111,7 @@ func (c GitHubClient) getJSON(ctx context.Context, client *http.Client, rawURL s
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
 		if (resp.StatusCode == http.StatusForbidden || resp.StatusCode == http.StatusTooManyRequests) && resp.Header.Get("X-RateLimit-Remaining") == "0" {
@@ -113,7 +122,7 @@ func (c GitHubClient) getJSON(ctx context.Context, client *http.Client, rawURL s
 	if err := json.NewDecoder(resp.Body).Decode(out); err != nil {
 		return nil, err
 	}
-	return resp, nil
+	return resp.Header.Clone(), nil
 }
 
 func nextLink(linkHeader string) string {
@@ -135,6 +144,7 @@ func nextLink(linkHeader string) string {
 	return ""
 }
 
+// DownloadAsset downloads a release asset with size and transport checks.
 func (c GitHubClient) DownloadAsset(ctx context.Context, asset Asset) ([]byte, error) {
 	client := c.hardenedHTTPClient()
 	downloadURL := asset.BrowserDownloadURL
@@ -162,7 +172,7 @@ func (c GitHubClient) DownloadAsset(ctx context.Context, asset Asset) ([]byte, e
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return nil, fmt.Errorf("asset download failed: %s", resp.Status)
 	}
@@ -223,7 +233,7 @@ func validateGitHubURL(rawURL string) error {
 	if isLocalHTTP(u) {
 		return nil
 	}
-	if host := strings.ToLower(u.Hostname()); host != "api.github.com" {
+	if host := strings.ToLower(u.Hostname()); host != githubAPIHost {
 		return fmt.Errorf("refusing non-GitHub API host %q", host)
 	}
 	return nil
@@ -241,7 +251,7 @@ func validateAssetDownloadURL(rawURL string, authenticatedAPI bool) error {
 		return nil
 	}
 	host := strings.ToLower(u.Hostname())
-	if authenticatedAPI && host != "api.github.com" {
+	if authenticatedAPI && host != githubAPIHost {
 		return fmt.Errorf("refusing to send authenticated asset request to non-GitHub API host %q", host)
 	}
 	if !allowedGitHubAssetHost(host) {
@@ -267,7 +277,7 @@ func isLocalHTTP(u *url.URL) bool {
 }
 
 func allowedGitHubAssetHost(host string) bool {
-	return host == "api.github.com" || host == "github.com" || strings.HasSuffix(host, ".githubusercontent.com")
+	return host == githubAPIHost || host == githubWebHost || strings.HasSuffix(host, ".githubusercontent.com")
 }
 
 func sameHost(a, b *url.URL) bool {

--- a/cli/internal/update/github.go
+++ b/cli/internal/update/github.go
@@ -27,13 +27,14 @@ const (
 
 // GitHubClient lists releases and downloads release assets from GitHub.
 type GitHubClient struct {
-	HTTPClient *http.Client
-	BaseURL    string
-	Owner      string
-	Repo       string
-	Token      string
-	UserAgent  string
-	MaxPages   int
+	HTTPClient             *http.Client
+	BaseURL                string
+	Owner                  string
+	Repo                   string
+	Token                  string
+	UserAgent              string
+	MaxPages               int
+	AllowInsecureLocalHTTP bool
 }
 
 // PageLimitError reports that GitHub release pagination exceeded the configured cap.
@@ -53,6 +54,7 @@ func NewGitHubClient(timeout time.Duration, token string) GitHubClient {
 		Owner:      DefaultGitHubOwner,
 		Repo:       DefaultGitHubRepo,
 		Token:      token,
+		UserAgent:  "spt/unknown",
 	}
 }
 
@@ -63,7 +65,7 @@ func (c GitHubClient) ListReleases(ctx context.Context) ([]Release, error) {
 	if baseURL == "" {
 		baseURL = DefaultGitHubAPIBaseURL
 	}
-	if err := validateGitHubURL(baseURL); err != nil {
+	if err := validateGitHubURL(baseURL, c.AllowInsecureLocalHTTP); err != nil {
 		return nil, err
 	}
 	owner := c.Owner
@@ -156,7 +158,7 @@ func (c GitHubClient) DownloadAsset(ctx context.Context, asset Asset) ([]byte, e
 	if downloadURL == "" {
 		return nil, fmt.Errorf("asset %q has no download URL", asset.Name)
 	}
-	if err := validateAssetDownloadURL(downloadURL, usingAssetAPI); err != nil {
+	if err := validateAssetDownloadURL(downloadURL, usingAssetAPI, c.AllowInsecureLocalHTTP); err != nil {
 		return nil, err
 	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, downloadURL, nil)
@@ -198,7 +200,7 @@ func (c GitHubClient) hardenedHTTPClient() *http.Client {
 	clone := *base
 	previous := base.CheckRedirect
 	clone.CheckRedirect = func(req *http.Request, via []*http.Request) error {
-		if err := validateAssetDownloadURL(req.URL.String(), false); err != nil {
+		if err := validateAssetDownloadURL(req.URL.String(), false, c.AllowInsecureLocalHTTP); err != nil {
 			return err
 		}
 		if len(via) > 0 && !sameHost(via[len(via)-1].URL, req.URL) {
@@ -222,15 +224,15 @@ func (c GitHubClient) userAgent() string {
 	return "spt/unknown"
 }
 
-func validateGitHubURL(rawURL string) error {
+func validateGitHubURL(rawURL string, allowInsecureLocalHTTP bool) error {
 	u, err := url.Parse(rawURL)
 	if err != nil {
 		return err
 	}
-	if !secureURL(u) {
+	if !secureURL(u, allowInsecureLocalHTTP) {
 		return fmt.Errorf("refusing non-HTTPS GitHub URL %q", rawURL)
 	}
-	if isLocalHTTP(u) {
+	if allowInsecureLocalHTTP && isLocalHTTP(u) {
 		return nil
 	}
 	if host := strings.ToLower(u.Hostname()); host != githubAPIHost {
@@ -239,15 +241,15 @@ func validateGitHubURL(rawURL string) error {
 	return nil
 }
 
-func validateAssetDownloadURL(rawURL string, authenticatedAPI bool) error {
+func validateAssetDownloadURL(rawURL string, authenticatedAPI, allowInsecureLocalHTTP bool) error {
 	u, err := url.Parse(rawURL)
 	if err != nil {
 		return err
 	}
-	if !secureURL(u) {
+	if !secureURL(u, allowInsecureLocalHTTP) {
 		return fmt.Errorf("refusing non-HTTPS asset URL %q", rawURL)
 	}
-	if isLocalHTTP(u) {
+	if allowInsecureLocalHTTP && isLocalHTTP(u) {
 		return nil
 	}
 	host := strings.ToLower(u.Hostname())
@@ -260,8 +262,8 @@ func validateAssetDownloadURL(rawURL string, authenticatedAPI bool) error {
 	return nil
 }
 
-func secureURL(u *url.URL) bool {
-	return u.Scheme == "https" || isLocalHTTP(u)
+func secureURL(u *url.URL, allowInsecureLocalHTTP bool) bool {
+	return u.Scheme == "https" || (allowInsecureLocalHTTP && isLocalHTTP(u))
 }
 
 func isLocalHTTP(u *url.URL) bool {

--- a/cli/internal/update/github.go
+++ b/cli/internal/update/github.go
@@ -1,0 +1,159 @@
+package update
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	DefaultGitHubAPIBaseURL = "https://api.github.com"
+	DefaultGitHubOwner      = "dell"
+	DefaultGitHubRepo       = "storage-performance-tool"
+)
+
+type GitHubClient struct {
+	HTTPClient *http.Client
+	BaseURL    string
+	Owner      string
+	Repo       string
+	Token      string
+}
+
+func NewGitHubClient(timeout time.Duration, token string) GitHubClient {
+	return GitHubClient{
+		HTTPClient: &http.Client{Timeout: timeout},
+		BaseURL:    DefaultGitHubAPIBaseURL,
+		Owner:      DefaultGitHubOwner,
+		Repo:       DefaultGitHubRepo,
+		Token:      token,
+	}
+}
+
+func (c GitHubClient) ListReleases(ctx context.Context) ([]Release, error) {
+	client := c.HTTPClient
+	if client == nil {
+		client = &http.Client{Timeout: 30 * time.Second}
+	}
+	baseURL := strings.TrimRight(c.BaseURL, "/")
+	if baseURL == "" {
+		baseURL = DefaultGitHubAPIBaseURL
+	}
+	owner := c.Owner
+	if owner == "" {
+		owner = DefaultGitHubOwner
+	}
+	repo := c.Repo
+	if repo == "" {
+		repo = DefaultGitHubRepo
+	}
+
+	pageURL := fmt.Sprintf("%s/repos/%s/%s/releases?per_page=100&page=1", baseURL, url.PathEscape(owner), url.PathEscape(repo))
+	var releases []Release
+	for pageURL != "" {
+		var page []Release
+		resp, err := c.getJSON(ctx, client, pageURL, &page)
+		if err != nil {
+			return nil, err
+		}
+		releases = append(releases, page...)
+		pageURL = nextLink(resp.Header.Get("Link"))
+	}
+	return releases, nil
+}
+
+func (c GitHubClient) getJSON(ctx context.Context, client *http.Client, rawURL string, out any) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+	if strings.TrimSpace(c.Token) != "" {
+		req.Header.Set("Authorization", "Bearer "+strings.TrimSpace(c.Token))
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		if resp.StatusCode == http.StatusForbidden && resp.Header.Get("X-RateLimit-Remaining") == "0" {
+			return nil, fmt.Errorf("GitHub API rate limit exceeded")
+		}
+		return nil, fmt.Errorf("GitHub API request failed: %s: %s", resp.Status, strings.TrimSpace(string(body)))
+	}
+	if err := json.NewDecoder(resp.Body).Decode(out); err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+func nextLink(linkHeader string) string {
+	for _, part := range strings.Split(linkHeader, ",") {
+		sections := strings.Split(part, ";")
+		if len(sections) < 2 {
+			continue
+		}
+		target := strings.TrimSpace(sections[0])
+		if !strings.HasPrefix(target, "<") || !strings.HasSuffix(target, ">") {
+			continue
+		}
+		for _, param := range sections[1:] {
+			if strings.TrimSpace(param) == `rel="next"` {
+				return strings.TrimSuffix(strings.TrimPrefix(target, "<"), ">")
+			}
+		}
+	}
+	return ""
+}
+
+func (c GitHubClient) DownloadAsset(ctx context.Context, asset Asset) ([]byte, error) {
+	client := c.HTTPClient
+	if client == nil {
+		client = &http.Client{Timeout: 30 * time.Second}
+	}
+	downloadURL := asset.BrowserDownloadURL
+	accept := "application/octet-stream"
+	if strings.TrimSpace(c.Token) != "" && asset.URL != "" {
+		downloadURL = asset.URL
+	}
+	if downloadURL == "" {
+		return nil, fmt.Errorf("asset %q has no download URL", asset.Name)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, downloadURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", accept)
+	if strings.TrimSpace(c.Token) != "" && asset.URL != "" {
+		req.Header.Set("Authorization", "Bearer "+strings.TrimSpace(c.Token))
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("asset download failed: %s", resp.Status)
+	}
+	limit := int64(MaxCompressedAssetBytes + 1)
+	if asset.Size > 0 && asset.Size < limit {
+		limit = asset.Size + 1
+	}
+	data, err := io.ReadAll(io.LimitReader(resp.Body, limit))
+	if err != nil {
+		return nil, err
+	}
+	if len(data) >= int(limit) {
+		return nil, fmt.Errorf("asset %q exceeds compressed size limit %s", asset.Name, strconv.FormatInt(limit-1, 10))
+	}
+	return data, nil
+}

--- a/cli/internal/update/github.go
+++ b/cli/internal/update/github.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -16,6 +17,7 @@ const (
 	DefaultGitHubAPIBaseURL = "https://api.github.com"
 	DefaultGitHubOwner      = "dell"
 	DefaultGitHubRepo       = "storage-performance-tool"
+	defaultMaxReleasePages  = 10
 )
 
 type GitHubClient struct {
@@ -24,6 +26,16 @@ type GitHubClient struct {
 	Owner      string
 	Repo       string
 	Token      string
+	UserAgent  string
+	MaxPages   int
+}
+
+type PageLimitError struct {
+	Limit int
+}
+
+func (e *PageLimitError) Error() string {
+	return fmt.Sprintf("GitHub release pagination exceeded %d pages", e.Limit)
 }
 
 func NewGitHubClient(timeout time.Duration, token string) GitHubClient {
@@ -37,13 +49,13 @@ func NewGitHubClient(timeout time.Duration, token string) GitHubClient {
 }
 
 func (c GitHubClient) ListReleases(ctx context.Context) ([]Release, error) {
-	client := c.HTTPClient
-	if client == nil {
-		client = &http.Client{Timeout: 30 * time.Second}
-	}
+	client := c.hardenedHTTPClient()
 	baseURL := strings.TrimRight(c.BaseURL, "/")
 	if baseURL == "" {
 		baseURL = DefaultGitHubAPIBaseURL
+	}
+	if err := validateGitHubURL(baseURL); err != nil {
+		return nil, err
 	}
 	owner := c.Owner
 	if owner == "" {
@@ -55,14 +67,21 @@ func (c GitHubClient) ListReleases(ctx context.Context) ([]Release, error) {
 	}
 
 	pageURL := fmt.Sprintf("%s/repos/%s/%s/releases?per_page=100&page=1", baseURL, url.PathEscape(owner), url.PathEscape(repo))
+	maxPages := c.MaxPages
+	if maxPages <= 0 {
+		maxPages = defaultMaxReleasePages
+	}
 	var releases []Release
-	for pageURL != "" {
-		var page []Release
-		resp, err := c.getJSON(ctx, client, pageURL, &page)
+	for page := 1; pageURL != ""; page++ {
+		if page > maxPages {
+			return nil, &PageLimitError{Limit: maxPages}
+		}
+		var releasePage []Release
+		resp, err := c.getJSON(ctx, client, pageURL, &releasePage)
 		if err != nil {
 			return nil, err
 		}
-		releases = append(releases, page...)
+		releases = append(releases, releasePage...)
 		pageURL = nextLink(resp.Header.Get("Link"))
 	}
 	return releases, nil
@@ -75,6 +94,7 @@ func (c GitHubClient) getJSON(ctx context.Context, client *http.Client, rawURL s
 	}
 	req.Header.Set("Accept", "application/vnd.github+json")
 	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+	req.Header.Set("User-Agent", c.userAgent())
 	if strings.TrimSpace(c.Token) != "" {
 		req.Header.Set("Authorization", "Bearer "+strings.TrimSpace(c.Token))
 	}
@@ -85,8 +105,8 @@ func (c GitHubClient) getJSON(ctx context.Context, client *http.Client, rawURL s
 	defer resp.Body.Close()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
-		if resp.StatusCode == http.StatusForbidden && resp.Header.Get("X-RateLimit-Remaining") == "0" {
-			return nil, fmt.Errorf("GitHub API rate limit exceeded")
+		if (resp.StatusCode == http.StatusForbidden || resp.StatusCode == http.StatusTooManyRequests) && resp.Header.Get("X-RateLimit-Remaining") == "0" {
+			return nil, rateLimitError(resp)
 		}
 		return nil, fmt.Errorf("GitHub API request failed: %s: %s", resp.Status, strings.TrimSpace(string(body)))
 	}
@@ -116,23 +136,25 @@ func nextLink(linkHeader string) string {
 }
 
 func (c GitHubClient) DownloadAsset(ctx context.Context, asset Asset) ([]byte, error) {
-	client := c.HTTPClient
-	if client == nil {
-		client = &http.Client{Timeout: 30 * time.Second}
-	}
+	client := c.hardenedHTTPClient()
 	downloadURL := asset.BrowserDownloadURL
 	accept := "application/octet-stream"
-	if strings.TrimSpace(c.Token) != "" && asset.URL != "" {
+	usingAssetAPI := strings.TrimSpace(c.Token) != "" && asset.URL != ""
+	if usingAssetAPI {
 		downloadURL = asset.URL
 	}
 	if downloadURL == "" {
 		return nil, fmt.Errorf("asset %q has no download URL", asset.Name)
+	}
+	if err := validateAssetDownloadURL(downloadURL, usingAssetAPI); err != nil {
+		return nil, err
 	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, downloadURL, nil)
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Accept", accept)
+	req.Header.Set("User-Agent", c.userAgent())
 	if strings.TrimSpace(c.Token) != "" && asset.URL != "" {
 		req.Header.Set("Authorization", "Bearer "+strings.TrimSpace(c.Token))
 	}
@@ -156,4 +178,106 @@ func (c GitHubClient) DownloadAsset(ctx context.Context, asset Asset) ([]byte, e
 		return nil, fmt.Errorf("asset %q exceeds compressed size limit %s", asset.Name, strconv.FormatInt(limit-1, 10))
 	}
 	return data, nil
+}
+
+func (c GitHubClient) hardenedHTTPClient() *http.Client {
+	base := c.HTTPClient
+	if base == nil {
+		base = &http.Client{Timeout: 30 * time.Second}
+	}
+	clone := *base
+	previous := base.CheckRedirect
+	clone.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		if err := validateAssetDownloadURL(req.URL.String(), false); err != nil {
+			return err
+		}
+		if len(via) > 0 && !sameHost(via[len(via)-1].URL, req.URL) {
+			req.Header.Del("Authorization")
+		}
+		if previous != nil {
+			return previous(req, via)
+		}
+		if len(via) >= 10 {
+			return http.ErrUseLastResponse
+		}
+		return nil
+	}
+	return &clone
+}
+
+func (c GitHubClient) userAgent() string {
+	if strings.TrimSpace(c.UserAgent) != "" {
+		return strings.TrimSpace(c.UserAgent)
+	}
+	return "spt/unknown"
+}
+
+func validateGitHubURL(rawURL string) error {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return err
+	}
+	if !secureURL(u) {
+		return fmt.Errorf("refusing non-HTTPS GitHub URL %q", rawURL)
+	}
+	if isLocalHTTP(u) {
+		return nil
+	}
+	if host := strings.ToLower(u.Hostname()); host != "api.github.com" {
+		return fmt.Errorf("refusing non-GitHub API host %q", host)
+	}
+	return nil
+}
+
+func validateAssetDownloadURL(rawURL string, authenticatedAPI bool) error {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return err
+	}
+	if !secureURL(u) {
+		return fmt.Errorf("refusing non-HTTPS asset URL %q", rawURL)
+	}
+	if isLocalHTTP(u) {
+		return nil
+	}
+	host := strings.ToLower(u.Hostname())
+	if authenticatedAPI && host != "api.github.com" {
+		return fmt.Errorf("refusing to send authenticated asset request to non-GitHub API host %q", host)
+	}
+	if !allowedGitHubAssetHost(host) {
+		return fmt.Errorf("refusing non-GitHub asset host %q", host)
+	}
+	return nil
+}
+
+func secureURL(u *url.URL) bool {
+	return u.Scheme == "https" || isLocalHTTP(u)
+}
+
+func isLocalHTTP(u *url.URL) bool {
+	if u.Scheme != "http" {
+		return false
+	}
+	host := u.Hostname()
+	if host == "localhost" {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
+}
+
+func allowedGitHubAssetHost(host string) bool {
+	return host == "api.github.com" || host == "github.com" || strings.HasSuffix(host, ".githubusercontent.com")
+}
+
+func sameHost(a, b *url.URL) bool {
+	return strings.EqualFold(a.Hostname(), b.Hostname())
+}
+
+func rateLimitError(resp *http.Response) error {
+	reset := resp.Header.Get("X-RateLimit-Reset")
+	if reset == "" {
+		reset = "unknown"
+	}
+	return fmt.Errorf("GitHub API rate limit exceeded; set SPT_GITHUB_TOKEN or GITHUB_TOKEN to raise the limit and retry (X-RateLimit-Reset=%s)", reset)
 }

--- a/cli/internal/update/github_hardening_test.go
+++ b/cli/internal/update/github_hardening_test.go
@@ -18,7 +18,7 @@ func TestGitHubClientSetsUserAgent(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := GitHubClient{HTTPClient: server.Client(), BaseURL: server.URL, Owner: "dell", Repo: "storage-performance-tool", UserAgent: "spt/5.10.4"}
+	client := GitHubClient{HTTPClient: server.Client(), BaseURL: server.URL, Owner: "dell", Repo: "storage-performance-tool", UserAgent: "spt/5.10.4", AllowInsecureLocalHTTP: true}
 	if _, err := client.ListReleases(context.Background()); err != nil {
 		t.Fatalf("ListReleases returned error: %v", err)
 	}
@@ -32,7 +32,7 @@ func TestGitHubClientRateLimitErrorIsActionable(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := GitHubClient{HTTPClient: server.Client(), BaseURL: server.URL, Owner: "dell", Repo: "storage-performance-tool"}
+	client := GitHubClient{HTTPClient: server.Client(), BaseURL: server.URL, Owner: "dell", Repo: "storage-performance-tool", AllowInsecureLocalHTTP: true}
 	_, err := client.ListReleases(context.Background())
 	if err == nil {
 		t.Fatal("ListReleases accepted rate-limit response")
@@ -75,7 +75,7 @@ func TestGitHubClientPageCap(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := GitHubClient{HTTPClient: server.Client(), BaseURL: server.URL, Owner: "dell", Repo: "storage-performance-tool", MaxPages: 1}
+	client := GitHubClient{HTTPClient: server.Client(), BaseURL: server.URL, Owner: "dell", Repo: "storage-performance-tool", MaxPages: 1, AllowInsecureLocalHTTP: true}
 	_, err := client.ListReleases(context.Background())
 	if err == nil {
 		t.Fatal("ListReleases followed pagination beyond cap")

--- a/cli/internal/update/github_hardening_test.go
+++ b/cli/internal/update/github_hardening_test.go
@@ -1,0 +1,87 @@
+package update
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestGitHubClientSetsUserAgent(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("User-Agent"); got != "spt/5.10.4" {
+			t.Fatalf("User-Agent = %q", got)
+		}
+		writeJSON(t, w, []Release{})
+	}))
+	defer server.Close()
+
+	client := GitHubClient{HTTPClient: server.Client(), BaseURL: server.URL, Owner: "dell", Repo: "storage-performance-tool", UserAgent: "spt/5.10.4"}
+	if _, err := client.ListReleases(context.Background()); err != nil {
+		t.Fatalf("ListReleases returned error: %v", err)
+	}
+}
+
+func TestGitHubClientRateLimitErrorIsActionable(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("X-RateLimit-Remaining", "0")
+		w.Header().Set("X-RateLimit-Reset", "1782420000")
+		http.Error(w, "rate limited", http.StatusForbidden)
+	}))
+	defer server.Close()
+
+	client := GitHubClient{HTTPClient: server.Client(), BaseURL: server.URL, Owner: "dell", Repo: "storage-performance-tool"}
+	_, err := client.ListReleases(context.Background())
+	if err == nil {
+		t.Fatal("ListReleases accepted rate-limit response")
+	}
+	msg := err.Error()
+	for _, want := range []string{"rate limit", "SPT_GITHUB_TOKEN", "GITHUB_TOKEN", "1782420000"} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("rate-limit error %q missing %q", msg, want)
+		}
+	}
+}
+
+func TestGitHubClientRejectsInsecureBaseURL(t *testing.T) {
+	client := GitHubClient{BaseURL: "http://api.github.com", Owner: "dell", Repo: "storage-performance-tool"}
+	if _, err := client.ListReleases(context.Background()); err == nil {
+		t.Fatal("ListReleases accepted insecure base URL")
+	}
+}
+
+func TestGitHubClientRejectsInsecureAssetURL(t *testing.T) {
+	client := GitHubClient{}
+	_, err := client.DownloadAsset(context.Background(), Asset{Name: "asset.gz", BrowserDownloadURL: "http://example.com/asset.gz"})
+	if err == nil {
+		t.Fatal("DownloadAsset accepted insecure asset URL")
+	}
+}
+
+func TestGitHubClientRejectsNonGitHubAuthenticatedAssetURL(t *testing.T) {
+	client := GitHubClient{Token: "token"}
+	_, err := client.DownloadAsset(context.Background(), Asset{Name: "asset.gz", URL: "https://evil.example.com/asset"})
+	if err == nil {
+		t.Fatal("DownloadAsset accepted non-GitHub authenticated asset URL")
+	}
+}
+
+func TestGitHubClientPageCap(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Link", `<`+serverURL(t, r)+`?per_page=100&page=2>; rel="next"`)
+		writeJSON(t, w, []Release{})
+	}))
+	defer server.Close()
+
+	client := GitHubClient{HTTPClient: server.Client(), BaseURL: server.URL, Owner: "dell", Repo: "storage-performance-tool", MaxPages: 1}
+	_, err := client.ListReleases(context.Background())
+	if err == nil {
+		t.Fatal("ListReleases followed pagination beyond cap")
+	}
+	var pageErr *PageLimitError
+	if !errors.As(err, &pageErr) {
+		t.Fatalf("error = %T %v, want PageLimitError", err, err)
+	}
+}

--- a/cli/internal/update/github_test.go
+++ b/cli/internal/update/github_test.go
@@ -30,7 +30,7 @@ func TestGitHubClientListReleasesPaginates(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := GitHubClient{HTTPClient: server.Client(), BaseURL: server.URL, Owner: "dell", Repo: "storage-performance-tool"}
+	client := GitHubClient{HTTPClient: server.Client(), BaseURL: server.URL, Owner: "dell", Repo: "storage-performance-tool", AllowInsecureLocalHTTP: true}
 	releases, err := client.ListReleases(context.Background())
 	if err != nil {
 		t.Fatalf("ListReleases returned error: %v", err)
@@ -52,7 +52,7 @@ func TestGitHubClientListReleasesUsesToken(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := GitHubClient{HTTPClient: server.Client(), BaseURL: server.URL, Owner: "dell", Repo: "storage-performance-tool", Token: "test-token"}
+	client := GitHubClient{HTTPClient: server.Client(), BaseURL: server.URL, Owner: "dell", Repo: "storage-performance-tool", Token: "test-token", AllowInsecureLocalHTTP: true}
 	if _, err := client.ListReleases(context.Background()); err != nil {
 		t.Fatalf("ListReleases returned error: %v", err)
 	}
@@ -65,7 +65,7 @@ func TestGitHubClientListReleasesRateLimitError(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := GitHubClient{HTTPClient: server.Client(), BaseURL: server.URL, Owner: "dell", Repo: "storage-performance-tool"}
+	client := GitHubClient{HTTPClient: server.Client(), BaseURL: server.URL, Owner: "dell", Repo: "storage-performance-tool", AllowInsecureLocalHTTP: true}
 	if _, err := client.ListReleases(context.Background()); err == nil {
 		t.Fatal("ListReleases accepted rate-limit response")
 	}

--- a/cli/internal/update/github_test.go
+++ b/cli/internal/update/github_test.go
@@ -1,0 +1,85 @@
+package update
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestGitHubClientListReleasesPaginates(t *testing.T) {
+	var pages []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Accept"); got != "application/vnd.github+json" {
+			t.Fatalf("Accept header = %q", got)
+		}
+		if got := r.URL.Path; got != "/repos/dell/storage-performance-tool/releases" {
+			t.Fatalf("path = %q", got)
+		}
+		pages = append(pages, r.URL.Query().Get("page"))
+		switch r.URL.Query().Get("page") {
+		case "", "1":
+			w.Header().Set("Link", `<`+serverURL(t, r)+`?per_page=100&page=2>; rel="next"`)
+			writeJSON(t, w, []Release{{TagName: "v5.10.4"}})
+		case "2":
+			writeJSON(t, w, []Release{{TagName: "v5.11.0"}})
+		default:
+			t.Fatalf("unexpected page %q", r.URL.Query().Get("page"))
+		}
+	}))
+	defer server.Close()
+
+	client := GitHubClient{HTTPClient: server.Client(), BaseURL: server.URL, Owner: "dell", Repo: "storage-performance-tool"}
+	releases, err := client.ListReleases(context.Background())
+	if err != nil {
+		t.Fatalf("ListReleases returned error: %v", err)
+	}
+	if len(releases) != 2 {
+		t.Fatalf("len(releases) = %d, want 2", len(releases))
+	}
+	if len(pages) != 2 || pages[0] != "1" || pages[1] != "2" {
+		t.Fatalf("pages = %#v, want [1 2]", pages)
+	}
+}
+
+func TestGitHubClientListReleasesUsesToken(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+			t.Fatalf("Authorization header = %q", got)
+		}
+		writeJSON(t, w, []Release{})
+	}))
+	defer server.Close()
+
+	client := GitHubClient{HTTPClient: server.Client(), BaseURL: server.URL, Owner: "dell", Repo: "storage-performance-tool", Token: "test-token"}
+	if _, err := client.ListReleases(context.Background()); err != nil {
+		t.Fatalf("ListReleases returned error: %v", err)
+	}
+}
+
+func TestGitHubClientListReleasesRateLimitError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("X-RateLimit-Remaining", "0")
+		http.Error(w, "rate limited", http.StatusForbidden)
+	}))
+	defer server.Close()
+
+	client := GitHubClient{HTTPClient: server.Client(), BaseURL: server.URL, Owner: "dell", Repo: "storage-performance-tool"}
+	if _, err := client.ListReleases(context.Background()); err == nil {
+		t.Fatal("ListReleases accepted rate-limit response")
+	}
+}
+
+func serverURL(t *testing.T, r *http.Request) string {
+	t.Helper()
+	return "http://" + r.Host + r.URL.Path
+}
+
+func writeJSON(t *testing.T, w http.ResponseWriter, v any) {
+	t.Helper()
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		t.Fatalf("json encode: %v", err)
+	}
+}

--- a/cli/internal/update/release.go
+++ b/cli/internal/update/release.go
@@ -1,0 +1,63 @@
+package update
+
+import "fmt"
+
+type Channel int
+
+const (
+	ChannelStable Channel = iota
+	ChannelPrerelease
+)
+
+type Release struct {
+	TagName    string  `json:"tag_name"`
+	Draft      bool    `json:"draft"`
+	Prerelease bool    `json:"prerelease"`
+	HTMLURL    string  `json:"html_url"`
+	Assets     []Asset `json:"assets"`
+	version    Version
+}
+
+type Asset struct {
+	Name               string `json:"name"`
+	BrowserDownloadURL string `json:"browser_download_url"`
+	URL                string `json:"url"`
+	Size               int64  `json:"size"`
+}
+
+func SelectLatestRelease(releases []Release, channel Channel) (Release, error) {
+	var best Release
+	found := false
+	for _, r := range releases {
+		v, ok := releaseVersionForChannel(r, channel)
+		if !ok {
+			continue
+		}
+		r.version = v
+		if !found || v.Compare(best.version) > 0 {
+			best = r
+			found = true
+		}
+	}
+	if !found {
+		return Release{}, fmt.Errorf("no matching release found")
+	}
+	return best, nil
+}
+
+func releaseVersionForChannel(r Release, channel Channel) (Version, bool) {
+	if r.Draft {
+		return Version{}, false
+	}
+	v, err := ParseTag(r.TagName)
+	if err != nil {
+		return Version{}, false
+	}
+	if v.IsPrerelease() != r.Prerelease {
+		return Version{}, false
+	}
+	if channel == ChannelStable && v.IsPrerelease() {
+		return Version{}, false
+	}
+	return v, true
+}

--- a/cli/internal/update/release.go
+++ b/cli/internal/update/release.go
@@ -2,13 +2,17 @@ package update
 
 import "fmt"
 
+// Channel selects which release channel should be considered for updates.
 type Channel int
 
 const (
+	// ChannelStable selects only stable release tags.
 	ChannelStable Channel = iota
+	// ChannelPrerelease selects stable and prerelease tags.
 	ChannelPrerelease
 )
 
+// Release is the GitHub release metadata used by update selection.
 type Release struct {
 	TagName    string  `json:"tag_name"`
 	Draft      bool    `json:"draft"`
@@ -18,6 +22,7 @@ type Release struct {
 	version    Version
 }
 
+// Asset is the GitHub release asset metadata used by the updater.
 type Asset struct {
 	Name               string `json:"name"`
 	BrowserDownloadURL string `json:"browser_download_url"`
@@ -25,10 +30,12 @@ type Asset struct {
 	Size               int64  `json:"size"`
 }
 
+// Version parses the release tag into a semantic version.
 func (r Release) Version() (Version, error) {
 	return ParseTag(r.TagName)
 }
 
+// SelectLatestRelease returns the highest-precedence release for channel.
 func SelectLatestRelease(releases []Release, channel Channel) (Release, error) {
 	var best Release
 	found := false

--- a/cli/internal/update/release.go
+++ b/cli/internal/update/release.go
@@ -25,6 +25,10 @@ type Asset struct {
 	Size               int64  `json:"size"`
 }
 
+func (r Release) Version() (Version, error) {
+	return ParseTag(r.TagName)
+}
+
 func SelectLatestRelease(releases []Release, channel Channel) (Release, error) {
 	var best Release
 	found := false

--- a/cli/internal/update/release_test.go
+++ b/cli/internal/update/release_test.go
@@ -54,7 +54,7 @@ func TestSelectLatestReleaseSkipsPrereleaseFlagMismatch(t *testing.T) {
 	}
 }
 
-func TestUpdateAvailable(t *testing.T) {
+func TestAvailable(t *testing.T) {
 	tests := []struct {
 		current string
 		latest  string
@@ -71,8 +71,8 @@ func TestUpdateAvailable(t *testing.T) {
 		t.Run(tt.current+"_to_"+tt.latest, func(t *testing.T) {
 			current := mustParseVersion(t, tt.current)
 			latest := mustParseVersion(t, tt.latest)
-			if got := UpdateAvailable(current, latest); got != tt.want {
-				t.Fatalf("UpdateAvailable(%q, %q) = %v, want %v", tt.current, tt.latest, got, tt.want)
+			if got := Available(current, latest); got != tt.want {
+				t.Fatalf("Available(%q, %q) = %v, want %v", tt.current, tt.latest, got, tt.want)
 			}
 		})
 	}

--- a/cli/internal/update/release_test.go
+++ b/cli/internal/update/release_test.go
@@ -1,0 +1,79 @@
+package update
+
+import "testing"
+
+func TestSelectLatestRelease(t *testing.T) {
+	releases := []Release{
+		{TagName: "v5.10.4"},
+		{TagName: "v5.11.0-rc.1", Prerelease: true},
+		{TagName: "v5.11.0"},
+		{TagName: "v5.12.0-rc.1", Prerelease: true},
+		{TagName: "v99.0.0", Draft: true},
+		{TagName: "not-semver"},
+	}
+
+	stable, err := SelectLatestRelease(releases, ChannelStable)
+	if err != nil {
+		t.Fatalf("SelectLatestRelease stable: %v", err)
+	}
+	if stable.TagName != "v5.11.0" {
+		t.Fatalf("stable tag = %q, want v5.11.0", stable.TagName)
+	}
+
+	pre, err := SelectLatestRelease(releases, ChannelPrerelease)
+	if err != nil {
+		t.Fatalf("SelectLatestRelease prerelease: %v", err)
+	}
+	if pre.TagName != "v5.12.0-rc.1" {
+		t.Fatalf("pre tag = %q, want v5.12.0-rc.1", pre.TagName)
+	}
+}
+
+func TestSelectLatestReleaseSkipsPrereleaseFlagMismatch(t *testing.T) {
+	releases := []Release{
+		{TagName: "v5.12.0", Prerelease: true},
+		{TagName: "v5.11.0"},
+		{TagName: "v5.13.0-rc.1", Prerelease: false},
+		{TagName: "v5.10.0-rc.1", Prerelease: true},
+	}
+
+	stable, err := SelectLatestRelease(releases, ChannelStable)
+	if err != nil {
+		t.Fatalf("SelectLatestRelease stable: %v", err)
+	}
+	if stable.TagName != "v5.11.0" {
+		t.Fatalf("stable tag = %q, want v5.11.0", stable.TagName)
+	}
+
+	pre, err := SelectLatestRelease(releases, ChannelPrerelease)
+	if err != nil {
+		t.Fatalf("SelectLatestRelease prerelease: %v", err)
+	}
+	if pre.TagName != "v5.11.0" {
+		t.Fatalf("pre tag = %q, want v5.11.0", pre.TagName)
+	}
+}
+
+func TestUpdateAvailable(t *testing.T) {
+	tests := []struct {
+		current string
+		latest  string
+		want    bool
+	}{
+		{"5.10.4", "5.10.4", false},
+		{"5.10.4", "5.10.5", true},
+		{"5.10.4", "5.10.3", false},
+		{"5.11.0-rc.1", "5.11.0-rc.2", true},
+		{"5.11.0-rc.2", "5.11.0", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.current+"_to_"+tt.latest, func(t *testing.T) {
+			current := mustParseVersion(t, tt.current)
+			latest := mustParseVersion(t, tt.latest)
+			if got := UpdateAvailable(current, latest); got != tt.want {
+				t.Fatalf("UpdateAvailable(%q, %q) = %v, want %v", tt.current, tt.latest, got, tt.want)
+			}
+		})
+	}
+}

--- a/cli/internal/update/replace.go
+++ b/cli/internal/update/replace.go
@@ -14,6 +14,35 @@ func ResolveExecutableTarget(path string) (string, error) {
 	return resolved, nil
 }
 
+func VerifyReplaceAccess(target string) error {
+	info, err := os.Stat(target)
+	if err != nil {
+		return err
+	}
+	if info.IsDir() {
+		return fmt.Errorf("target %q is a directory", target)
+	}
+	f, err := os.OpenFile(target, os.O_WRONLY, 0)
+	if err != nil {
+		return err
+	}
+	if err := f.Close(); err != nil {
+		return err
+	}
+	dir := filepath.Dir(target)
+	tmp, err := os.CreateTemp(dir, ".spt-access-*")
+	if err != nil {
+		return err
+	}
+	name := tmp.Name()
+	closeErr := tmp.Close()
+	removeErr := os.Remove(name)
+	if closeErr != nil {
+		return closeErr
+	}
+	return removeErr
+}
+
 func ReplaceExecutable(target string, data []byte) error {
 	info, err := os.Stat(target)
 	if err != nil {

--- a/cli/internal/update/replace.go
+++ b/cli/internal/update/replace.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 )
 
+// ResolveExecutableTarget resolves symlinks for the current executable path.
 func ResolveExecutableTarget(path string) (string, error) {
 	resolved, err := filepath.EvalSymlinks(path)
 	if err != nil {
@@ -14,6 +15,7 @@ func ResolveExecutableTarget(path string) (string, error) {
 	return resolved, nil
 }
 
+// VerifyReplaceAccess checks that target and its parent directory are writable.
 func VerifyReplaceAccess(target string) error {
 	info, err := os.Stat(target)
 	if err != nil {
@@ -43,6 +45,7 @@ func VerifyReplaceAccess(target string) error {
 	return removeErr
 }
 
+// ReplaceExecutable replaces target with data while preserving target permissions.
 func ReplaceExecutable(target string, data []byte) error {
 	info, err := os.Stat(target)
 	if err != nil {
@@ -58,6 +61,7 @@ func ReplaceExecutable(target string, data []byte) error {
 	return WriteFileAtomic(target, data, mode)
 }
 
+// WriteFileAtomic writes data to path through a same-directory temporary file.
 func WriteFileAtomic(path string, data []byte, mode os.FileMode) error {
 	if mode == 0 {
 		mode = 0o755
@@ -103,6 +107,6 @@ func syncParentDir(dir string) error {
 	if err != nil {
 		return err
 	}
-	defer d.Close()
+	defer func() { _ = d.Close() }()
 	return d.Sync()
 }

--- a/cli/internal/update/replace.go
+++ b/cli/internal/update/replace.go
@@ -91,15 +91,5 @@ func WriteFileAtomic(path string, data []byte, mode os.FileMode) error {
 		return err
 	}
 	keepTemp = false
-	_ = syncParentDir(dir)
 	return nil
-}
-
-func syncParentDir(dir string) error {
-	d, err := os.Open(dir)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = d.Close() }()
-	return d.Sync()
 }

--- a/cli/internal/update/replace.go
+++ b/cli/internal/update/replace.go
@@ -15,7 +15,7 @@ func ResolveExecutableTarget(path string) (string, error) {
 	return resolved, nil
 }
 
-// VerifyReplaceAccess checks that target and its parent directory are writable.
+// VerifyReplaceAccess checks that target is a file and its parent directory is writable.
 func VerifyReplaceAccess(target string) error {
 	info, err := os.Stat(target)
 	if err != nil {
@@ -23,13 +23,6 @@ func VerifyReplaceAccess(target string) error {
 	}
 	if info.IsDir() {
 		return fmt.Errorf("target %q is a directory", target)
-	}
-	f, err := os.OpenFile(target, os.O_WRONLY, 0)
-	if err != nil {
-		return err
-	}
-	if err := f.Close(); err != nil {
-		return err
 	}
 	dir := filepath.Dir(target)
 	tmp, err := os.CreateTemp(dir, ".spt-access-*")

--- a/cli/internal/update/replace.go
+++ b/cli/internal/update/replace.go
@@ -1,0 +1,79 @@
+package update
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+func ResolveExecutableTarget(path string) (string, error) {
+	resolved, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		return "", err
+	}
+	return resolved, nil
+}
+
+func ReplaceExecutable(target string, data []byte) error {
+	info, err := os.Stat(target)
+	if err != nil {
+		return err
+	}
+	if info.IsDir() {
+		return fmt.Errorf("target %q is a directory", target)
+	}
+	mode := info.Mode().Perm() & 0o777
+	if mode == 0 {
+		mode = 0o755
+	}
+	return WriteFileAtomic(target, data, mode)
+}
+
+func WriteFileAtomic(path string, data []byte, mode os.FileMode) error {
+	if mode == 0 {
+		mode = 0o755
+	}
+	dir := filepath.Dir(path)
+	base := filepath.Base(path)
+	tmp, err := os.CreateTemp(dir, "."+base+".tmp-*")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	keepTemp := true
+	defer func() {
+		if keepTemp {
+			_ = os.Remove(tmpName)
+		}
+	}()
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Chmod(mode); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		return err
+	}
+	keepTemp = false
+	_ = syncParentDir(dir)
+	return nil
+}
+
+func syncParentDir(dir string) error {
+	d, err := os.Open(dir)
+	if err != nil {
+		return err
+	}
+	defer d.Close()
+	return d.Sync()
+}

--- a/cli/internal/update/replace_test.go
+++ b/cli/internal/update/replace_test.go
@@ -29,6 +29,20 @@ func TestWriteFileAtomicCreatesOutput(t *testing.T) {
 	}
 }
 
+func TestVerifyReplaceAccessAllowsReadOnlyTargetInWritableDirectory(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix permission model test")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "spt")
+	if err := os.WriteFile(path, []byte("old"), 0o444); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	if err := VerifyReplaceAccess(path); err != nil {
+		t.Fatalf("VerifyReplaceAccess returned error: %v", err)
+	}
+}
+
 func TestReplaceExecutablePreservesExistingMode(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("mode preservation is Unix-specific")

--- a/cli/internal/update/replace_test.go
+++ b/cli/internal/update/replace_test.go
@@ -1,0 +1,86 @@
+package update
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestWriteFileAtomicCreatesOutput(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "spt")
+	if err := WriteFileAtomic(path, []byte("new"), 0o755); err != nil {
+		t.Fatalf("WriteFileAtomic returned error: %v", err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if string(got) != "new" {
+		t.Fatalf("file contents = %q, want new", got)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+	if runtime.GOOS != "windows" && info.Mode().Perm() != 0o755 {
+		t.Fatalf("mode = %v, want 0755", info.Mode().Perm())
+	}
+}
+
+func TestReplaceExecutablePreservesExistingMode(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("mode preservation is Unix-specific")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "spt")
+	if err := os.WriteFile(path, []byte("old"), 0o750); err != nil {
+		t.Fatalf("WriteFile old: %v", err)
+	}
+	if err := ReplaceExecutable(path, []byte("new")); err != nil {
+		t.Fatalf("ReplaceExecutable returned error: %v", err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if string(got) != "new" {
+		t.Fatalf("file contents = %q, want new", got)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+	if info.Mode().Perm() != 0o750 {
+		t.Fatalf("mode = %v, want 0750", info.Mode().Perm())
+	}
+}
+
+func TestReplaceExecutableRejectsDirectory(t *testing.T) {
+	if err := ReplaceExecutable(t.TempDir(), []byte("new")); err == nil {
+		t.Fatal("ReplaceExecutable accepted directory target")
+	}
+}
+
+func TestResolveExecutableTargetFollowsSymlink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink behavior differs on Windows")
+	}
+	dir := t.TempDir()
+	realPath := filepath.Join(dir, "real-spt")
+	linkPath := filepath.Join(dir, "spt")
+	if err := os.WriteFile(realPath, []byte("old"), 0o755); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	if err := os.Symlink(realPath, linkPath); err != nil {
+		t.Fatalf("Symlink: %v", err)
+	}
+	got, err := ResolveExecutableTarget(linkPath)
+	if err != nil {
+		t.Fatalf("ResolveExecutableTarget returned error: %v", err)
+	}
+	if got != realPath {
+		t.Fatalf("target = %q, want %q", got, realPath)
+	}
+}

--- a/cli/internal/update/version.go
+++ b/cli/internal/update/version.go
@@ -1,0 +1,144 @@
+package update
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+var (
+	versionRE    = regexp.MustCompile(`^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(?:-([0-9A-Za-z][0-9A-Za-z.-]*))?$`)
+	numericIDRE  = regexp.MustCompile(`^(0|[1-9][0-9]*)$`)
+	devVersionRE = regexp.MustCompile(`(?:^dev$|-dev(?:[+.-]|$)|-SNAPSHOT$)`)
+)
+
+type Version struct {
+	major int
+	minor int
+	patch int
+	pre   []string
+}
+
+func ParseVersion(s string) (Version, error) {
+	m := versionRE.FindStringSubmatch(s)
+	if m == nil {
+		return Version{}, fmt.Errorf("invalid semver version %q", s)
+	}
+	major, _ := strconv.Atoi(m[1])
+	minor, _ := strconv.Atoi(m[2])
+	patch, _ := strconv.Atoi(m[3])
+	v := Version{major: major, minor: minor, patch: patch}
+	if m[4] != "" {
+		v.pre = strings.Split(m[4], ".")
+		for _, id := range v.pre {
+			if id == "" {
+				return Version{}, fmt.Errorf("invalid empty prerelease identifier in %q", s)
+			}
+			if numericIDRE.MatchString(id) && len(id) > 1 && id[0] == '0' {
+				return Version{}, fmt.Errorf("invalid numeric prerelease identifier %q", id)
+			}
+		}
+	}
+	return v, nil
+}
+
+func ParseTag(tag string) (Version, error) {
+	if !strings.HasPrefix(tag, "v") {
+		return Version{}, fmt.Errorf("release tag %q does not start with v", tag)
+	}
+	return ParseVersion(strings.TrimPrefix(tag, "v"))
+}
+
+func (v Version) String() string {
+	base := fmt.Sprintf("%d.%d.%d", v.major, v.minor, v.patch)
+	if len(v.pre) == 0 {
+		return base
+	}
+	return base + "-" + strings.Join(v.pre, ".")
+}
+
+func (v Version) IsPrerelease() bool {
+	return len(v.pre) > 0
+}
+
+func (v Version) Compare(other Version) int {
+	if c := compareInt(v.major, other.major); c != 0 {
+		return c
+	}
+	if c := compareInt(v.minor, other.minor); c != 0 {
+		return c
+	}
+	if c := compareInt(v.patch, other.patch); c != 0 {
+		return c
+	}
+	return comparePrerelease(v.pre, other.pre)
+}
+
+func CanSelfUpdateCurrentBuild(version string) (bool, string) {
+	if version == "" {
+		return false, "empty version"
+	}
+	if devVersionRE.MatchString(version) {
+		return false, "local or snapshot build cannot self-update"
+	}
+	if _, err := ParseVersion(version); err != nil {
+		return false, err.Error()
+	}
+	return true, ""
+}
+
+func UpdateAvailable(current, latest Version) bool {
+	return latest.Compare(current) > 0
+}
+
+func compareInt(a, b int) int {
+	switch {
+	case a < b:
+		return -1
+	case a > b:
+		return 1
+	default:
+		return 0
+	}
+}
+
+func comparePrerelease(a, b []string) int {
+	if len(a) == 0 && len(b) == 0 {
+		return 0
+	}
+	if len(a) == 0 {
+		return 1
+	}
+	if len(b) == 0 {
+		return -1
+	}
+	for i := 0; i < len(a) && i < len(b); i++ {
+		if a[i] == b[i] {
+			continue
+		}
+		aNum, aIsNum := parseNumericIdentifier(a[i])
+		bNum, bIsNum := parseNumericIdentifier(b[i])
+		switch {
+		case aIsNum && bIsNum:
+			return compareInt(aNum, bNum)
+		case aIsNum:
+			return -1
+		case bIsNum:
+			return 1
+		case a[i] < b[i]:
+			return -1
+		default:
+			return 1
+		}
+	}
+	return compareInt(len(a), len(b))
+}
+
+func parseNumericIdentifier(s string) (int, bool) {
+	if !numericIDRE.MatchString(s) {
+		return 0, false
+	}
+	n, err := strconv.Atoi(s)
+	return n, err == nil
+}

--- a/cli/internal/update/version.go
+++ b/cli/internal/update/version.go
@@ -13,6 +13,7 @@ var (
 	devVersionRE = regexp.MustCompile(`(?:^dev$|-dev(?:[+.-]|$)|-SNAPSHOT$)`)
 )
 
+// Version is a parsed semantic version without build metadata.
 type Version struct {
 	major int
 	minor int
@@ -20,6 +21,7 @@ type Version struct {
 	pre   []string
 }
 
+// ParseVersion parses a semantic version string without a leading v prefix.
 func ParseVersion(s string) (Version, error) {
 	m := versionRE.FindStringSubmatch(s)
 	if m == nil {
@@ -43,6 +45,7 @@ func ParseVersion(s string) (Version, error) {
 	return v, nil
 }
 
+// ParseTag parses a GitHub release tag with the required leading v prefix.
 func ParseTag(tag string) (Version, error) {
 	if !strings.HasPrefix(tag, "v") {
 		return Version{}, fmt.Errorf("release tag %q does not start with v", tag)
@@ -58,10 +61,12 @@ func (v Version) String() string {
 	return base + "-" + strings.Join(v.pre, ".")
 }
 
+// IsPrerelease reports whether v has a prerelease suffix.
 func (v Version) IsPrerelease() bool {
 	return len(v.pre) > 0
 }
 
+// Compare compares v with other using semantic-version precedence.
 func (v Version) Compare(other Version) int {
 	if c := compareInt(v.major, other.major); c != 0 {
 		return c
@@ -75,6 +80,7 @@ func (v Version) Compare(other Version) int {
 	return comparePrerelease(v.pre, other.pre)
 }
 
+// CanSelfUpdateCurrentBuild reports whether a current version may replace itself.
 func CanSelfUpdateCurrentBuild(version string) (bool, string) {
 	if version == "" {
 		return false, "empty version"
@@ -88,7 +94,8 @@ func CanSelfUpdateCurrentBuild(version string) (bool, string) {
 	return true, ""
 }
 
-func UpdateAvailable(current, latest Version) bool {
+// Available reports whether latest has higher precedence than current.
+func Available(current, latest Version) bool {
 	return latest.Compare(current) > 0
 }
 

--- a/cli/internal/update/version_test.go
+++ b/cli/internal/update/version_test.go
@@ -1,0 +1,86 @@
+package update
+
+import "testing"
+
+func TestCanSelfUpdateCurrentBuild(t *testing.T) {
+	tests := []struct {
+		version string
+		wantOK  bool
+	}{
+		{"", false},
+		{"dev", false},
+		{"5.10.4-dev+abc1234", false},
+		{"5.10.4-SNAPSHOT", false},
+		{"not-semver", false},
+		{"5.10.4", true},
+		{"5.11.0-rc.1", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.version, func(t *testing.T) {
+			gotOK, reason := CanSelfUpdateCurrentBuild(tt.version)
+			if gotOK != tt.wantOK {
+				t.Fatalf("CanSelfUpdateCurrentBuild(%q) ok = %v, want %v (reason %q)", tt.version, gotOK, tt.wantOK, reason)
+			}
+			if !gotOK && reason == "" {
+				t.Fatalf("CanSelfUpdateCurrentBuild(%q) returned empty rejection reason", tt.version)
+			}
+		})
+	}
+}
+
+func TestCompareVersions(t *testing.T) {
+	tests := []struct {
+		left  string
+		right string
+		want  int
+	}{
+		{"1.0.0", "1.0.0", 0},
+		{"1.0.1", "1.0.0", 1},
+		{"1.2.0", "1.10.0", -1},
+		{"2.0.0", "1.99.99", 1},
+		{"1.0.0-rc.1", "1.0.0", -1},
+		{"1.0.0", "1.0.0-rc.1", 1},
+		{"1.0.0-rc.2", "1.0.0-rc.1", 1},
+		{"1.0.0-rc.10", "1.0.0-rc.2", 1},
+		{"1.0.0-alpha", "1.0.0-alpha.1", -1},
+		{"1.0.0-alpha.1", "1.0.0-alpha.beta", -1},
+		{"1.0.0-alpha.beta", "1.0.0-beta", -1},
+		{"1.0.0-beta", "1.0.0-beta.2", -1},
+		{"1.0.0-beta.11", "1.0.0-rc.1", -1},
+		{"1.0.0-1", "1.0.0-alpha", -1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.left+"_vs_"+tt.right, func(t *testing.T) {
+			left := mustParseVersion(t, tt.left)
+			right := mustParseVersion(t, tt.right)
+			got := left.Compare(right)
+			if got != tt.want {
+				t.Fatalf("Compare(%q, %q) = %d, want %d", tt.left, tt.right, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseTagRequiresVPrefix(t *testing.T) {
+	if _, err := ParseTag("5.10.4"); err == nil {
+		t.Fatal("ParseTag accepted bare version")
+	}
+	got, err := ParseTag("v5.10.4-rc.1")
+	if err != nil {
+		t.Fatalf("ParseTag returned error: %v", err)
+	}
+	if got.String() != "5.10.4-rc.1" {
+		t.Fatalf("ParseTag string = %q", got.String())
+	}
+}
+
+func mustParseVersion(t *testing.T, s string) Version {
+	t.Helper()
+	v, err := ParseVersion(s)
+	if err != nil {
+		t.Fatalf("ParseVersion(%q): %v", s, err)
+	}
+	return v
+}


### PR DESCRIPTION
## Summary
- Add `spt update` with lightweight `--check`, prerelease selection, `--output`, confirmation, and exit-code handling
- Add release discovery, semver selection, checksum verification, archive hardening, and atomic replace helpers under `internal/update`
- Harden GitHub transport with HTTPS/host validation, User-Agent, pagination cap, and actionable rate-limit errors
- Verify replace access before download and intentionally block Windows running-binary self-update while keeping `--output` supported
- Document update usage, exit codes, and caveats