### PR TITLE
Fix items CSV reuse in Docker runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Fixed
+
+- **External items files in Docker runs** — `--items-file`, mixed `--read-items-file`, and mixed `--delete-items-file` are now rewritten to stable container paths and mounted into local or remote Docker test containers, allowing saved item catalogs to be reused by later read/delete workflows.
+- **Large auto-results artifacts** — CLI artifact retrieval now downloads engine log artifacts larger than the engine log page size with HTTP range requests, preserving large `items.csv` files instead of truncating them at the first page.
+
 ## [5.11.0] - 2026-06-25
 
 ### Added

--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -709,6 +709,10 @@ Available workload types:
 		// Lock the base timestamp so that every GenerateScenario call
 		// (here and later in the orchestrator) produces identical step IDs.
 		params.BaseTimestamp = scenario.BaseTimestamp()
+		params, err = scenario.PrepareExternalItemFiles(params)
+		if err != nil {
+			return err
+		}
 
 		// Generate scenario content
 		scenarioContent, err := scenario.GenerateScenario(params)

--- a/cli/internal/constants/constants.go
+++ b/cli/internal/constants/constants.go
@@ -111,6 +111,13 @@ const (
 	SptMetricsEndpoint = "/metrics/json"
 )
 
+// Engine log artifact constants
+const (
+	// EngineLogArtifactPageSize mirrors LogServlet.LOG_PAGE_SIZE_LIMIT.
+	EngineLogArtifactPageSize      = 1024 * 1024
+	EnginePlainLogArtifactMaxBytes = EngineLogArtifactPageSize - 1
+)
+
 // Progress indicator constants
 const (
 	ProgressSpinner = "⏳"

--- a/cli/internal/constants/constants.go
+++ b/cli/internal/constants/constants.go
@@ -38,6 +38,7 @@ const (
 // SSH connection constants
 const (
 	SSHCommand        = "ssh"
+	SCPCommand        = "scp"
 	SSHConnectTimeout = "ConnectTimeout=10"
 	SSHBatchMode      = "BatchMode=yes"
 )

--- a/cli/internal/docker/command/builder.go
+++ b/cli/internal/docker/command/builder.go
@@ -88,6 +88,10 @@ func (b *DockerCommandBuilderImpl) BuildRunCommand(config ContainerConfig) []str
 		dockerArgs = append(dockerArgs, "--ulimit", ulimit)
 	}
 
+	for _, bind := range config.BindMounts {
+		dockerArgs = append(dockerArgs, "-v", bind)
+	}
+
 	// Add image
 	dockerArgs = append(dockerArgs, config.Image)
 

--- a/cli/internal/docker/command/builder_test.go
+++ b/cli/internal/docker/command/builder_test.go
@@ -149,6 +149,16 @@ func TestDockerCommandBuilderImpl_BuildRunCommand(t *testing.T) {
 			},
 		},
 		{
+			name: "container with bind mount",
+			config: ContainerConfig{
+				Image:      constants.DefaultSptImage,
+				BindMounts: []string{"/tmp/items.csv:/spt-input/items/read-items.csv:ro"},
+			},
+			expected: []string{
+				"docker", "run", "-v", "/tmp/items.csv:/spt-input/items/read-items.csv:ro", constants.DefaultSptImage,
+			},
+		},
+		{
 			name: "empty container name",
 			config: ContainerConfig{
 				Image:    constants.DefaultSptImage,

--- a/cli/internal/docker/command/executor.go
+++ b/cli/internal/docker/command/executor.go
@@ -7,6 +7,7 @@ package command
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os/exec"
 	"strings"
 
@@ -19,6 +20,9 @@ type Executor interface {
 	// ExecuteCommand executes a command on the given host (local or remote via SSH)
 	// Returns stdout, stderr, and error
 	ExecuteCommand(ctx context.Context, host *hostparse.HostInfo, command []string) (stdout, stderr string, err error)
+
+	// CopyFile copies a local file to the given host path.
+	CopyFile(ctx context.Context, host *hostparse.HostInfo, localPath, remotePath string) error
 }
 
 // RealCommandExecutor implements Executor using actual system commands
@@ -39,6 +43,10 @@ type CommandExecutor = Executor
 // returns stdout, stderr (when available), and an error value.
 func (r *RealCommandExecutor) ExecuteCommand(ctx context.Context, host *hostparse.HostInfo, command []string) (stdout, stderr string, err error) {
 	var cmd *exec.Cmd
+
+	if len(command) == 0 {
+		return "", "", fmt.Errorf("empty command")
+	}
 
 	if host.IsLocal {
 		// Local execution
@@ -68,4 +76,26 @@ func (r *RealCommandExecutor) ExecuteCommand(ctx context.Context, host *hostpars
 	}
 
 	return strings.TrimSpace(string(stdoutBytes)), "", nil
+}
+
+// CopyFile copies a local file to the target host path.
+func (r *RealCommandExecutor) CopyFile(ctx context.Context, host *hostparse.HostInfo, localPath, remotePath string) error {
+	var cmd *exec.Cmd
+	if host.IsLocal {
+		cmd = exec.CommandContext(ctx, "cp", localPath, remotePath) // #nosec G204 -- paths are user-selected SPT artifacts.
+	} else {
+		sshTarget := host.GetSSHTarget() + ":" + remotePath
+		scpArgs := []string{
+			"-o", constants.SSHConnectTimeout,
+			"-o", constants.SSHBatchMode,
+			localPath,
+			sshTarget,
+		}
+		cmd = exec.CommandContext(ctx, constants.SCPCommand, scpArgs...) // #nosec G204 -- SCP target is built from parsed host info.
+	}
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("copy %s to %s:%s failed: %w: %s", localPath, host.Original, remotePath, err, strings.TrimSpace(string(out)))
+	}
+	return nil
 }

--- a/cli/internal/docker/command/executor_test.go
+++ b/cli/internal/docker/command/executor_test.go
@@ -66,15 +66,6 @@ func TestRealCommandExecutor_ExecuteCommand_Local(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Skip empty command test as it would panic
-			if len(tt.command) == 0 {
-				defer func() {
-					if r := recover(); r == nil {
-						t.Error("Expected panic for empty command")
-					}
-				}()
-			}
-
 			stdout, stderr, err := executor.ExecuteCommand(ctx, host, tt.command)
 
 			if (err != nil) != tt.wantErr {

--- a/cli/internal/docker/command/test_helpers.go
+++ b/cli/internal/docker/command/test_helpers.go
@@ -21,6 +21,7 @@ type MockCommandExecutor struct {
 
 	// ExecutedCommands tracks what commands were executed
 	ExecutedCommands []ExecutedCommand
+	CopiedFiles      []CopiedFile
 
 	// FailureMode simulates specific failures
 	FailureMode string
@@ -42,6 +43,13 @@ type ExecutedCommand struct {
 	Host    *hostparse.HostInfo
 	Command []string
 	Context context.Context
+}
+
+// CopiedFile tracks file copy operations.
+type CopiedFile struct {
+	Host       *hostparse.HostInfo
+	LocalPath  string
+	RemotePath string
 }
 
 // NewMockCommandExecutor creates a new MockCommandExecutor
@@ -100,6 +108,15 @@ func (m *MockCommandExecutor) ExecuteCommand(ctx context.Context, host *hostpars
 
 	// Return default response
 	return m.DefaultResponse.Stdout, m.DefaultResponse.Stderr, m.DefaultResponse.Error
+}
+
+// CopyFile simulates copying a local file to a host.
+func (m *MockCommandExecutor) CopyFile(_ context.Context, host *hostparse.HostInfo, localPath, remotePath string) error {
+	m.CopiedFiles = append(m.CopiedFiles, CopiedFile{Host: host, LocalPath: localPath, RemotePath: remotePath})
+	if m.FailureMode == "copy_failure" {
+		return fmt.Errorf("copy failed")
+	}
+	return nil
 }
 
 // SetCommandResponse sets the response for a specific command

--- a/cli/internal/docker/command/types.go
+++ b/cli/internal/docker/command/types.go
@@ -43,6 +43,7 @@ type ContainerConfig struct {
 	Devices      []string          // Host devices to pass through (--device flags)
 	CapAdd       []string          // Linux capabilities to add (--cap-add flags)
 	Ulimits      []string          // Resource limits (--ulimit flags, e.g. "memlock=-1:-1")
+	BindMounts   []string          // Docker bind specs, e.g. host:container:ro
 }
 
 // PortMapping represents a Docker port mapping

--- a/cli/internal/netprobe/netprobe_test.go
+++ b/cli/internal/netprobe/netprobe_test.go
@@ -36,6 +36,10 @@ func (m *mockExec) set(cmd string, out, errStr string, err error) {
 	}{out, errStr, err}
 }
 
+func (m *mockExec) CopyFile(context.Context, *hostparse.HostInfo, string, string) error {
+	return nil
+}
+
 func (m *mockExec) ExecuteCommand(ctx context.Context, host *hostparse.HostInfo, cmd []string) (string, string, error) {
 	key := strings.Join(cmd, " ")
 	m.calls = append(m.calls, key)

--- a/cli/internal/results/fetcher.go
+++ b/cli/internal/results/fetcher.go
@@ -1,6 +1,7 @@
 package results
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -18,7 +19,10 @@ import (
 	"github.com/dell/storage-performance-tool/cli/internal/secretmask"
 )
 
-const fileStatusMissing = "missing"
+const (
+	fileStatusMissing   = "missing"
+	logArtifactPageSize = 1024 * 1024
+)
 
 // ArtifactSpec defines a log endpoint and its output filename suffix.
 type ArtifactSpec struct {
@@ -211,7 +215,7 @@ func (f *Fetcher) fetchStep(ctx context.Context, stepID string) StepManifest {
 		}
 		idxItem := indexMap[selected]
 		outPath := filepath.Join(f.OutputDir, name)
-		size, err := f.downloadOne(ctx, stepID, selected, outPath)
+		size, err := f.downloadOne(ctx, stepID, selected, outPath, idxItem.Size)
 		if err != nil {
 			status := fileStatusMissing
 			if !errors.Is(err, errNotFound) {
@@ -294,17 +298,23 @@ func normalizeResultXML(filePath, rootTag string) int64 {
 	return int64(len(out))
 }
 
-func (f *Fetcher) downloadOne(ctx context.Context, stepID, logger, outPath string) (int64, error) {
+func (f *Fetcher) downloadOne(ctx context.Context, stepID, logger, outPath string, expectedSize int64) (int64, error) {
 	u, err := url.Parse(f.BaseURL)
 	if err != nil {
 		return 0, fmt.Errorf("parse base url: %w", err)
 	}
 	u.Path = path.Join(u.Path, "/logs/", stepID, logger)
+	if expectedSize > logArtifactPageSize {
+		return f.downloadOneRanged(ctx, u.String(), outPath, expectedSize)
+	}
+	return f.downloadOnePlain(ctx, u.String(), outPath, expectedSize)
+}
 
+func (f *Fetcher) downloadOnePlain(ctx context.Context, url, outPath string, _ int64) (int64, error) {
 	var lastErr error
 	var bytesWritten int64
 	for attempt := 0; attempt < max(1, f.Retries); attempt++ {
-		req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 		if err != nil {
 			return 0, fmt.Errorf("new request: %w", err)
 		}
@@ -316,67 +326,161 @@ func (f *Fetcher) downloadOne(ctx context.Context, stepID, logger, outPath strin
 				defer func() { _ = resp.Body.Close() }()
 				switch resp.StatusCode {
 				case http.StatusOK:
-					// Write to temp then rename
-					tmpDir := filepath.Dir(outPath)
-					if err := os.MkdirAll(tmpDir, 0o750); err != nil {
-						lastErr = fmt.Errorf("mkdir: %w", err)
-						return
-					}
-					tmp, err := os.CreateTemp(tmpDir, ".part-*")
+					n, err := writeResponseToFile(resp.Body, outPath)
 					if err != nil {
-						lastErr = fmt.Errorf("create temp: %w", err)
+						lastErr = err
 						return
 					}
-					n, copyErr := io.Copy(tmp, resp.Body)
-					if closeErr := tmp.Close(); closeErr != nil && copyErr == nil {
-						copyErr = closeErr
-					}
-					if copyErr != nil {
-						_ = os.Remove(tmp.Name())
-						lastErr = fmt.Errorf("write file: %w", copyErr)
-						return
-					}
-					if err := os.Rename(tmp.Name(), outPath); err != nil {
-						_ = os.Remove(tmp.Name())
-						lastErr = fmt.Errorf("rename file: %w", err)
-						return
-					}
-					// success
 					lastErr = nil
 					bytesWritten = n
-					return
 				case http.StatusNotFound:
 					lastErr = errNotFound
 				default:
-					b, _ := io.ReadAll(resp.Body)
-					if len(b) > 0 {
-						lastErr = fmt.Errorf("status %d: %s", resp.StatusCode, string(b))
-					} else {
-						lastErr = fmt.Errorf("status %d", resp.StatusCode)
-					}
+					lastErr = responseStatusError(resp)
 				}
 			}()
 		}
-
 		if lastErr == nil {
 			return bytesWritten, nil
 		}
-
-		// Stop retrying on 404
 		if errors.Is(lastErr, errNotFound) {
 			break
 		}
-		// Delay before next attempt unless last attempt
-		if attempt < f.Retries-1 && f.RetryDelay > 0 && f.Sleeper != nil {
-			f.Sleeper(f.RetryDelay)
-		}
+		f.sleepBeforeRetry(attempt)
 	}
-
 	if lastErr == nil {
-		// Shouldn't happen; treat as error
 		return 0, fmt.Errorf("unknown download state")
 	}
 	return 0, lastErr
+}
+
+func (f *Fetcher) downloadOneRanged(ctx context.Context, url, outPath string, expectedSize int64) (int64, error) {
+	tmpDir := filepath.Dir(outPath)
+	if err := os.MkdirAll(tmpDir, 0o750); err != nil {
+		return 0, fmt.Errorf("mkdir: %w", err)
+	}
+	tmp, err := os.CreateTemp(tmpDir, ".part-*")
+	if err != nil {
+		return 0, fmt.Errorf("create temp: %w", err)
+	}
+	tmpName := tmp.Name()
+	var bytesWritten int64
+	defer func() { _ = os.Remove(tmpName) }()
+	for start := int64(0); start < expectedSize; start += logArtifactPageSize {
+		end := min(start+logArtifactPageSize-1, expectedSize-1)
+		n, err := f.downloadRangeChunk(ctx, url, tmp, start, end)
+		if err != nil {
+			_ = tmp.Close()
+			return 0, err
+		}
+		want := end - start + 1
+		if n != want {
+			_ = tmp.Close()
+			return 0, fmt.Errorf("range %d-%d returned %d bytes, want %d", start, end, n, want)
+		}
+		bytesWritten += n
+	}
+	if err := tmp.Close(); err != nil {
+		return 0, fmt.Errorf("close temp: %w", err)
+	}
+	if bytesWritten != expectedSize {
+		return 0, fmt.Errorf("downloaded size %d does not match index size %d", bytesWritten, expectedSize)
+	}
+	if err := os.Rename(tmpName, outPath); err != nil {
+		return 0, fmt.Errorf("rename file: %w", err)
+	}
+	return bytesWritten, nil
+}
+
+func (f *Fetcher) downloadRangeChunk(ctx context.Context, url string, out io.Writer, start, end int64) (int64, error) {
+	var lastErr error
+	var bytesWritten int64
+	for attempt := 0; attempt < max(1, f.Retries); attempt++ {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+		if err != nil {
+			return 0, fmt.Errorf("new request: %w", err)
+		}
+		req.Header.Set("Range", fmt.Sprintf("bytes=%d-%d", start, end))
+		resp, err := f.HTTPClient.Do(req)
+		if err != nil {
+			lastErr = err
+		} else {
+			func() {
+				defer func() { _ = resp.Body.Close() }()
+				switch resp.StatusCode {
+				case http.StatusOK, http.StatusPartialContent:
+					var buf bytes.Buffer
+					bytesWritten, lastErr = io.Copy(&buf, resp.Body)
+					if lastErr != nil {
+						lastErr = fmt.Errorf("read range %d-%d: %w", start, end, lastErr)
+						return
+					}
+					n, err := out.Write(buf.Bytes())
+					if err != nil {
+						lastErr = fmt.Errorf("write range %d-%d: %w", start, end, err)
+						return
+					}
+					if int64(n) != bytesWritten {
+						lastErr = fmt.Errorf("write range %d-%d: %w", start, end, io.ErrShortWrite)
+					}
+				case http.StatusNotFound:
+					lastErr = errNotFound
+				default:
+					lastErr = responseStatusError(resp)
+				}
+			}()
+		}
+		if lastErr == nil {
+			return bytesWritten, nil
+		}
+		if errors.Is(lastErr, errNotFound) {
+			break
+		}
+		f.sleepBeforeRetry(attempt)
+	}
+	if lastErr == nil {
+		return 0, fmt.Errorf("unknown range download state")
+	}
+	return 0, lastErr
+}
+
+func (f *Fetcher) sleepBeforeRetry(attempt int) {
+	if attempt < f.Retries-1 && f.RetryDelay > 0 && f.Sleeper != nil {
+		f.Sleeper(f.RetryDelay)
+	}
+}
+
+func writeResponseToFile(body io.Reader, outPath string) (int64, error) {
+	tmpDir := filepath.Dir(outPath)
+	if err := os.MkdirAll(tmpDir, 0o750); err != nil {
+		return 0, fmt.Errorf("mkdir: %w", err)
+	}
+	tmp, err := os.CreateTemp(tmpDir, ".part-*")
+	if err != nil {
+		return 0, fmt.Errorf("create temp: %w", err)
+	}
+	tmpName := tmp.Name()
+	n, copyErr := io.Copy(tmp, body)
+	if closeErr := tmp.Close(); closeErr != nil && copyErr == nil {
+		copyErr = closeErr
+	}
+	if copyErr != nil {
+		_ = os.Remove(tmpName)
+		return 0, fmt.Errorf("write file: %w", copyErr)
+	}
+	if err := os.Rename(tmpName, outPath); err != nil {
+		_ = os.Remove(tmpName)
+		return 0, fmt.Errorf("rename file: %w", err)
+	}
+	return n, nil
+}
+
+func responseStatusError(resp *http.Response) error {
+	b, _ := io.ReadAll(resp.Body)
+	if len(b) > 0 {
+		return fmt.Errorf("status %d: %s", resp.StatusCode, string(b))
+	}
+	return fmt.Errorf("status %d", resp.StatusCode)
 }
 
 // stepIndexItem represents one item in /logs/<stepId>/index.json

--- a/cli/internal/results/fetcher.go
+++ b/cli/internal/results/fetcher.go
@@ -19,10 +19,7 @@ import (
 	"github.com/dell/storage-performance-tool/cli/internal/secretmask"
 )
 
-const (
-	fileStatusMissing   = "missing"
-	logArtifactPageSize = 1024 * 1024
-)
+const fileStatusMissing = "missing"
 
 // ArtifactSpec defines a log endpoint and its output filename suffix.
 type ArtifactSpec struct {
@@ -298,19 +295,49 @@ func normalizeResultXML(filePath, rootTag string) int64 {
 	return int64(len(out))
 }
 
-func (f *Fetcher) downloadOne(ctx context.Context, stepID, logger, outPath string, expectedSize int64) (int64, error) {
+func (f *Fetcher) downloadOne(ctx context.Context, stepID, logger, outPath string, indexedSize int64) (int64, error) {
 	u, err := url.Parse(f.BaseURL)
 	if err != nil {
 		return 0, fmt.Errorf("parse base url: %w", err)
 	}
 	u.Path = path.Join(u.Path, "/logs/", stepID, logger)
-	if expectedSize > logArtifactPageSize {
+	expectedSize, err := f.resolveArtifactSize(ctx, u.String(), indexedSize)
+	if err != nil {
+		return 0, err
+	}
+	if expectedSize > constants.EnginePlainLogArtifactMaxBytes {
 		return f.downloadOneRanged(ctx, u.String(), outPath, expectedSize)
 	}
 	return f.downloadOnePlain(ctx, u.String(), outPath, expectedSize)
 }
 
-func (f *Fetcher) downloadOnePlain(ctx context.Context, url, outPath string, _ int64) (int64, error) {
+func (f *Fetcher) resolveArtifactSize(ctx context.Context, url string, indexedSize int64) (int64, error) {
+	if indexedSize > 0 {
+		return indexedSize, nil
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodHead, url, nil)
+	if err != nil {
+		return 0, fmt.Errorf("new HEAD request: %w", err)
+	}
+	resp, err := f.HTTPClient.Do(req)
+	if err != nil {
+		return 0, fmt.Errorf("resolve artifact size with HEAD: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	switch resp.StatusCode {
+	case http.StatusOK:
+		if resp.ContentLength >= 0 {
+			return resp.ContentLength, nil
+		}
+		return 0, fmt.Errorf("artifact size missing in index and HEAD response")
+	case http.StatusNotFound:
+		return 0, errNotFound
+	default:
+		return 0, responseStatusError(resp)
+	}
+}
+
+func (f *Fetcher) downloadOnePlain(ctx context.Context, url, outPath string, expectedSize int64) (int64, error) {
 	var lastErr error
 	var bytesWritten int64
 	for attempt := 0; attempt < max(1, f.Retries); attempt++ {
@@ -329,6 +356,11 @@ func (f *Fetcher) downloadOnePlain(ctx context.Context, url, outPath string, _ i
 					n, err := writeResponseToFile(resp.Body, outPath)
 					if err != nil {
 						lastErr = err
+						return
+					}
+					if n < expectedSize {
+						_ = os.Remove(outPath)
+						lastErr = fmt.Errorf("downloaded size %d is smaller than index size %d", n, expectedSize)
 						return
 					}
 					lastErr = nil
@@ -366,19 +398,30 @@ func (f *Fetcher) downloadOneRanged(ctx context.Context, url, outPath string, ex
 	tmpName := tmp.Name()
 	var bytesWritten int64
 	defer func() { _ = os.Remove(tmpName) }()
-	for start := int64(0); start < expectedSize; start += logArtifactPageSize {
-		end := min(start+logArtifactPageSize-1, expectedSize-1)
-		n, err := f.downloadRangeChunk(ctx, url, tmp, start, end)
+	// Keep chunks aligned with LogServlet.LOG_PAGE_SIZE_LIMIT;
+	// the engine caps each ranged response at that size.
+	for start := int64(0); start < expectedSize; start += constants.EngineLogArtifactPageSize {
+		end := min(start+constants.EngineLogArtifactPageSize-1, expectedSize-1)
+		chunk, err := f.downloadRangeChunk(ctx, url, start, end)
 		if err != nil {
 			_ = tmp.Close()
 			return 0, err
 		}
 		want := end - start + 1
-		if n != want {
+		if int64(len(chunk)) != want {
 			_ = tmp.Close()
-			return 0, fmt.Errorf("range %d-%d returned %d bytes, want %d", start, end, n, want)
+			return 0, fmt.Errorf("range %d-%d returned %d bytes, want %d", start, end, len(chunk), want)
 		}
-		bytesWritten += n
+		n, err := tmp.Write(chunk)
+		if err != nil {
+			_ = tmp.Close()
+			return 0, fmt.Errorf("write range %d-%d: %w", start, end, err)
+		}
+		if n != len(chunk) {
+			_ = tmp.Close()
+			return 0, fmt.Errorf("write range %d-%d: %w", start, end, io.ErrShortWrite)
+		}
+		bytesWritten += int64(n)
 	}
 	if err := tmp.Close(); err != nil {
 		return 0, fmt.Errorf("close temp: %w", err)
@@ -392,46 +435,39 @@ func (f *Fetcher) downloadOneRanged(ctx context.Context, url, outPath string, ex
 	return bytesWritten, nil
 }
 
-func (f *Fetcher) downloadRangeChunk(ctx context.Context, url string, out io.Writer, start, end int64) (int64, error) {
+func (f *Fetcher) downloadRangeChunk(ctx context.Context, url string, start, end int64) ([]byte, error) {
 	var lastErr error
-	var bytesWritten int64
 	for attempt := 0; attempt < max(1, f.Retries); attempt++ {
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 		if err != nil {
-			return 0, fmt.Errorf("new request: %w", err)
+			return nil, fmt.Errorf("new request: %w", err)
 		}
 		req.Header.Set("Range", fmt.Sprintf("bytes=%d-%d", start, end))
 		resp, err := f.HTTPClient.Do(req)
 		if err != nil {
 			lastErr = err
 		} else {
+			var chunk []byte
 			func() {
 				defer func() { _ = resp.Body.Close() }()
 				switch resp.StatusCode {
 				case http.StatusOK, http.StatusPartialContent:
 					var buf bytes.Buffer
-					bytesWritten, lastErr = io.Copy(&buf, resp.Body)
+					_, lastErr = io.Copy(&buf, resp.Body)
 					if lastErr != nil {
 						lastErr = fmt.Errorf("read range %d-%d: %w", start, end, lastErr)
 						return
 					}
-					n, err := out.Write(buf.Bytes())
-					if err != nil {
-						lastErr = fmt.Errorf("write range %d-%d: %w", start, end, err)
-						return
-					}
-					if int64(n) != bytesWritten {
-						lastErr = fmt.Errorf("write range %d-%d: %w", start, end, io.ErrShortWrite)
-					}
+					chunk = buf.Bytes()
 				case http.StatusNotFound:
 					lastErr = errNotFound
 				default:
 					lastErr = responseStatusError(resp)
 				}
 			}()
-		}
-		if lastErr == nil {
-			return bytesWritten, nil
+			if lastErr == nil {
+				return chunk, nil
+			}
 		}
 		if errors.Is(lastErr, errNotFound) {
 			break
@@ -439,9 +475,9 @@ func (f *Fetcher) downloadRangeChunk(ctx context.Context, url string, out io.Wri
 		f.sleepBeforeRetry(attempt)
 	}
 	if lastErr == nil {
-		return 0, fmt.Errorf("unknown range download state")
+		return nil, fmt.Errorf("unknown range download state")
 	}
-	return 0, lastErr
+	return nil, lastErr
 }
 
 func (f *Fetcher) sleepBeforeRetry(attempt int) {

--- a/cli/internal/results/fetcher_test.go
+++ b/cli/internal/results/fetcher_test.go
@@ -1,8 +1,10 @@
 package results
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -99,6 +101,136 @@ func TestFetcher_HappyPath_AllArtifacts(t *testing.T) {
 	}
 	if man.BaseURL == "" || man.OutputDir == "" || len(man.Steps) != 1 {
 		t.Fatalf("manifest fields not populated correctly: %#v", man)
+	}
+}
+
+func TestFetcher_DownloadsLargeArtifactsWithRanges(t *testing.T) {
+	step := "mt-001-20250101.000000.000-create"
+	const pageSize = 1024 * 1024
+	largeContent := bytes.Repeat([]byte("0123456789abcdef"), (2*pageSize+123)/16+1)
+	largeContent = largeContent[:2*pageSize+123]
+	var rangeCalls int32
+	var plainItemsCalls int32
+
+	srv := newTestServer(t, map[string]http.HandlerFunc{
+		"/logs/" + step + "/index.json": func(w http.ResponseWriter, r *http.Request) {
+			idx := map[string]any{
+				"step_id": step,
+				"items": []map[string]any{
+					{"logger": "metrics.FileTotal", "href": "/logs/" + step + "/metrics.FileTotal", "size": 5},
+					{"logger": "items.csv", "href": "/logs/" + step + "/items.csv", "size": len(largeContent)},
+				},
+			}
+			_ = json.NewEncoder(w).Encode(idx)
+		},
+		"/logs/" + step + "/metrics.FileTotal": func(w http.ResponseWriter, r *http.Request) { _, _ = w.Write([]byte("total")) },
+		"/logs/" + step + "/items.csv": func(w http.ResponseWriter, r *http.Request) {
+			rangeHeader := r.Header.Get("Range")
+			if rangeHeader == "" {
+				atomic.AddInt32(&plainItemsCalls, 1)
+				_, _ = w.Write(largeContent[:pageSize])
+				return
+			}
+			atomic.AddInt32(&rangeCalls, 1)
+			var start, end int
+			if _, err := fmt.Sscanf(rangeHeader, "bytes=%d-%d", &start, &end); err != nil {
+				http.Error(w, "bad range", http.StatusRequestedRangeNotSatisfiable)
+				return
+			}
+			if start < 0 || end < start || end >= len(largeContent) {
+				http.Error(w, "bad range", http.StatusRequestedRangeNotSatisfiable)
+				return
+			}
+			_, _ = w.Write(largeContent[start : end+1])
+		},
+	})
+	defer srv.Close()
+
+	out := t.TempDir()
+	f := NewFetcher(srv.URL, out)
+	f.Sleeper = func(time.Duration) {}
+	f.Artifacts = []ArtifactSpec{
+		{Loggers: []string{"metrics.FileTotal"}, Suffix: "metrics.total.csv", Required: true},
+		{Loggers: []string{"items.csv"}, Suffix: "items.csv", Required: false},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if _, err := f.FetchArtifactsForSteps(ctx, []string{step}); err != nil {
+		t.Fatalf("FetchArtifactsForSteps error: %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(out, step+".items.csv"))
+	if err != nil {
+		t.Fatalf("read items artifact: %v", err)
+	}
+	if !bytes.Equal(got, largeContent) {
+		t.Fatalf("downloaded items length/content mismatch: got %d bytes, want %d", len(got), len(largeContent))
+	}
+	if atomic.LoadInt32(&rangeCalls) == 0 {
+		t.Fatal("expected range requests for large artifact")
+	}
+	if atomic.LoadInt32(&plainItemsCalls) != 0 {
+		t.Fatal("large artifact should not be fetched with a plain GET")
+	}
+}
+
+func TestFetcher_LargeArtifactRangeFailureMarksError(t *testing.T) {
+	step := "mt-001-20250101.000000.000-create"
+	const pageSize = 1024 * 1024
+	largeSize := int64(pageSize + 10)
+	srv := newTestServer(t, map[string]http.HandlerFunc{
+		"/logs/" + step + "/index.json": func(w http.ResponseWriter, r *http.Request) {
+			idx := map[string]any{
+				"step_id": step,
+				"items": []map[string]any{
+					{"logger": "metrics.FileTotal", "href": "/logs/" + step + "/metrics.FileTotal", "size": 5},
+					{"logger": "items.csv", "href": "/logs/" + step + "/items.csv", "size": largeSize},
+				},
+			}
+			_ = json.NewEncoder(w).Encode(idx)
+		},
+		"/logs/" + step + "/metrics.FileTotal": func(w http.ResponseWriter, r *http.Request) { _, _ = w.Write([]byte("total")) },
+		"/logs/" + step + "/items.csv": func(w http.ResponseWriter, r *http.Request) {
+			if r.Header.Get("Range") == "bytes=0-1048575" {
+				_, _ = w.Write(bytes.Repeat([]byte("a"), pageSize))
+				return
+			}
+			http.Error(w, "chunk failed", http.StatusInternalServerError)
+		},
+	})
+	defer srv.Close()
+
+	out := t.TempDir()
+	f := NewFetcher(srv.URL, out)
+	f.Sleeper = func(time.Duration) {}
+	f.Retries = 1
+	f.Artifacts = []ArtifactSpec{
+		{Loggers: []string{"metrics.FileTotal"}, Suffix: "metrics.total.csv", Required: true},
+		{Loggers: []string{"items.csv"}, Suffix: "items.csv", Required: false},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	man, err := f.FetchArtifactsForSteps(ctx, []string{step})
+	if err != nil {
+		t.Fatalf("FetchArtifactsForSteps error = %v", err)
+	}
+	var itemStatus *FileStatus
+	for i := range man.Steps[0].Files {
+		if man.Steps[0].Files[i].Name == step+".items.csv" {
+			itemStatus = &man.Steps[0].Files[i]
+			break
+		}
+	}
+	if itemStatus == nil {
+		t.Fatal("items.csv status not recorded")
+	}
+	if itemStatus.Status != "error" || !strings.Contains(itemStatus.Error, "chunk failed") {
+		t.Fatalf("items.csv status = %#v, want error containing chunk failure", itemStatus)
+	}
+	if _, err := os.Stat(filepath.Join(out, step+".items.csv")); !os.IsNotExist(err) {
+		t.Fatalf("partial items artifact should not exist, stat err = %v", err)
 	}
 }
 

--- a/cli/internal/results/fetcher_test.go
+++ b/cli/internal/results/fetcher_test.go
@@ -24,6 +24,37 @@ func newTestServer(t *testing.T, handlers map[string]http.HandlerFunc) *httptest
 	return httptest.NewServer(mux)
 }
 
+func enginePagedArtifactHandler(content []byte, pageSize int, plainCalls, rangeCalls *int32) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodHead {
+			w.Header().Set("Content-Length", fmt.Sprint(len(content)))
+			return
+		}
+		rangeHeader := r.Header.Get("Range")
+		if rangeHeader == "" {
+			if plainCalls != nil {
+				atomic.AddInt32(plainCalls, 1)
+			}
+			_, _ = w.Write(content[:min(len(content), pageSize-1)])
+			return
+		}
+		if rangeCalls != nil {
+			atomic.AddInt32(rangeCalls, 1)
+		}
+		var start, end int64
+		if _, err := fmt.Sscanf(rangeHeader, "bytes=%d-%d", &start, &end); err != nil {
+			http.Error(w, "bad range", http.StatusRequestedRangeNotSatisfiable)
+			return
+		}
+		if start < 0 || end < start || start >= int64(len(content)) {
+			http.Error(w, "bad range", http.StatusRequestedRangeNotSatisfiable)
+			return
+		}
+		n := min(end+1, int64(pageSize), int64(len(content))-start)
+		_, _ = w.Write(content[int(start):int(start+n)])
+	}
+}
+
 func TestFetcher_HappyPath_AllArtifacts(t *testing.T) {
 	step := "mt-001-20250101.000000.000-create"
 	srv := newTestServer(t, map[string]http.HandlerFunc{
@@ -36,11 +67,11 @@ func TestFetcher_HappyPath_AllArtifacts(t *testing.T) {
 					{"logger": "Cli", "href": "/logs/" + step + "/Cli", "size": 3},
 					{"logger": "Messages", "href": "/logs/" + step + "/Messages", "size": 4},
 					{"logger": "Errors", "href": "/logs/" + step + "/Errors", "size": 4},
-					{"logger": "metrics.File", "href": "/logs/" + step + "/metrics.File", "size": 5},
+					{"logger": "metrics.File", "href": "/logs/" + step + "/metrics.File", "size": 4},
 					{"logger": "Scenario", "href": "/logs/" + step + "/Scenario", "size": 3},
 					{"logger": "metrics.threshold.FileTotal", "href": "/logs/" + step + "/metrics.threshold.FileTotal", "size": 2},
 					{"logger": "OpTraces", "href": "/logs/" + step + "/OpTraces", "size": 5},
-					{"logger": "PartsUpload", "href": "/logs/" + step + "/PartsUpload", "size": 10},
+					{"logger": "PartsUpload", "href": "/logs/" + step + "/PartsUpload", "size": 12},
 				},
 			}
 			_ = json.NewEncoder(w).Encode(idx)
@@ -124,25 +155,7 @@ func TestFetcher_DownloadsLargeArtifactsWithRanges(t *testing.T) {
 			_ = json.NewEncoder(w).Encode(idx)
 		},
 		"/logs/" + step + "/metrics.FileTotal": func(w http.ResponseWriter, r *http.Request) { _, _ = w.Write([]byte("total")) },
-		"/logs/" + step + "/items.csv": func(w http.ResponseWriter, r *http.Request) {
-			rangeHeader := r.Header.Get("Range")
-			if rangeHeader == "" {
-				atomic.AddInt32(&plainItemsCalls, 1)
-				_, _ = w.Write(largeContent[:pageSize])
-				return
-			}
-			atomic.AddInt32(&rangeCalls, 1)
-			var start, end int
-			if _, err := fmt.Sscanf(rangeHeader, "bytes=%d-%d", &start, &end); err != nil {
-				http.Error(w, "bad range", http.StatusRequestedRangeNotSatisfiable)
-				return
-			}
-			if start < 0 || end < start || end >= len(largeContent) {
-				http.Error(w, "bad range", http.StatusRequestedRangeNotSatisfiable)
-				return
-			}
-			_, _ = w.Write(largeContent[start : end+1])
-		},
+		"/logs/" + step + "/items.csv":         enginePagedArtifactHandler(largeContent, pageSize, &plainItemsCalls, &rangeCalls),
 	})
 	defer srv.Close()
 
@@ -172,6 +185,190 @@ func TestFetcher_DownloadsLargeArtifactsWithRanges(t *testing.T) {
 	}
 	if atomic.LoadInt32(&plainItemsCalls) != 0 {
 		t.Fatal("large artifact should not be fetched with a plain GET")
+	}
+}
+
+func TestFetcher_DownloadsPageSizedArtifactWithRanges(t *testing.T) {
+	step := "mt-001-20250101.000000.000-create"
+	const pageSize = 1024 * 1024
+	content := bytes.Repeat([]byte("x"), pageSize)
+	var rangeCalls int32
+	var plainCalls int32
+	srv := newTestServer(t, map[string]http.HandlerFunc{
+		"/logs/" + step + "/index.json": func(w http.ResponseWriter, r *http.Request) {
+			idx := map[string]any{
+				"step_id": step,
+				"items": []map[string]any{
+					{"logger": "metrics.FileTotal", "href": "/logs/" + step + "/metrics.FileTotal", "size": 5},
+					{"logger": "items.csv", "href": "/logs/" + step + "/items.csv", "size": len(content)},
+				},
+			}
+			_ = json.NewEncoder(w).Encode(idx)
+		},
+		"/logs/" + step + "/metrics.FileTotal": func(w http.ResponseWriter, r *http.Request) { _, _ = w.Write([]byte("total")) },
+		"/logs/" + step + "/items.csv":         enginePagedArtifactHandler(content, pageSize, &plainCalls, &rangeCalls),
+	})
+	defer srv.Close()
+
+	out := t.TempDir()
+	f := NewFetcher(srv.URL, out)
+	f.Sleeper = func(time.Duration) {}
+	f.Artifacts = []ArtifactSpec{
+		{Loggers: []string{"metrics.FileTotal"}, Suffix: "metrics.total.csv", Required: true},
+		{Loggers: []string{"items.csv"}, Suffix: "items.csv", Required: false},
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if _, err := f.FetchArtifactsForSteps(ctx, []string{step}); err != nil {
+		t.Fatalf("FetchArtifactsForSteps error: %v", err)
+	}
+	got, err := os.ReadFile(filepath.Join(out, step+".items.csv"))
+	if err != nil {
+		t.Fatalf("read items artifact: %v", err)
+	}
+	if !bytes.Equal(got, content) {
+		t.Fatalf("downloaded items length/content mismatch: got %d bytes, want %d", len(got), len(content))
+	}
+	if atomic.LoadInt32(&rangeCalls) == 0 || atomic.LoadInt32(&plainCalls) != 0 {
+		t.Fatalf("rangeCalls=%d plainCalls=%d, want ranged only", rangeCalls, plainCalls)
+	}
+}
+
+func TestFetcher_UsesHeadSizeWhenIndexOmitsSize(t *testing.T) {
+	step := "mt-001-20250101.000000.000-create"
+	const pageSize = 1024 * 1024
+	content := bytes.Repeat([]byte("abcdef"), (pageSize+100)/6+1)
+	content = content[:pageSize+100]
+	var rangeCalls int32
+	srv := newTestServer(t, map[string]http.HandlerFunc{
+		"/logs/" + step + "/index.json": func(w http.ResponseWriter, r *http.Request) {
+			idx := map[string]any{
+				"step_id": step,
+				"items": []map[string]any{
+					{"logger": "metrics.FileTotal", "href": "/logs/" + step + "/metrics.FileTotal", "size": 5},
+					{"logger": "items.csv", "href": "/logs/" + step + "/items.csv"},
+				},
+			}
+			_ = json.NewEncoder(w).Encode(idx)
+		},
+		"/logs/" + step + "/metrics.FileTotal": func(w http.ResponseWriter, r *http.Request) { _, _ = w.Write([]byte("total")) },
+		"/logs/" + step + "/items.csv":         enginePagedArtifactHandler(content, pageSize, nil, &rangeCalls),
+	})
+	defer srv.Close()
+
+	out := t.TempDir()
+	f := NewFetcher(srv.URL, out)
+	f.Sleeper = func(time.Duration) {}
+	f.Artifacts = []ArtifactSpec{
+		{Loggers: []string{"metrics.FileTotal"}, Suffix: "metrics.total.csv", Required: true},
+		{Loggers: []string{"items.csv"}, Suffix: "items.csv", Required: false},
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if _, err := f.FetchArtifactsForSteps(ctx, []string{step}); err != nil {
+		t.Fatalf("FetchArtifactsForSteps error: %v", err)
+	}
+	got, err := os.ReadFile(filepath.Join(out, step+".items.csv"))
+	if err != nil {
+		t.Fatalf("read items artifact: %v", err)
+	}
+	if !bytes.Equal(got, content) {
+		t.Fatalf("downloaded items length/content mismatch: got %d bytes, want %d", len(got), len(content))
+	}
+	if atomic.LoadInt32(&rangeCalls) == 0 {
+		t.Fatal("expected range requests after resolving size with HEAD")
+	}
+}
+
+func TestFetcher_SmallArtifactCanGrowAfterIndex(t *testing.T) {
+	step := "mt-001-20250101.000000.000-create"
+	srv := newTestServer(t, map[string]http.HandlerFunc{
+		"/logs/" + step + "/index.json": func(w http.ResponseWriter, r *http.Request) {
+			idx := map[string]any{
+				"step_id": step,
+				"items": []map[string]any{
+					{"logger": "metrics.FileTotal", "href": "/logs/" + step + "/metrics.FileTotal", "size": 5},
+					{"logger": "Messages", "href": "/logs/" + step + "/Messages", "size": 4},
+				},
+			}
+			_ = json.NewEncoder(w).Encode(idx)
+		},
+		"/logs/" + step + "/metrics.FileTotal": func(w http.ResponseWriter, r *http.Request) { _, _ = w.Write([]byte("total")) },
+		"/logs/" + step + "/Messages":          func(w http.ResponseWriter, r *http.Request) { _, _ = w.Write([]byte("msgs\n")) },
+	})
+	defer srv.Close()
+
+	out := t.TempDir()
+	f := NewFetcher(srv.URL, out)
+	f.Sleeper = func(time.Duration) {}
+	f.Artifacts = []ArtifactSpec{
+		{Loggers: []string{"metrics.FileTotal"}, Suffix: "metrics.total.csv", Required: true},
+		{Loggers: []string{"Messages"}, Suffix: "messages.log", Required: true},
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	man, err := f.FetchArtifactsForSteps(ctx, []string{step})
+	if err != nil {
+		t.Fatalf("FetchArtifactsForSteps error: %v", err)
+	}
+	var messagesStatus *FileStatus
+	for i := range man.Steps[0].Files {
+		if man.Steps[0].Files[i].Name == step+".messages.log" {
+			messagesStatus = &man.Steps[0].Files[i]
+			break
+		}
+	}
+	if messagesStatus == nil {
+		t.Fatal("messages status not recorded")
+	}
+	if messagesStatus.Status != "ok" || messagesStatus.Size != 5 {
+		t.Fatalf("messages status = %#v, want ok with fetched size 5", messagesStatus)
+	}
+}
+
+func TestFetcher_SmallArtifactSizeMismatchMarksError(t *testing.T) {
+	step := "mt-001-20250101.000000.000-create"
+	srv := newTestServer(t, map[string]http.HandlerFunc{
+		"/logs/" + step + "/index.json": func(w http.ResponseWriter, r *http.Request) {
+			idx := map[string]any{
+				"step_id": step,
+				"items": []map[string]any{
+					{"logger": "metrics.FileTotal", "href": "/logs/" + step + "/metrics.FileTotal", "size": 5},
+					{"logger": "items.csv", "href": "/logs/" + step + "/items.csv", "size": 7},
+				},
+			}
+			_ = json.NewEncoder(w).Encode(idx)
+		},
+		"/logs/" + step + "/metrics.FileTotal": func(w http.ResponseWriter, r *http.Request) { _, _ = w.Write([]byte("total")) },
+		"/logs/" + step + "/items.csv":         func(w http.ResponseWriter, r *http.Request) { _, _ = w.Write([]byte("short!")) },
+	})
+	defer srv.Close()
+
+	out := t.TempDir()
+	f := NewFetcher(srv.URL, out)
+	f.Sleeper = func(time.Duration) {}
+	f.Artifacts = []ArtifactSpec{
+		{Loggers: []string{"metrics.FileTotal"}, Suffix: "metrics.total.csv", Required: true},
+		{Loggers: []string{"items.csv"}, Suffix: "items.csv", Required: false},
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	man, err := f.FetchArtifactsForSteps(ctx, []string{step})
+	if err != nil {
+		t.Fatalf("FetchArtifactsForSteps error: %v", err)
+	}
+	var itemStatus *FileStatus
+	for i := range man.Steps[0].Files {
+		if man.Steps[0].Files[i].Name == step+".items.csv" {
+			itemStatus = &man.Steps[0].Files[i]
+			break
+		}
+	}
+	if itemStatus == nil {
+		t.Fatal("items.csv status not recorded")
+	}
+	if itemStatus.Status != "error" || !strings.Contains(itemStatus.Error, "downloaded size 6 is smaller than index size 7") {
+		t.Fatalf("items.csv status = %#v, want short-read error", itemStatus)
 	}
 }
 
@@ -290,13 +487,23 @@ func TestFetcher_MissingOptionalFiles(t *testing.T) {
 
 func TestFetcher_SanitizesConfigArtifact(t *testing.T) {
 	step := "replay-001-20260606.000000.000-create"
+	configArtifact := []byte(`storage:
+  auth:
+    uid: LOCALACCESSKEY
+    secret: LOCALSECRETKEY
+  driver:
+    type: s3
+aws:
+  accessKeyId: AWSACCESSKEY
+  secretAccessKey: AWSSECRETKEY
+`)
 	srv := newTestServer(t, map[string]http.HandlerFunc{
 		"/logs/" + step + "/index.json": func(w http.ResponseWriter, r *http.Request) {
 			idx := map[string]any{
 				"step_id": step,
 				"items": []map[string]any{
 					{"logger": "metrics.FileTotal", "href": "/logs/" + step + "/metrics.FileTotal", "size": 5},
-					{"logger": "Config", "href": "/logs/" + step + "/Config", "size": 120},
+					{"logger": "Config", "href": "/logs/" + step + "/Config", "size": len(configArtifact)},
 					{"logger": "Cli", "href": "/logs/" + step + "/Cli", "size": 3},
 					{"logger": "Messages", "href": "/logs/" + step + "/Messages", "size": 4},
 					{"logger": "Errors", "href": "/logs/" + step + "/Errors", "size": 4},
@@ -306,16 +513,7 @@ func TestFetcher_SanitizesConfigArtifact(t *testing.T) {
 		},
 		"/logs/" + step + "/metrics.FileTotal": func(w http.ResponseWriter, r *http.Request) { _, _ = w.Write([]byte("total")) },
 		"/logs/" + step + "/Config": func(w http.ResponseWriter, r *http.Request) {
-			_, _ = w.Write([]byte(`storage:
-  auth:
-    uid: LOCALACCESSKEY
-    secret: LOCALSECRETKEY
-  driver:
-    type: s3
-aws:
-  accessKeyId: AWSACCESSKEY
-  secretAccessKey: AWSSECRETKEY
-`))
+			_, _ = w.Write(configArtifact)
 		},
 		"/logs/" + step + "/Cli":      func(w http.ResponseWriter, r *http.Request) { _, _ = w.Write([]byte("cli")) },
 		"/logs/" + step + "/Messages": func(w http.ResponseWriter, r *http.Request) { _, _ = w.Write([]byte("msgs")) },
@@ -503,8 +701,8 @@ func TestFetcher_UsesIndexJsonForDiscovery(t *testing.T) {
 					{"logger": "metrics.FileTotal", "href": "/logs/" + step + "/metrics.FileTotal", "size": 5, "modified": time.Now().UTC().Format(time.RFC1123), "content_type": "text/csv"},
 					{"logger": "Config", "href": "/logs/" + step + "/Config", "size": 3, "modified": time.Now().UTC().Format(time.RFC1123), "content_type": "text/yaml"},
 					{"logger": "Cli", "href": "/logs/" + step + "/Cli", "size": 3},
-					{"logger": "Messages", "href": "/logs/" + step + "/Messages", "size": 4},
-					{"logger": "Errors", "href": "/logs/" + step + "/Errors", "size": 4},
+					{"logger": "Messages", "href": "/logs/" + step + "/Messages", "size": 3},
+					{"logger": "Errors", "href": "/logs/" + step + "/Errors", "size": 3},
 				},
 			}
 			_ = json.NewEncoder(w).Encode(idx)

--- a/cli/internal/scenario/item_files.go
+++ b/cli/internal/scenario/item_files.go
@@ -1,0 +1,70 @@
+package scenario
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const containerItemFilesDir = "/spt-input/items"
+
+// FileMount describes a read-only host file bind-mounted into the SPT container.
+type FileMount struct {
+	HostPath      string
+	ContainerPath string
+}
+
+// PrepareExternalItemFiles rewrites user-provided item CSV paths to container paths.
+func PrepareExternalItemFiles(params Params) (Params, error) {
+	if len(params.ItemFileMounts) > 0 || !hasExternalItemFiles(params) {
+		return params, nil
+	}
+
+	var mounts []FileMount
+	var err error
+	if params.ItemsFile != "" {
+		params.ItemsFile, mounts, err = prepareItemFileMount(params.ItemsFile, "read-items.csv", mounts)
+		if err != nil {
+			return params, fmt.Errorf("--items-file: %w", err)
+		}
+	}
+	if params.ReadItemsFile != "" {
+		params.ReadItemsFile, mounts, err = prepareItemFileMount(params.ReadItemsFile, "mixed-read-items.csv", mounts)
+		if err != nil {
+			return params, fmt.Errorf("--read-items-file: %w", err)
+		}
+	}
+	if params.DeleteItemsFile != "" {
+		params.DeleteItemsFile, mounts, err = prepareItemFileMount(params.DeleteItemsFile, "mixed-delete-items.csv", mounts)
+		if err != nil {
+			return params, fmt.Errorf("--delete-items-file: %w", err)
+		}
+	}
+	params.ItemFileMounts = mounts
+	return params, nil
+}
+
+func hasExternalItemFiles(params Params) bool {
+	return params.ItemsFile != "" || params.ReadItemsFile != "" || params.DeleteItemsFile != ""
+}
+
+func prepareItemFileMount(hostPath, containerName string, mounts []FileMount) (string, []FileMount, error) {
+	if strings.HasPrefix(hostPath, containerItemFilesDir+"/") {
+		return hostPath, mounts, nil
+	}
+	absPath, err := filepath.Abs(hostPath)
+	if err != nil {
+		return "", nil, fmt.Errorf("resolve path %q: %w", hostPath, err)
+	}
+	info, err := os.Stat(absPath)
+	if err != nil {
+		return "", nil, fmt.Errorf("stat %q: %w", hostPath, err)
+	}
+	if info.IsDir() {
+		return "", nil, fmt.Errorf("%q is a directory, expected an items CSV file", hostPath)
+	}
+	containerPath := containerItemFilesDir + "/" + containerName
+	mounts = append(mounts, FileMount{HostPath: absPath, ContainerPath: containerPath})
+	return containerPath, mounts, nil
+}

--- a/cli/internal/scenario/item_files_test.go
+++ b/cli/internal/scenario/item_files_test.go
@@ -1,0 +1,93 @@
+package scenario
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestPrepareExternalItemFilesRewritesReadItemsFileAndRecordsMount(t *testing.T) {
+	dir := t.TempDir()
+	itemsPath := filepath.Join(dir, "items.csv")
+	if err := os.WriteFile(itemsPath, []byte("obj-1\n"), 0o600); err != nil {
+		t.Fatalf("write items file: %v", err)
+	}
+
+	params, err := PrepareExternalItemFiles(Params{WorkloadType: WorkloadTypeRead, ItemsFile: itemsPath})
+	if err != nil {
+		t.Fatalf("PrepareExternalItemFiles() error = %v", err)
+	}
+
+	if params.ItemsFile != "/spt-input/items/read-items.csv" {
+		t.Fatalf("ItemsFile = %q, want container path", params.ItemsFile)
+	}
+	if len(params.ItemFileMounts) != 1 {
+		t.Fatalf("ItemFileMounts len = %d, want 1", len(params.ItemFileMounts))
+	}
+	mount := params.ItemFileMounts[0]
+	if mount.HostPath != itemsPath {
+		t.Fatalf("mount host path = %q, want %q", mount.HostPath, itemsPath)
+	}
+	if mount.ContainerPath != params.ItemsFile {
+		t.Fatalf("mount container path = %q, want %q", mount.ContainerPath, params.ItemsFile)
+	}
+}
+
+func TestPrepareExternalItemFilesRewritesMixedItemFiles(t *testing.T) {
+	dir := t.TempDir()
+	readPath := filepath.Join(dir, "read.csv")
+	deletePath := filepath.Join(dir, "delete.csv")
+	for _, p := range []string{readPath, deletePath} {
+		if err := os.WriteFile(p, []byte("obj\n"), 0o600); err != nil {
+			t.Fatalf("write %s: %v", p, err)
+		}
+	}
+
+	params, err := PrepareExternalItemFiles(Params{WorkloadType: WorkloadTypeMixed, ReadItemsFile: readPath, DeleteItemsFile: deletePath})
+	if err != nil {
+		t.Fatalf("PrepareExternalItemFiles() error = %v", err)
+	}
+
+	if params.ReadItemsFile != "/spt-input/items/mixed-read-items.csv" {
+		t.Fatalf("ReadItemsFile = %q", params.ReadItemsFile)
+	}
+	if params.DeleteItemsFile != "/spt-input/items/mixed-delete-items.csv" {
+		t.Fatalf("DeleteItemsFile = %q", params.DeleteItemsFile)
+	}
+	if len(params.ItemFileMounts) != 2 {
+		t.Fatalf("ItemFileMounts len = %d, want 2", len(params.ItemFileMounts))
+	}
+}
+
+func TestGenerateScenarioAfterPreparingExternalItemFileUsesContainerPath(t *testing.T) {
+	dir := t.TempDir()
+	itemsPath := filepath.Join(dir, "items.csv")
+	if err := os.WriteFile(itemsPath, []byte("obj-1\n"), 0o600); err != nil {
+		t.Fatalf("write items file: %v", err)
+	}
+	params, err := PrepareExternalItemFiles(Params{WorkloadType: WorkloadTypeRead, Bucket: "bucket", Threads: 1, ObjectSize: "1MB", Duration: "1m", ItemsFile: itemsPath})
+	if err != nil {
+		t.Fatalf("PrepareExternalItemFiles() error = %v", err)
+	}
+	scenarioJS, err := GenerateScenario(params)
+	if err != nil {
+		t.Fatalf("GenerateScenario() error = %v", err)
+	}
+	if !strings.Contains(scenarioJS, `/spt-input/items/read-items.csv`) {
+		t.Fatalf("scenario missing container items path:\n%s", scenarioJS)
+	}
+	if strings.Contains(scenarioJS, itemsPath) {
+		t.Fatalf("scenario leaked host items path %q:\n%s", itemsPath, scenarioJS)
+	}
+}
+
+func TestPrepareExternalItemFilesRejectsMissingFile(t *testing.T) {
+	_, err := PrepareExternalItemFiles(Params{WorkloadType: WorkloadTypeRead, ItemsFile: filepath.Join(t.TempDir(), "missing.csv")})
+	if err == nil {
+		t.Fatal("expected error for missing items file")
+	}
+	if !strings.Contains(err.Error(), "--items-file") || !strings.Contains(err.Error(), "stat") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/cli/internal/scenario/types.go
+++ b/cli/internal/scenario/types.go
@@ -29,6 +29,9 @@ type Params struct {
 	SeedCount int    // Number of seed objects for read benchmark (default: 2500)
 	ItemsFile string // Path to a local items.csv for read workload (skips seed phase)
 
+	// External item files bind-mounted into the engine container.
+	ItemFileMounts []FileMount
+
 	// Write workload
 	SaveItems bool // Save items.csv to the step log directory for later retrieval
 

--- a/cli/internal/verification/conflicts_snapshot_test.go
+++ b/cli/internal/verification/conflicts_snapshot_test.go
@@ -44,6 +44,10 @@ func (m *miniExec) set(cmd string, out, errStr string, err error) {
 		err         error
 	}{out, errStr, err}
 }
+func (m *miniExec) CopyFile(context.Context, *hostparse.HostInfo, string, string) error {
+	return nil
+}
+
 func (m *miniExec) ExecuteCommand(ctx context.Context, host *hostparse.HostInfo, command []string) (string, string, error) {
 	m.cmds = append(m.cmds, command)
 	key := strings.Join(command, " ")

--- a/cli/internal/verification/mocks.go
+++ b/cli/internal/verification/mocks.go
@@ -79,6 +79,11 @@ func (m *MockCommandExecutor) ExecuteCommand(ctx context.Context, host *hostpars
 	return "", "", fmt.Errorf("mock: unexpected command %s", cmdStr)
 }
 
+// CopyFile records no file copy behavior for verification tests.
+func (m *MockCommandExecutor) CopyFile(context.Context, *hostparse.HostInfo, string, string) error {
+	return nil
+}
+
 // SetupDockerSuccess configures mock to return successful Docker responses
 func (m *MockCommandExecutor) SetupDockerSuccess() {
 	m.mu.Lock()

--- a/cli/internal/verification/verifier_test.go
+++ b/cli/internal/verification/verifier_test.go
@@ -715,6 +715,10 @@ type FlexibleMockCommandExecutor struct {
 	ExecutedCommands []MockCommandExecution
 }
 
+func (m *FlexibleMockCommandExecutor) CopyFile(context.Context, *hostparse.HostInfo, string, string) error {
+	return nil
+}
+
 func (m *FlexibleMockCommandExecutor) ExecuteCommand(ctx context.Context, host *hostparse.HostInfo, command []string) (stdout, stderr string, err error) {
 	// Record the execution
 	m.ExecutedCommands = append(m.ExecutedCommands, MockCommandExecution{
@@ -748,6 +752,10 @@ type cleanupOnFailureExecutor struct {
 	ExecutedCommands []MockCommandExecution
 	cleanupCalls     int
 	cleanupTarget    string
+}
+
+func (m *cleanupOnFailureExecutor) CopyFile(context.Context, *hostparse.HostInfo, string, string) error {
+	return nil
 }
 
 func (m *cleanupOnFailureExecutor) ExecuteCommand(ctx context.Context, host *hostparse.HostInfo, command []string) (stdout, stderr string, err error) {

--- a/cli/tools/seeded-read.sh
+++ b/cli/tools/seeded-read.sh
@@ -1,0 +1,315 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")"/.. && pwd)"
+[ -f "$ROOT_DIR/.env" ] && source "$ROOT_DIR/.env"
+
+HOSTS=${HOSTS:-"127.0.0.1"}
+S3_ENDPOINT=${S3_ENDPOINT:-""}
+S3_ENDPOINTS=${S3_ENDPOINTS:-""}
+S3_ACCESS_KEY=${S3_ACCESS_KEY:-""}
+S3_SECRET_KEY=${S3_SECRET_KEY:-""}
+S3_BUCKET=${S3_BUCKET:-""}
+THREADS=${THREADS:-8}
+OBJECT_SIZE=${OBJECT_SIZE:-"1KB"}
+OBJECT_COUNT=${OBJECT_COUNT:-100000}
+READ_COUNT=${READ_COUNT:-$OBJECT_COUNT}
+MIN_HOSTS=${MIN_HOSTS:-3}
+RESULTS_DIR=${RESULTS_DIR:-"$ROOT_DIR/results"}
+LABEL_PREFIX=${LABEL_PREFIX:-"seeded-read"}
+VERBOSE=${VERBOSE:-true}
+FORCE=${FORCE:-true}
+KEEP_SCENARIO=${KEEP_SCENARIO:-true}
+CLEANUP=${CLEANUP:-false}
+ATTACH_EXISTING=${ATTACH_EXISTING:-false}
+WAIT_FOR_SHUTDOWN=${WAIT_FOR_SHUTDOWN:-true}
+WAIT_TIMEOUT_SECONDS=${WAIT_TIMEOUT_SECONDS:-90}
+WAIT_POLL_SECONDS=${WAIT_POLL_SECONDS:-2}
+WAIT_PORTS=${WAIT_PORTS:-"9999,1099"}
+SSH_OPTS=${SSH_OPTS:-"-o BatchMode=yes -o StrictHostKeyChecking=accept-new -o ConnectTimeout=10"}
+SPT_IMAGE=${SPT_IMAGE:-""}
+SKIP_IMAGE_PULL=${SPT_SKIP_IMAGE_PULL:-false}
+S3_DRIVER=${SPT_S3_DRIVER:-"default"}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --hosts) HOSTS="${2:-}"; shift 2 ;;
+    --s3-endpoint) S3_ENDPOINT="${2:-}"; shift 2 ;;
+    --s3-endpoints) S3_ENDPOINTS="${2:-}"; shift 2 ;;
+    --s3-access-key) S3_ACCESS_KEY="${2:-}"; shift 2 ;;
+    --s3-secret-key) S3_SECRET_KEY="${2:-}"; shift 2 ;;
+    --s3-bucket) S3_BUCKET="${2:-}"; shift 2 ;;
+    --threads) THREADS="${2:-}"; shift 2 ;;
+    --object-size) OBJECT_SIZE="${2:-}"; shift 2 ;;
+    --object-count) OBJECT_COUNT="${2:-}"; READ_COUNT="$OBJECT_COUNT"; shift 2 ;;
+    --read-count) READ_COUNT="${2:-}"; shift 2 ;;
+    --min-hosts) MIN_HOSTS="${2:-}"; shift 2 ;;
+    --results-dir) RESULTS_DIR="${2:-}"; shift 2 ;;
+    --label-prefix) LABEL_PREFIX="${2:-}"; shift 2 ;;
+    --s3-driver) S3_DRIVER="${2:-}"; shift 2 ;;
+    --image) SPT_IMAGE="${2:-}"; shift 2 ;;
+    --skip-image-pull) SKIP_IMAGE_PULL=true; shift 1 ;;
+    --verbose) VERBOSE=true; shift 1 ;;
+    --quiet|--no-verbose) VERBOSE=false; shift 1 ;;
+    --force) FORCE=true; shift 1 ;;
+    --no-force) FORCE=false; shift 1 ;;
+    --cleanup) CLEANUP=true; shift 1 ;;
+    --no-cleanup) CLEANUP=false; shift 1 ;;
+    --keep-scenario) KEEP_SCENARIO=true; shift 1 ;;
+    --no-keep-scenario) KEEP_SCENARIO=false; shift 1 ;;
+    --attach-existing) ATTACH_EXISTING=true; shift 1 ;;
+    --no-attach-existing) ATTACH_EXISTING=false; shift 1 ;;
+    --wait-for-shutdown) WAIT_FOR_SHUTDOWN=true; shift 1 ;;
+    --no-wait-for-shutdown) WAIT_FOR_SHUTDOWN=false; shift 1 ;;
+    --wait-timeout) WAIT_TIMEOUT_SECONDS="${2:-}"; shift 2 ;;
+    --wait-poll-seconds) WAIT_POLL_SECONDS="${2:-}"; shift 2 ;;
+    --wait-ports) WAIT_PORTS="${2:-}"; shift 2 ;;
+    -h|--help)
+      cat << EOF
+Usage: $(basename "$0") [options]
+
+Seeds objects with a write workload, saves the generated items.csv, then runs a read workload against that exact items.csv.
+
+Connection:
+  --hosts CSV              Comma-separated [user@]host list (env: HOSTS)
+  --s3-endpoint URL        Single S3 endpoint (env: S3_ENDPOINT)
+  --s3-endpoints CSV       Multiple S3 endpoints (env: S3_ENDPOINTS)
+  --s3-access-key KEY      S3 access key (env: S3_ACCESS_KEY)
+  --s3-secret-key KEY      S3 secret key (env: S3_SECRET_KEY)
+  --s3-bucket NAME         S3 bucket (env: S3_BUCKET)
+
+Workload:
+  --threads N              Concurrency per node (default: $THREADS)
+  --object-size SIZE       Seed/read object size (default: $OBJECT_SIZE)
+  --object-count N         Objects to seed and default read count (default: $OBJECT_COUNT)
+  --read-count N           Read operation count (default: object-count)
+  --min-hosts N            Minimum hosts required (default: $MIN_HOSTS)
+
+Output:
+  --results-dir DIR        Auto-results root (default: $RESULTS_DIR)
+  --label-prefix LABEL     Label prefix for seed/read result directories (default: $LABEL_PREFIX)
+
+Driver/Docker:
+  --s3-driver TYPE         Storage driver: default, aws, rdma (env: SPT_S3_DRIVER, default: $S3_DRIVER)
+  --image IMAGE            Override SPT Docker image (env: SPT_IMAGE)
+  --skip-image-pull        Use locally cached image, skip pull (env: SPT_SKIP_IMAGE_PULL)
+
+General:
+  --[no-]verbose           Enable verbose output (default: $VERBOSE)
+  --[no-]force             Stop conflicting containers (default: $FORCE)
+  --[no-]cleanup           Delete seeded objects after the read phase (default: $CLEANUP)
+  --[no-]keep-scenario     Keep generated scenario files (default: $KEEP_SCENARIO)
+  --[no-]attach-existing   Reuse prestarted worker nodes (default: $ATTACH_EXISTING)
+  --[no-]wait-for-shutdown Wait for seed containers to release ports before read (default: $WAIT_FOR_SHUTDOWN)
+  --wait-timeout SECONDS   Max wait for ports to close (default: $WAIT_TIMEOUT_SECONDS)
+  --wait-poll-seconds N    Poll interval while waiting (default: $WAIT_POLL_SECONDS)
+  --wait-ports CSV         Ports that must be free before read (default: $WAIT_PORTS)
+
+Examples:
+  $(basename "$0") --image ghcr.io/dell/storage-performance-tool:spt_dev --skip-image-pull
+  $(basename "$0") --s3-driver aws --threads 16 --cleanup
+EOF
+      exit 0 ;;
+    *) echo "Unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+[ -n "$SPT_IMAGE" ] && export SPT_IMAGE
+if [ "$SKIP_IMAGE_PULL" = true ]; then
+  export SPT_SKIP_IMAGE_PULL=true
+fi
+
+RUN_ID="$(date -u +%Y%m%d.%H%M%S)"
+SEED_LABEL="${LABEL_PREFIX}-seed-${RUN_ID}"
+READ_LABEL="${LABEL_PREFIX}-read-${RUN_ID}"
+
+add_common_args() {
+  local -n cmd_ref=$1
+  cmd_ref+=(
+    --access-key "$S3_ACCESS_KEY"
+    --secret-key "$S3_SECRET_KEY"
+    --test-hosts "$HOSTS"
+    --bucket "$S3_BUCKET"
+    --threads "$THREADS"
+    --object-size "$OBJECT_SIZE"
+    --min-hosts "$MIN_HOSTS"
+    --results-dir "$RESULTS_DIR"
+  )
+  if [ -n "$S3_ENDPOINTS" ]; then
+    cmd_ref+=(--endpoints "$S3_ENDPOINTS")
+  elif [ -n "$S3_ENDPOINT" ]; then
+    cmd_ref+=(--endpoint "$S3_ENDPOINT")
+  fi
+  if [ "$S3_DRIVER" != "default" ]; then
+    cmd_ref+=(--s3-driver "$S3_DRIVER")
+  fi
+  $FORCE && cmd_ref+=(--force) || true
+  $VERBOSE && cmd_ref+=(--verbose) || true
+  $KEEP_SCENARIO && cmd_ref+=(--keep-scenario) || true
+  $ATTACH_EXISTING && cmd_ref+=(--attach-existing) || true
+}
+
+latest_matching_dir() {
+  local pattern=$1
+  local matches=()
+  shopt -s nullglob
+  matches=( $pattern )
+  shopt -u nullglob
+  if [ ${#matches[@]} -eq 0 ]; then
+    return 1
+  fi
+  local newest=${matches[0]}
+  local candidate
+  for candidate in "${matches[@]}"; do
+    if [[ "$candidate" > "$newest" ]]; then
+      newest=$candidate
+    fi
+  done
+  printf '%s\n' "$newest"
+}
+
+find_items_file() {
+  local dir=$1
+  local matches=()
+  shopt -s nullglob
+  matches=( "$dir"/*.items.csv "$dir"/*items.csv )
+  shopt -u nullglob
+  if [ ${#matches[@]} -eq 0 ]; then
+    return 1
+  fi
+  printf '%s\n' "${matches[0]}"
+}
+
+trim_host() {
+  local value=$1
+  value="${value//$'\n'/}"
+  value="${value//$'\t'/}"
+  value="${value//$'\r'/}"
+  value="${value// /}"
+  printf '%s\n' "$value"
+}
+
+is_local_host() {
+  local target=$1
+  local host_no_user=${target#*@}
+  [[ "$host_no_user" == "127.0.0.1" || "$host_no_user" == "localhost" || "$host_no_user" == "::1" ]]
+}
+
+port_open_on_host() {
+  local target=$1
+  local port=$2
+  if is_local_host "$target"; then
+    bash -c ": >/dev/tcp/127.0.0.1/$port" >/dev/null 2>&1
+    return $?
+  fi
+  ssh $SSH_OPTS "$target" "bash -lc ': >/dev/tcp/127.0.0.1/$port'" >/dev/null 2>&1
+}
+
+busy_spt_ports() {
+  local busy=()
+  local host_entries=()
+  local port_entries=()
+  local raw_host target raw_port port
+  IFS=',' read -r -a host_entries <<<"$HOSTS"
+  IFS=',' read -r -a port_entries <<<"$WAIT_PORTS"
+  for raw_host in "${host_entries[@]}"; do
+    target=$(trim_host "$raw_host")
+    [ -z "$target" ] && continue
+    for raw_port in "${port_entries[@]}"; do
+      port=$(trim_host "$raw_port")
+      [ -z "$port" ] && continue
+      if port_open_on_host "$target" "$port"; then
+        busy+=("$target:$port")
+      fi
+    done
+  done
+  if [ ${#busy[@]} -gt 0 ]; then
+    printf '%s\n' "${busy[*]}"
+    return 0
+  fi
+  return 1
+}
+
+wait_for_seed_shutdown() {
+  if [ "$WAIT_FOR_SHUTDOWN" != true ]; then
+    return 0
+  fi
+  local deadline=$(( $(date +%s) + WAIT_TIMEOUT_SECONDS ))
+  local busy=""
+  echo "Waiting for seed containers to release ports ($WAIT_PORTS) on all hosts..."
+  while true; do
+    if ! busy=$(busy_spt_ports); then
+      echo "Seed containers have released required ports."
+      return 0
+    fi
+    if [ "$(date +%s)" -ge "$deadline" ]; then
+      echo "Timed out waiting for seed containers to release ports: $busy" >&2
+      echo "Try increasing --wait-timeout or inspect/stop lingering containers before retrying." >&2
+      return 1
+    fi
+    echo "Still waiting; busy ports: $busy"
+    sleep "$WAIT_POLL_SECONDS"
+  done
+}
+
+echo "=== Seeded Read Test ==="
+echo "Hosts: $HOSTS (min-hosts: $MIN_HOSTS)"
+if [ -n "$S3_ENDPOINTS" ]; then
+  echo "Endpoints: $S3_ENDPOINTS"
+else
+  echo "Endpoint: $S3_ENDPOINT"
+fi
+echo "Bucket: $S3_BUCKET"
+echo "Threads: $THREADS  ObjectSize: $OBJECT_SIZE  SeedObjects: $OBJECT_COUNT  ReadCount: $READ_COUNT"
+echo "Results: $RESULTS_DIR"
+if [ "$S3_DRIVER" != "default" ]; then
+  echo "S3 Driver: $S3_DRIVER"
+fi
+[ -n "$SPT_IMAGE" ] && echo "Image: $SPT_IMAGE"
+[ "$SKIP_IMAGE_PULL" = true ] && echo "Skip image pull: true"
+$CLEANUP && echo "Cleanup: read phase will delete seeded objects" || echo "Cleanup: disabled"
+$WAIT_FOR_SHUTDOWN && echo "Read start wait: ports $WAIT_PORTS free on all hosts (timeout ${WAIT_TIMEOUT_SECONDS}s)" || echo "Read start wait: disabled"
+echo
+
+seed_cmd=("$ROOT_DIR"/spt --debug run write --headless
+  --label "$SEED_LABEL"
+  --object-count "$OBJECT_COUNT"
+  --save-items
+)
+add_common_args seed_cmd
+
+echo "=== Phase 1/2: seed $OBJECT_COUNT objects and save items.csv ==="
+"${seed_cmd[@]}"
+
+SEED_DIR=$(latest_matching_dir "$RESULTS_DIR/$SEED_LABEL-*") || {
+  echo "Could not find seed results directory matching $RESULTS_DIR/$SEED_LABEL-*" >&2
+  exit 1
+}
+ITEMS_FILE=$(find_items_file "$SEED_DIR") || {
+  echo "Could not find saved items.csv artifact in $SEED_DIR" >&2
+  exit 1
+}
+
+echo
+echo "Saved items file: $ITEMS_FILE"
+wait_for_seed_shutdown
+echo
+
+read_cmd=("$ROOT_DIR"/spt --debug run read --headless
+  --label "$READ_LABEL"
+  --object-count "$READ_COUNT"
+  --items-file "$ITEMS_FILE"
+)
+add_common_args read_cmd
+$CLEANUP && read_cmd+=(--cleanup) || true
+
+echo "=== Phase 2/2: read back $READ_COUNT objects from saved items.csv ==="
+"${read_cmd[@]}"
+
+echo
+echo "Seed results: $SEED_DIR"
+READ_DIR=$(latest_matching_dir "$RESULTS_DIR/$READ_LABEL-*") || true
+if [ -n "${READ_DIR:-}" ]; then
+  echo "Read results: $READ_DIR"
+fi
+echo "=== Seeded Read Test Complete ==="

--- a/cli/tui/docker.go
+++ b/cli/tui/docker.go
@@ -21,6 +21,7 @@ import (
 	"github.com/dell/storage-performance-tool/cli/internal/docker/command"
 	"github.com/dell/storage-performance-tool/cli/internal/hostparse"
 	"github.com/dell/storage-performance-tool/cli/internal/logging"
+	"github.com/dell/storage-performance-tool/cli/internal/scenario"
 	"github.com/dell/storage-performance-tool/cli/internal/secretmask"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
@@ -68,6 +69,7 @@ type DockerManager struct {
 	hostInfo    *hostparse.HostInfo  // New field to track host information
 	remote      *RemoteDockerManager // When non-nil, delegate operations to remote CLI manager
 	nodeLogDir  string               // Host-side temp dir mounted for node startup diagnostics
+	fileMounts  []scenario.FileMount
 }
 
 func skipImagePull(image string) bool {
@@ -92,6 +94,26 @@ func (dm *DockerManager) ContainerID() string {
 		return dm.remote.ContainerID()
 	}
 	return dm.containerID
+}
+
+// SetFileMounts configures read-only external files that must be visible inside SPT containers.
+func (dm *DockerManager) SetFileMounts(mounts []scenario.FileMount) error {
+	if dm.remote != nil {
+		return dm.remote.SetFileMounts(mounts)
+	}
+	dm.fileMounts = append([]scenario.FileMount(nil), mounts...)
+	return nil
+}
+
+func (dm *DockerManager) itemFileBindSpecs() []string {
+	if len(dm.fileMounts) == 0 {
+		return nil
+	}
+	binds := make([]string, 0, len(dm.fileMounts))
+	for _, mount := range dm.fileMounts {
+		binds = append(binds, fmt.Sprintf("%s:%s:ro", mount.HostPath, mount.ContainerPath))
+	}
+	return binds
 }
 
 // HostInfo returns the host information for this Docker manager
@@ -356,9 +378,9 @@ func (dm *DockerManager) StartContainerWithScenario(image string, scenarioPath s
 		AttachStderr: true,
 		Env:          envVars,
 	}, &container.HostConfig{
-		Binds: []string{
+		Binds: append([]string{
 			fmt.Sprintf("%s:/tmp/scenario.js:ro", absScenarioPath),
-		},
+		}, dm.itemFileBindSpecs()...),
 	}, nil, nil, "")
 
 	if err != nil {
@@ -426,7 +448,7 @@ func (dm *DockerManager) StartContainerInNodeMode(image string, apiPort string, 
 
 	useHostNetwork := selectedNodeNetworkMode(networkMode) == command.NetworkModeHost
 	hostConfig := &container.HostConfig{
-		Binds: logBinds,
+		Binds: append(logBinds, dm.itemFileBindSpecs()...),
 	}
 	if useHostNetwork {
 		hostConfig.NetworkMode = container.NetworkMode(command.NetworkModeHost)
@@ -567,6 +589,7 @@ func (dm *DockerManager) StartWorkerNodeContainer(image string, rmiHostname stri
 
 	hostConfig := &container.HostConfig{
 		PortBindings: portBindings,
+		Binds:        dm.itemFileBindSpecs(),
 	}
 
 	// RDMA device passthrough when SPT_RDMA is enabled
@@ -655,7 +678,7 @@ func (dm *DockerManager) StartEntryNodeContainer(image string, workerAddresses [
 		}
 	}
 
-	hostConfig := &container.HostConfig{}
+	hostConfig := &container.HostConfig{Binds: dm.itemFileBindSpecs()}
 	if useHostNetwork {
 		hostConfig.NetworkMode = container.NetworkMode(command.NetworkModeHost)
 	} else {

--- a/cli/tui/docker_client_shim_test.go
+++ b/cli/tui/docker_client_shim_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/dell/storage-performance-tool/cli/internal/constants"
+	"github.com/dell/storage-performance-tool/cli/internal/scenario"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/image"
@@ -31,6 +32,7 @@ type fakeDockerClient struct {
 	logOptions       container.LogsOptions
 	stopErr          error
 	removeErr        error
+	createHostConfig *container.HostConfig
 }
 
 func (f *fakeDockerClient) ImageInspect(ctx context.Context, imageID string, _ ...client.ImageInspectOption) (image.InspectResponse, error) {
@@ -50,6 +52,7 @@ func (f *fakeDockerClient) ContainerLogs(ctx context.Context, container string, 
 	return io.NopCloser(bytes.NewReader(logs.Bytes())), nil
 }
 func (f *fakeDockerClient) ContainerCreate(ctx context.Context, config *container.Config, hostConfig *container.HostConfig, networkingConfig *network.NetworkingConfig, platform *ocispec.Platform, containerName string) (container.CreateResponse, error) {
+	f.createHostConfig = hostConfig
 	return container.CreateResponse{ID: "abc"}, nil
 }
 func (f *fakeDockerClient) ContainerStart(ctx context.Context, containerID string, options container.StartOptions) error {
@@ -99,6 +102,25 @@ func TestEnsureImageAvailable_DevImagePresent(t *testing.T) {
 	}
 	if dm.client.(*fakeDockerClient).pulled {
 		t.Fatalf("did not expect pull for present dev image")
+	}
+}
+
+func TestStartContainerInNodeModeMountsItemFiles(t *testing.T) {
+	f := &fakeDockerClient{}
+	dm := &DockerManager{client: f, ctx: context.Background()}
+	mounts := []scenario.FileMount{{HostPath: "/host/items.csv", ContainerPath: "/spt-input/items/read-items.csv"}}
+	if err := dm.SetFileMounts(mounts); err != nil {
+		t.Fatalf("SetFileMounts() error = %v", err)
+	}
+	if _, err := dm.StartContainerInNodeMode("test-image", "10080", constants.BridgeNetworkMode); err != nil {
+		t.Fatalf("StartContainerInNodeMode() error = %v", err)
+	}
+	if f.createHostConfig == nil {
+		t.Fatal("ContainerCreate host config was nil")
+	}
+	want := "/host/items.csv:/spt-input/items/read-items.csv:ro"
+	if !containsString(f.createHostConfig.Binds, want) {
+		t.Fatalf("host binds = %v, want %q", f.createHostConfig.Binds, want)
 	}
 }
 

--- a/cli/tui/docker_mock.go
+++ b/cli/tui/docker_mock.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"sync"
 	"time"
+
+	"github.com/dell/storage-performance-tool/cli/internal/scenario"
 )
 
 // MockDockerManager is a mock implementation of DockerInterface for testing
@@ -24,6 +26,7 @@ type MockDockerManager struct {
 	startCallCount   int
 	cleanupCallCount int
 	closeCallCount   int
+	fileMounts       []scenario.FileMount
 
 	// For testing scenario support
 	scenarioCalls []struct {
@@ -76,6 +79,14 @@ func (m *MockDockerManager) ContainerID() string {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return m.containerID
+}
+
+// SetFileMounts records configured file mounts.
+func (m *MockDockerManager) SetFileMounts(mounts []scenario.FileMount) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.fileMounts = append([]scenario.FileMount(nil), mounts...)
+	return nil
 }
 
 // StartContainer simulates starting a container
@@ -311,6 +322,15 @@ func (m *MockDockerManager) GetCloseCallCount() int {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return m.closeCallCount
+}
+
+// GetFileMounts returns configured file mounts.
+func (m *MockDockerManager) GetFileMounts() []scenario.FileMount {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	result := make([]scenario.FileMount, len(m.fileMounts))
+	copy(result, m.fileMounts)
+	return result
 }
 
 // GetScenarioCalls returns all scenario-based container starts

--- a/cli/tui/orchestrator.go
+++ b/cli/tui/orchestrator.go
@@ -65,6 +65,21 @@ type containerDiagnosticTailer interface {
 	ContainerDiagnosticTail(containerID string, maxLines int) (string, error)
 }
 
+type fileMountConfigurer interface {
+	SetFileMounts([]scenario.FileMount) error
+}
+
+func configureDockerFileMounts(dm DockerInterface, mounts []scenario.FileMount) error {
+	if len(mounts) == 0 {
+		return nil
+	}
+	configurer, ok := dm.(fileMountConfigurer)
+	if !ok {
+		return fmt.Errorf("docker manager does not support external item file mounts")
+	}
+	return configurer.SetFileMounts(mounts)
+}
+
 // NewTestOrchestrator creates a new test orchestrator
 func NewTestOrchestrator(dm DockerInterface, apiPort string) *TestOrchestrator {
 	if apiPort == "" {
@@ -125,6 +140,12 @@ func (o *TestOrchestrator) containerStartupDiagnostics() string {
 
 // StartTest starts a Spt test using the API approach
 func (o *TestOrchestrator) StartTest(ctx context.Context, image string, params scenario.Params) error {
+	var err error
+	params, err = scenario.PrepareExternalItemFiles(params)
+	if err != nil {
+		return err
+	}
+
 	// Generate scenario
 	scenarioContent, err := scenario.GenerateScenario(params)
 	if err != nil {
@@ -158,6 +179,10 @@ func (o *TestOrchestrator) StartTestWithContent(ctx context.Context, image strin
 			o.keepScenario = true
 			logging.LogInfo("orchestrator", "saved scenario file", "path", o.scenarioPath)
 		}
+	}
+
+	if err := configureDockerFileMounts(o.dockerManager, params.ItemFileMounts); err != nil {
+		return err
 	}
 
 	// Start container in node mode

--- a/cli/tui/orchestrator_multi.go
+++ b/cli/tui/orchestrator_multi.go
@@ -80,6 +80,7 @@ type MultiHostOrchestrator struct {
 	image           string
 	apiPort         string
 	attachWorkers   bool
+	itemFileMounts  []scenario.FileMount
 
 	// RMI Configuration
 	networkMode  string
@@ -467,6 +468,21 @@ func (o *MultiHostOrchestrator) GetReadyHosts() []*HostConnection {
 	return readyHosts
 }
 
+func (o *MultiHostOrchestrator) configureItemFileMounts(hosts []*HostConnection, mounts []scenario.FileMount) error {
+	if len(mounts) == 0 {
+		return nil
+	}
+	for _, host := range hosts {
+		if host.DockerManager == nil {
+			return fmt.Errorf("host %s has no Docker manager configured", host.Info.Original)
+		}
+		if err := configureDockerFileMounts(host.DockerManager, mounts); err != nil {
+			return fmt.Errorf("configure item file mounts on %s: %w", host.Info.Original, err)
+		}
+	}
+	return nil
+}
+
 // StartContainers starts Spt containers on all ready hosts
 func (o *MultiHostOrchestrator) StartContainers(_ context.Context, image string, _ string) error {
 	o.mu.Lock()
@@ -476,6 +492,9 @@ func (o *MultiHostOrchestrator) StartContainers(_ context.Context, image string,
 	readyHosts := o.GetReadyHosts()
 	if len(readyHosts) == 0 {
 		return fmt.Errorf("no ready hosts available for container startup")
+	}
+	if err := o.configureItemFileMounts(readyHosts, o.itemFileMounts); err != nil {
+		return err
 	}
 
 	o.notifyf("🚀 Starting containers on %d host(s)...", len(readyHosts))
@@ -1304,6 +1323,11 @@ collectLoop:
 
 // StartTest starts monitoring tests on all hosts
 func (m *MultiHostTestOrchestrator) StartTest(ctx context.Context, image string, params scenario.ScenarioParams) error {
+	var err error
+	params, err = scenario.PrepareExternalItemFiles(params)
+	if err != nil {
+		return err
+	}
 	readyHosts := m.multiHost.GetReadyHosts()
 
 	if len(readyHosts) == 0 {
@@ -1490,7 +1514,7 @@ func (m *MultiHostTestOrchestrator) StartTest(ctx context.Context, image string,
 		}
 
 		// Use the full distributed test flow with RMI coordination
-		err := m.multiHost.StartDistributedTest(ctx, image, params)
+		err = m.multiHost.StartDistributedTest(ctx, image, params)
 		if err != nil {
 			return err
 		}
@@ -1512,6 +1536,7 @@ func (m *MultiHostTestOrchestrator) StartTestWithContent(ctx context.Context, im
 	if len(scenarioContent) == 0 {
 		return fmt.Errorf("scenario content is empty")
 	}
+	m.multiHost.itemFileMounts = params.ItemFileMounts
 	if len(readyHosts) != 1 {
 		if m.onStatusUpdate != nil {
 			m.onStatusUpdate(&TestStatus{
@@ -1867,6 +1892,9 @@ func (o *MultiHostOrchestrator) StartDistributedTestWithContent(_ context.Contex
 
 	entryNode := o.hosts[0]
 	workerNodes := o.hosts[1:]
+	if err := o.configureItemFileMounts(o.hosts, params.ItemFileMounts); err != nil {
+		return err
+	}
 
 	logging.LogInfo("orchestrator", "starting distributed test",
 		"entry_node", entryNode.Info.Host,

--- a/cli/tui/orchestrator_multi_test.go
+++ b/cli/tui/orchestrator_multi_test.go
@@ -697,7 +697,8 @@ func TestMultiHostTestOrchestrator_StartTestWithContent_MultiHostStartsDistribut
 	defer cancel()
 	replayScenario := []byte(`var step = "replay-001-max-w10kb"; Load.config({}).run();`)
 	replayDefaults := []byte("storage:\n  driver:\n    type: s3\n")
-	params := scenario.ScenarioParams{WorkloadType: "write", Threads: 1}
+	mounts := []scenario.FileMount{{HostPath: "/host/items.csv", ContainerPath: "/spt-input/items/read-items.csv"}}
+	params := scenario.ScenarioParams{WorkloadType: "write", Threads: 1, ItemFileMounts: mounts}
 	if err := wrapper.StartTestWithContent(ctx, "test-image", params, replayScenario, replayDefaults); err != nil {
 		t.Fatalf("StartTestWithContent() error = %v", err)
 	}
@@ -725,6 +726,12 @@ func TestMultiHostTestOrchestrator_StartTestWithContent_MultiHostStartsDistribut
 	wantWorkerAddr := "127.0.0.1:" + constants.RMIRegistryPort
 	if len(entryCalls[0].WorkerAddresses) != 1 || entryCalls[0].WorkerAddresses[0] != wantWorkerAddr {
 		t.Fatalf("entry worker addresses = %v, want [%s]", entryCalls[0].WorkerAddresses, wantWorkerAddr)
+	}
+	if got := entryDM.GetFileMounts(); len(got) != 1 || got[0] != mounts[0] {
+		t.Fatalf("entry item mounts = %#v, want %#v", got, mounts)
+	}
+	if got := workerDM.GetFileMounts(); len(got) != 1 || got[0] != mounts[0] {
+		t.Fatalf("worker item mounts = %#v, want %#v", got, mounts)
 	}
 	if orchestrator.hosts[0].APIClient == nil {
 		t.Fatal("expected entry API client to be attached after readiness")

--- a/cli/tui/orchestrator_test.go
+++ b/cli/tui/orchestrator_test.go
@@ -326,6 +326,49 @@ func TestOrchestratorStartTestWithContentPostsProvidedArtifacts(t *testing.T) {
 	}
 }
 
+func TestOrchestratorStartTestConfiguresItemFileMounts(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/ready", "/health":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"ready":true,"status":"ok"}`))
+		case "/run":
+			if r.Method == http.MethodHead {
+				w.WriteHeader(http.StatusOK)
+				return
+			}
+			w.Header().Set("ETag", `"run-items"`)
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"runId":"run-items"}`))
+		case "/status":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"state":"RUNNING"}`))
+		case "/metrics/json":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`[]`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	mockDM := NewMockDockerManager()
+	orchestrator := NewTestOrchestrator(mockDM, constants.SptAPIPort)
+	orchestrator.apiClient = NewSptAPIClient(server.URL)
+	mounts := []scenario.FileMount{{HostPath: "/host/items.csv", ContainerPath: "/spt-input/items/read-items.csv"}}
+	params := scenario.ScenarioParams{WorkloadType: scenario.WorkloadTypeRead, ItemFileMounts: mounts}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := orchestrator.StartTestWithContent(ctx, "test-image", params, []byte(`Load.run({})`), nil); err != nil {
+		t.Fatalf("StartTestWithContent() error = %v", err)
+	}
+	got := mockDM.GetFileMounts()
+	if len(got) != 1 || got[0] != mounts[0] {
+		t.Fatalf("configured mounts = %#v, want %#v", got, mounts)
+	}
+}
+
 func TestOrchestratorStartTestUsesConfiguredNetworkMode(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {

--- a/cli/tui/remote_docker.go
+++ b/cli/tui/remote_docker.go
@@ -7,6 +7,7 @@ package tui
 import (
 	"context"
 	"fmt"
+	"path"
 	"strings"
 	"time"
 
@@ -16,17 +17,20 @@ import (
 	"github.com/dell/storage-performance-tool/cli/internal/hostparse"
 	"github.com/dell/storage-performance-tool/cli/internal/logging"
 	"github.com/dell/storage-performance-tool/cli/internal/remoteip"
+	"github.com/dell/storage-performance-tool/cli/internal/scenario"
 )
 
 // RemoteDockerManager implements DockerInterface by executing docker CLI via SSH
 // using the shared command layer (internal/docker/command).
 // It is used for remote hosts where the Docker SDK ssh:// transport is unavailable.
 type RemoteDockerManager struct {
-	host        *hostparse.HostInfo
-	exec        command.CommandExecutor
-	ops         command.DockerOperations
-	containerID string
-	proberRun   func(ctx context.Context, baseURL string, pollInterval time.Duration) error
+	host             *hostparse.HostInfo
+	exec             command.CommandExecutor
+	ops              command.DockerOperations
+	containerID      string
+	proberRun        func(ctx context.Context, baseURL string, pollInterval time.Duration) error
+	stagedBindMounts []string
+	stagingDir       string
 }
 
 func sanitizeHostComponent(host string) string {
@@ -99,6 +103,41 @@ func NewRemoteDockerManager(host *hostparse.HostInfo) (*RemoteDockerManager, err
 // ContainerID returns the last started container ID (if any)
 func (m *RemoteDockerManager) ContainerID() string { return m.containerID }
 
+func (m *RemoteDockerManager) cleanupStaging(ctx context.Context) {
+	if m.stagingDir == "" {
+		return
+	}
+	_, _, _ = m.exec.ExecuteCommand(ctx, m.host, []string{"rm", "-rf", m.stagingDir})
+	m.stagingDir = ""
+	m.stagedBindMounts = nil
+}
+
+// SetFileMounts stages local item files onto the remote Docker host for bind mounting.
+func (m *RemoteDockerManager) SetFileMounts(mounts []scenario.FileMount) error {
+	m.stagedBindMounts = nil
+	m.stagingDir = ""
+	if len(mounts) == 0 {
+		return nil
+	}
+	m.stagingDir = fmt.Sprintf("/tmp/spt-items-%d", time.Now().UnixNano())
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(constants.ContainerStartTimeoutSecs)*time.Second)
+	defer cancel()
+	if _, stderr, err := m.exec.ExecuteCommand(ctx, m.host, []string{"mkdir", "-p", m.stagingDir}); err != nil {
+		return fmt.Errorf("create remote item staging directory on %s: %w (stderr: %s)", m.host.Original, err, stderr)
+	}
+	for _, mount := range mounts {
+		remotePath := path.Join(m.stagingDir, path.Base(mount.ContainerPath))
+		if err := m.exec.CopyFile(ctx, m.host, mount.HostPath, remotePath); err != nil {
+			return err
+		}
+		if _, stderr, err := m.exec.ExecuteCommand(ctx, m.host, []string{"chmod", "0444", remotePath}); err != nil {
+			return fmt.Errorf("chmod remote item file on %s: %w (stderr: %s)", m.host.Original, err, stderr)
+		}
+		m.stagedBindMounts = append(m.stagedBindMounts, fmt.Sprintf("%s:%s:ro", remotePath, mount.ContainerPath))
+	}
+	return nil
+}
+
 // StartContainer is not used for remote multi-host mode; return a clear error
 func (m *RemoteDockerManager) StartContainer(_ string, _ []string) (string, error) {
 	return "", fmt.Errorf("StartContainer not supported for remote manager; use node/worker/entry helpers")
@@ -125,6 +164,7 @@ func (m *RemoteDockerManager) StartContainerInNodeMode(image string, apiPort str
 		Detached:    true,
 		Labels:      m.baseLabels(constants.DockerRoleNode),
 		Command:     []string{dockerNodeModeArg, "--run-port=" + apiPort},
+		BindMounts:  m.stagedBindMounts,
 	}
 	if mode != command.NetworkModeHost {
 		cfg.PortMappings = []command.PortMapping{{HostPort: port, ContainerPort: port}}
@@ -135,6 +175,7 @@ func (m *RemoteDockerManager) StartContainerInNodeMode(image string, apiPort str
 
 	id, _, err := m.ops.StartContainer(ctx, cfg)
 	if err != nil {
+		m.cleanupStaging(ctx)
 		return "", err
 	}
 	m.containerID = strings.TrimSpace(id)
@@ -173,7 +214,8 @@ func (m *RemoteDockerManager) StartWorkerNodeContainer(image string, rmiHostname
 			constants.JavaOptsEnvVar:        fmt.Sprintf("%s%s", constants.JavaRMIHostnamePrefix, advIP),
 			constants.JavaToolOptionsEnvVar: fmt.Sprintf("%s%s", constants.JavaRMIHostnamePrefix, advIP),
 		},
-		Command: []string{dockerNodeModeArg, "--run-port=9999", "--load-step-node-port=1099"},
+		Command:    []string{dockerNodeModeArg, "--run-port=9999", "--load-step-node-port=1099"},
+		BindMounts: m.stagedBindMounts,
 	}
 
 	// RDMA device passthrough when SPT_RDMA is enabled
@@ -191,6 +233,7 @@ func (m *RemoteDockerManager) StartWorkerNodeContainer(image string, rmiHostname
 
 	id, _, err := m.ops.StartContainer(ctx, cfg)
 	if err != nil {
+		m.cleanupStaging(ctx)
 		return "", err
 	}
 	m.containerID = strings.TrimSpace(id)
@@ -225,6 +268,7 @@ func (m *RemoteDockerManager) StartEntryNodeContainer(image string, workerAddres
 		Detached:    true,
 		Labels:      m.baseLabels(constants.DockerRoleEntry),
 		Command:     cmd,
+		BindMounts:  m.stagedBindMounts,
 	}
 
 	// RDMA device passthrough when SPT_RDMA is enabled
@@ -239,6 +283,7 @@ func (m *RemoteDockerManager) StartEntryNodeContainer(image string, workerAddres
 
 	id, _, err := m.ops.StartContainer(ctx, cfg)
 	if err != nil {
+		m.cleanupStaging(ctx)
 		return "", err
 	}
 	m.containerID = strings.TrimSpace(id)
@@ -276,15 +321,15 @@ func (m *RemoteDockerManager) StreamOutput(containerID string, stdoutCallback fu
 
 // Cleanup force-removes the last started container (if any)
 func (m *RemoteDockerManager) Cleanup() error {
-	if m.containerID == "" {
-		return nil
-	}
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	if err := m.ops.StopContainer(ctx, m.containerID); err != nil {
-		return err
+	if m.containerID != "" {
+		if err := m.ops.StopContainer(ctx, m.containerID); err != nil {
+			return err
+		}
+		m.containerID = ""
 	}
-	m.containerID = ""
+	m.cleanupStaging(ctx)
 	return nil
 }
 

--- a/cli/tui/remote_docker_test.go
+++ b/cli/tui/remote_docker_test.go
@@ -5,12 +5,14 @@ Copyright © 2025 Dell Technologies
 package tui
 
 import (
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/dell/storage-performance-tool/cli/internal/constants"
 	"github.com/dell/storage-performance-tool/cli/internal/docker/command"
 	"github.com/dell/storage-performance-tool/cli/internal/hostparse"
+	"github.com/dell/storage-performance-tool/cli/internal/scenario"
 )
 
 func newTestRemoteManager(t *testing.T) (*RemoteDockerManager, *command.MockCommandExecutor, *hostparse.HostInfo) {
@@ -61,6 +63,38 @@ func TestRemoteDocker_StartContainerInNodeMode_RespectsPort(t *testing.T) {
 	}
 	if !strings.Contains(cmd, "--name spt-node-") {
 		t.Errorf("expected docker run command to include node name prefix, got: %s", cmd)
+	}
+}
+
+func TestRemoteDocker_StartContainerInNodeMode_StagesAndMountsItemFiles(t *testing.T) {
+	mgr, mock, _ := newTestRemoteManager(t)
+	localItems := filepath.Join(t.TempDir(), "items.csv")
+	mounts := []scenario.FileMount{{HostPath: localItems, ContainerPath: "/spt-input/items/read-items.csv"}}
+	if err := mgr.SetFileMounts(mounts); err != nil {
+		t.Fatalf("SetFileMounts() error = %v", err)
+	}
+
+	id, err := mgr.StartContainerInNodeMode(constants.DefaultSptImage, "10080", constants.BridgeNetworkMode)
+	if err != nil {
+		t.Fatalf("StartContainerInNodeMode error: %v", err)
+	}
+	if id == "" {
+		t.Fatal("container ID should not be empty")
+	}
+	if len(mock.CopiedFiles) != 1 {
+		t.Fatalf("copied files = %d, want 1", len(mock.CopiedFiles))
+	}
+	if mock.CopiedFiles[0].LocalPath != localItems {
+		t.Fatalf("copied local path = %q, want %q", mock.CopiedFiles[0].LocalPath, localItems)
+	}
+	executed := mock.GetExecutedCommandsMatching("docker run")
+	if len(executed) == 0 {
+		t.Fatalf("expected a docker run command to be executed")
+	}
+	cmd := strings.Join(executed[len(executed)-1].Command, " ")
+	wantBind := mock.CopiedFiles[0].RemotePath + ":/spt-input/items/read-items.csv:ro"
+	if !strings.Contains(cmd, "-v "+wantBind) {
+		t.Fatalf("docker run missing item bind %q: %s", wantBind, cmd)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Mount external item CSVs into local and remote Docker test containers and rewrite scenario paths to stable container paths.
- Download large auto-results artifacts with ranged requests so saved `items.csv` files are not truncated by the engine log page size.
- Add a seeded read helper script and regression coverage for item-file mounting, remote staging, and paged artifact downloads.
- Update the changelog for the item CSV reuse and artifact retrieval fixes.
