### PR TITLE
Fix prerelease Docker tag verification

### DIFF
--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -122,7 +122,7 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             # Exact version tag: v5.0.2
-            type=semver,pattern=v{{version}},value=${{ needs.prepare.outputs.version }}
+            type=raw,value=v${{ needs.prepare.outputs.version }}
             # Floating minor tag: v5.0 (only for stable releases)
             type=semver,pattern=v{{major}}.{{minor}},value=${{ needs.prepare.outputs.version }},enable=${{ needs.prepare.outputs.is_prerelease == 'false' }}
             # Floating major tag: v5 (only for stable releases)

--- a/.github/workflows/release-artifacts.yaml
+++ b/.github/workflows/release-artifacts.yaml
@@ -396,7 +396,7 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             # Exact version tag: v5.0.2
-            type=semver,pattern=v{{version}},value=${{ needs.prepare-version.outputs.version }}
+            type=raw,value=${{ needs.prepare-version.outputs.tag }}
             # Floating minor tag: v5.0 (only for stable releases)
             type=semver,pattern=v{{major}}.{{minor}},value=${{ needs.prepare-version.outputs.version }},enable=${{ needs.prepare-version.outputs.is_prerelease == 'false' }}
             # Floating major tag: v5 (only for stable releases)


### PR DESCRIPTION
## Summary
- preserve the exact `v`-prefixed Docker image tag explicitly in release workflows
- avoid prerelease failures where Docker metadata emits `5.11.0-rc.N` but manifest verification expects `v5.11.0-rc.N`
- keep stable floating tags (`vX.Y`, `vX`, `latest`) unchanged
