### PR TITLE
Add bounded read shuffle controls and default seeded-read shuffle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Added
+
+- **Bounded read-phase shuffle controls** — `spt run read` now supports `--shuffle` and `--shuffle-batch-size` to widen read randomness within the `ReadLoad` phase without globally exposing unbounded `load.batch.size`. The batch override is read-only, defaults to a bounded window when omitted, and is capped to avoid pathological buffer growth.
+
 ### Fixed
 
 - **External items files in Docker runs** — `--items-file`, mixed `--read-items-file`, and mixed `--delete-items-file` are now rewritten to stable container paths and mounted into local or remote Docker test containers, allowing saved item catalogs to be reused by later read/delete workflows.

--- a/cli/README.md
+++ b/cli/README.md
@@ -58,6 +58,24 @@ Need to profile how fast an existing namespace can be enumerated? The list workl
 Tip: If you omit both `--object-count` and `--duration`, the list workload will continue until you stop it. Always set `--auto-terminate-seconds` for unattended runs so CI jobs do not hang.
 Authentication defaults to Signature Version 4. Add `--auth-version 2` only when working with a legacy S3 implementation that rejects SigV4.
 
+For read benchmarks, `spt` can seed an item set automatically and optionally widen read randomness within each fetched batch:
+
+```bash
+# Seed 5,000 objects, then read them with bounded batch-local shuffling
+./spt run read \
+  --endpoints https://s3.example.com \
+  --access-key "$S3_ACCESS_KEY" \
+  --secret-key "$S3_SECRET_KEY" \
+  --bucket benchmark-test \
+  --threads 16 \
+  --object-size 10KB \
+  --seed-objects 5000 \
+  --duration 5m \
+  --shuffle \
+  --shuffle-batch-size 512000 \
+  --cleanup
+```
+
 ## Features
 
 - **Intuitive CLI**: Docker-style command structure (`spt run`, `spt replay`, `spt results`)
@@ -383,6 +401,10 @@ Executes a benchmark test with the specified workload type.
 - `--checksum`: Enable S3 checksum validation with the specified algorithm: `crc32`, `crc32c`, `sha1`, `sha256`, `crc64-nvme`. When used with `--part-size`, checksums are applied per part. (env: `SPT_CHECKSUM`)
 - `--object-data-compressibility`: Target compressibility percentage for generated object data, 0-100 (default: 0 = fully random). Each 4KB chunk is split into random and zero-filled portions according to the percentage. (env: `SPT_OBJECT_DATA_COMPRESSIBILITY`)
 - `--object-data-dedupable`: Whether generated data remains dedupe-friendly (default: true). Set `false` to stamp every 4KB with a unique object-id + offset header that defeats inline deduplication. Incompatible with `--items-file` / file-based data input. (env: `SPT_OBJECT_DATA_DEDUPABLE`)
+- `--seed-objects`: Objects to pre-create for `read` benchmarks (default: 2500)
+- `--items-file`: Path to a saved `items.csv` for `read` workloads (skips the seed phase)
+- `--shuffle`: `read` only. Shuffle items within each fetched read batch before issuing reads.
+- `--shuffle-batch-size`: `read` only. Override the read-phase shuffle window used with `--shuffle` (bounded to 1,000,000).
 - `--cleanup`: Delete all created objects after test completion
 - `--create-prefix`: Ensure target prefix exists before testing
 - `--output-dir, -O`: Directory to save detailed Spt reports

--- a/cli/cmd/constants.go
+++ b/cli/cmd/constants.go
@@ -36,17 +36,20 @@ var ValidWorkloadTypes = []string{
 
 // Error message constants
 const (
-	ErrMissingEndpoint        = "--endpoint flag is required for %s workload"
-	ErrMissingAccessKey       = "--access-key flag is required for %s workload"
-	ErrMissingSecretKey       = "--secret-key flag is required for %s workload" // #nosec G101: constant phrase contains "secret" but is not a credential
-	ErrMissingBucket          = "--bucket flag is required for %s workload"
-	ErrDurationOrCount        = "cannot specify both --object-count and --duration"
-	ErrInvalidWorkloadType    = "invalid workload type: %s. Must be one of: write, read, mixed, delete, list, mock"
-	ErrWorkloadNotImplemented = "workload type '%s' is not yet implemented. Currently only 'write', 'read', 'list', and 'mock' are supported"
-	ErrInvalidEndpointURL     = "invalid endpoint URL: %w"
-	ErrMissingHostname        = "endpoint URL must include a hostname"
-	ErrFlagNotSupported       = "%s flag is not supported for %s workload"
-	ErrInvalidAuthVersion     = "invalid auth version: %d (supported values: 2 or 4)"
+	ErrMissingEndpoint                = "--endpoint flag is required for %s workload"
+	ErrMissingAccessKey               = "--access-key flag is required for %s workload"
+	ErrMissingSecretKey               = "--secret-key flag is required for %s workload" // #nosec G101: constant phrase contains "secret" but is not a credential
+	ErrMissingBucket                  = "--bucket flag is required for %s workload"
+	ErrDurationOrCount                = "cannot specify both --object-count and --duration"
+	ErrInvalidWorkloadType            = "invalid workload type: %s. Must be one of: write, read, mixed, delete, list, mock"
+	ErrWorkloadNotImplemented         = "workload type '%s' is not yet implemented. Currently only 'write', 'read', 'list', and 'mock' are supported"
+	ErrInvalidEndpointURL             = "invalid endpoint URL: %w"
+	ErrMissingHostname                = "endpoint URL must include a hostname"
+	ErrFlagNotSupported               = "%s flag is not supported for %s workload"
+	ErrInvalidAuthVersion             = "invalid auth version: %d (supported values: 2 or 4)"
+	ErrReadShuffleBatchRequiresToggle = "--shuffle-batch-size requires --shuffle"
+	ErrReadShuffleBatchPositive       = "--shuffle-batch-size must be > 0"
+	ErrReadShuffleBatchTooLarge       = "--shuffle-batch-size must be <= %d"
 )
 
 // Spt parameter constants

--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -32,6 +32,8 @@ const (
 	flagSkipImagePull         = "skip-image-pull"
 	flagSptImage              = "spt-image"
 	flagAttachExistingWorkers = "attach-existing"
+	flagReadShuffle           = "shuffle"
+	flagReadShuffleBatchSize  = "shuffle-batch-size"
 )
 
 // resolvePortConflictFunc is a test seam for port conflict resolution.
@@ -1101,6 +1103,8 @@ func init() {
 	runCmd.Flags().Bool("keep-scenario", false, "Keep the scenario file after the test completes (default: delete on success)")
 	runCmd.Flags().Bool("save-items", false, "Save items.csv to the results directory (write workloads only; can be large for high-throughput runs)")
 	runCmd.Flags().String("items-file", "", "Path to a local items.csv to use for read workload (skips seed phase)")
+	runCmd.Flags().Bool(flagReadShuffle, false, "Read workload: shuffle items within each fetched batch before issuing reads (widens randomness, increases engine buffer usage, and does not guarantee storage-cache avoidance)")
+	runCmd.Flags().Int(flagReadShuffleBatchSize, 0, fmt.Sprintf("Read workload: batch size to use with --shuffle (0 = use the bounded default, max %d)", constants.ReadShuffleMaxBatchSize))
 	runCmd.Flags().Bool("force", false, "Automatically resolve port conflicts without user interaction")
 
 	// Mixed Workload Distribution Options (defaults: GET 45 / STAT 30 / PUT 15 / DELETE 10)
@@ -1304,6 +1308,12 @@ func buildScenarioParams(workloadType string, cmd *cobra.Command) (scenario.Para
 
 	itemsFile, _ := cmd.Flags().GetString("items-file")
 	params.ItemsFile = itemsFile
+
+	readShuffle, _ := cmd.Flags().GetBool(flagReadShuffle)
+	params.ReadShuffle = readShuffle
+
+	readShuffleBatchSize, _ := cmd.Flags().GetInt(flagReadShuffleBatchSize)
+	params.ReadShuffleBatchSize = readShuffleBatchSize
 
 	serviceThreads, _ := cmd.Flags().GetInt("service-threads")
 	params.ServiceThreads = serviceThreads

--- a/cli/cmd/run_scenario_test.go
+++ b/cli/cmd/run_scenario_test.go
@@ -309,6 +309,38 @@ func TestBuildScenarioParams(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name:         "read workload with shuffle override",
+			workloadType: "read",
+			flags: map[string]interface{}{
+				"endpoint":               "http://localhost:9000",
+				"access-key":             "test",
+				"secret-key":             "test123",
+				"bucket":                 "read-bucket",
+				"threads":                4,
+				"object-size":            "100KB",
+				"duration":               "5m",
+				flagReadShuffle:          true,
+				flagReadShuffleBatchSize: 1000000,
+			},
+			expected: scenario.Params{
+				WorkloadType:         "read",
+				Endpoint:             "http://localhost:9000",
+				Endpoints:            []string{"http://localhost:9000"},
+				AccessKey:            "test",
+				SecretKey:            "test123",
+				Bucket:               "read-bucket",
+				AuthVersion:          4,
+				Threads:              4,
+				ObjectSize:           "100KB",
+				ObjectCount:          0,
+				Duration:             "5m",
+				ReadShuffle:          true,
+				ReadShuffleBatchSize: 1000000,
+				ObjectDataDedupable:  true,
+			},
+			wantErr: false,
+		},
+		{
 			name:         "mixed workload",
 			workloadType: "mixed",
 			flags: map[string]interface{}{
@@ -445,6 +477,8 @@ func TestBuildScenarioParams(t *testing.T) {
 			cmd.Flags().Int("object-count", 0, "")
 			cmd.Flags().String("duration", "", "")
 			cmd.Flags().Bool("cleanup", false, "")
+			cmd.Flags().Bool(flagReadShuffle, false, "")
+			cmd.Flags().Int(flagReadShuffleBatchSize, 0, "")
 			cmd.Flags().Bool("create-prefix", false, "")
 			cmd.Flags().Int("service-threads", 0, "")
 			cmd.Flags().String("s3-driver", "default", "")
@@ -569,6 +603,8 @@ func TestBuildScenarioParamsEdgeCases(t *testing.T) {
 			cmd.Flags().String("object-size", "", "")
 			cmd.Flags().Int("object-count", 0, "")
 			cmd.Flags().String("duration", "", "")
+			cmd.Flags().Bool(flagReadShuffle, false, "")
+			cmd.Flags().Int(flagReadShuffleBatchSize, 0, "")
 			cmd.Flags().String("s3-driver", "default", "")
 			cmd.Flags().Bool("use-rdma", false, "")
 			cmd.Flags().String("rdma-local-ip", "", "")
@@ -620,6 +656,8 @@ func TestBuildScenarioParamsServiceThreads(t *testing.T) {
 			cmd.Flags().String("object-size", "", "")
 			cmd.Flags().Int("object-count", 0, "")
 			cmd.Flags().String("duration", "", "")
+			cmd.Flags().Bool(flagReadShuffle, false, "")
+			cmd.Flags().Int(flagReadShuffleBatchSize, 0, "")
 			cmd.Flags().Int("service-threads", 0, "")
 			cmd.Flags().String("s3-driver", "default", "")
 			cmd.Flags().Bool("use-rdma", false, "")
@@ -659,6 +697,8 @@ func TestBuildScenarioParams_S3DriverFlag(t *testing.T) {
 		cmd.Flags().String("object-size", "", "")
 		cmd.Flags().Int("object-count", 0, "")
 		cmd.Flags().String("duration", "", "")
+		cmd.Flags().Bool(flagReadShuffle, false, "")
+		cmd.Flags().Int(flagReadShuffleBatchSize, 0, "")
 		cmd.Flags().Bool("cleanup", false, "")
 		cmd.Flags().Int("service-threads", 0, "")
 		cmd.Flags().String("s3-driver", "default", "")

--- a/cli/cmd/validation.go
+++ b/cli/cmd/validation.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/dell/storage-performance-tool/cli/internal/constants"
 	"github.com/dell/storage-performance-tool/cli/internal/sizeparse"
 	"github.com/spf13/cobra"
 )
@@ -137,6 +138,36 @@ func ValidateMixedFlags(cmd *cobra.Command) error {
 	return nil
 }
 
+func validateReadShuffleFlags(cmd *cobra.Command, workloadType string) error {
+	shuffleChanged := cmd.Flags().Changed(flagReadShuffle)
+	batchChanged := cmd.Flags().Changed(flagReadShuffleBatchSize)
+
+	if workloadType != WorkloadTypeRead {
+		if shuffleChanged {
+			return fmt.Errorf(ErrFlagNotSupported, "--"+flagReadShuffle, workloadType)
+		}
+		if batchChanged {
+			return fmt.Errorf(ErrFlagNotSupported, "--"+flagReadShuffleBatchSize, workloadType)
+		}
+		return nil
+	}
+
+	shuffleEnabled, _ := cmd.Flags().GetBool(flagReadShuffle)
+	batchSize, _ := cmd.Flags().GetInt(flagReadShuffleBatchSize)
+
+	if batchChanged && !shuffleEnabled {
+		return errors.New(ErrReadShuffleBatchRequiresToggle)
+	}
+	if batchChanged && batchSize <= 0 {
+		return errors.New(ErrReadShuffleBatchPositive)
+	}
+	if batchChanged && batchSize > constants.ReadShuffleMaxBatchSize {
+		return fmt.Errorf(ErrReadShuffleBatchTooLarge, constants.ReadShuffleMaxBatchSize)
+	}
+
+	return nil
+}
+
 // ValidateRunCommand performs all validation for the run command
 func ValidateRunCommand(cmd *cobra.Command, args []string) error {
 	workloadType := args[0]
@@ -165,6 +196,11 @@ func ValidateRunCommand(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = false
 			return err
 		}
+	}
+
+	if err := validateReadShuffleFlags(cmd, workloadType); err != nil {
+		cmd.SilenceUsage = false
+		return err
 	}
 
 	// Validate duration vs object-count

--- a/cli/cmd/validation_test.go
+++ b/cli/cmd/validation_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/dell/storage-performance-tool/cli/internal/constants"
 	"github.com/spf13/cobra"
 )
 
@@ -275,6 +276,163 @@ func TestValidateDurationOrCount(t *testing.T) {
 				if !strings.Contains(err.Error(), tt.errContains) {
 					t.Errorf("ValidateDurationOrCount() error = %v, want error containing %v", err.Error(), tt.errContains)
 				}
+			}
+		})
+	}
+}
+
+func TestValidateReadShuffleFlags(t *testing.T) {
+	tests := []struct {
+		name         string
+		workloadType string
+		setup        func(*testing.T, *cobra.Command)
+		wantErr      bool
+		errContains  string
+	}{
+		{
+			name:         "read workload allows shuffle only",
+			workloadType: WorkloadTypeRead,
+			setup: func(t *testing.T, cmd *cobra.Command) {
+				if err := cmd.Flags().Set(flagReadShuffle, "true"); err != nil {
+					t.Fatalf("set shuffle: %v", err)
+				}
+			},
+		},
+		{
+			name:         "read workload allows shuffle batch override",
+			workloadType: WorkloadTypeRead,
+			setup: func(t *testing.T, cmd *cobra.Command) {
+				if err := cmd.Flags().Set(flagReadShuffle, "true"); err != nil {
+					t.Fatalf("set shuffle: %v", err)
+				}
+				if err := cmd.Flags().Set(flagReadShuffleBatchSize, "512000"); err != nil {
+					t.Fatalf("set shuffle-batch-size: %v", err)
+				}
+			},
+		},
+		{
+			name:         "shuffle batch requires shuffle",
+			workloadType: WorkloadTypeRead,
+			setup: func(t *testing.T, cmd *cobra.Command) {
+				if err := cmd.Flags().Set(flagReadShuffleBatchSize, "512000"); err != nil {
+					t.Fatalf("set shuffle-batch-size: %v", err)
+				}
+			},
+			wantErr:     true,
+			errContains: ErrReadShuffleBatchRequiresToggle,
+		},
+		{
+			name:         "shuffle batch must be positive",
+			workloadType: WorkloadTypeRead,
+			setup: func(t *testing.T, cmd *cobra.Command) {
+				if err := cmd.Flags().Set(flagReadShuffle, "true"); err != nil {
+					t.Fatalf("set shuffle: %v", err)
+				}
+				if err := cmd.Flags().Set(flagReadShuffleBatchSize, "0"); err != nil {
+					t.Fatalf("set shuffle-batch-size: %v", err)
+				}
+			},
+			wantErr:     true,
+			errContains: ErrReadShuffleBatchPositive,
+		},
+		{
+			name:         "shuffle batch must not exceed max",
+			workloadType: WorkloadTypeRead,
+			setup: func(t *testing.T, cmd *cobra.Command) {
+				if err := cmd.Flags().Set(flagReadShuffle, "true"); err != nil {
+					t.Fatalf("set shuffle: %v", err)
+				}
+				if err := cmd.Flags().Set(flagReadShuffleBatchSize, strconv.Itoa(constants.ReadShuffleMaxBatchSize+1)); err != nil {
+					t.Fatalf("set shuffle-batch-size: %v", err)
+				}
+			},
+			wantErr:     true,
+			errContains: strconv.Itoa(constants.ReadShuffleMaxBatchSize),
+		},
+		{
+			name:         "write workload rejects shuffle flag",
+			workloadType: WorkloadTypeWrite,
+			setup: func(t *testing.T, cmd *cobra.Command) {
+				if err := cmd.Flags().Set(flagReadShuffle, "true"); err != nil {
+					t.Fatalf("set shuffle: %v", err)
+				}
+			},
+			wantErr:     true,
+			errContains: "--shuffle flag is not supported for write workload",
+		},
+		{
+			name:         "delete workload rejects shuffle flag",
+			workloadType: WorkloadTypeDelete,
+			setup: func(t *testing.T, cmd *cobra.Command) {
+				if err := cmd.Flags().Set(flagReadShuffle, "true"); err != nil {
+					t.Fatalf("set shuffle: %v", err)
+				}
+			},
+			wantErr:     true,
+			errContains: "--shuffle flag is not supported for delete workload",
+		},
+		{
+			name:         "mixed workload rejects shuffle flag",
+			workloadType: WorkloadTypeMixed,
+			setup: func(t *testing.T, cmd *cobra.Command) {
+				if err := cmd.Flags().Set(flagReadShuffle, "true"); err != nil {
+					t.Fatalf("set shuffle: %v", err)
+				}
+			},
+			wantErr:     true,
+			errContains: "--shuffle flag is not supported for mixed workload",
+		},
+		{
+			name:         "list workload rejects shuffle flag",
+			workloadType: WorkloadTypeList,
+			setup: func(t *testing.T, cmd *cobra.Command) {
+				if err := cmd.Flags().Set(flagReadShuffle, "true"); err != nil {
+					t.Fatalf("set shuffle: %v", err)
+				}
+			},
+			wantErr:     true,
+			errContains: "--shuffle flag is not supported for list workload",
+		},
+		{
+			name:         "mock workload rejects shuffle flag",
+			workloadType: WorkloadTypeMock,
+			setup: func(t *testing.T, cmd *cobra.Command) {
+				if err := cmd.Flags().Set(flagReadShuffle, "true"); err != nil {
+					t.Fatalf("set shuffle: %v", err)
+				}
+			},
+			wantErr:     true,
+			errContains: "--shuffle flag is not supported for mock workload",
+		},
+		{
+			name:         "write workload rejects shuffle batch flag",
+			workloadType: WorkloadTypeWrite,
+			setup: func(t *testing.T, cmd *cobra.Command) {
+				if err := cmd.Flags().Set(flagReadShuffleBatchSize, "512000"); err != nil {
+					t.Fatalf("set shuffle-batch-size: %v", err)
+				}
+			},
+			wantErr:     true,
+			errContains: "--shuffle-batch-size flag is not supported for write workload",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := &cobra.Command{}
+			cmd.Flags().Bool(flagReadShuffle, false, "")
+			cmd.Flags().Int(flagReadShuffleBatchSize, 0, "")
+			if tt.setup != nil {
+				tt.setup(t, cmd)
+			}
+
+			err := validateReadShuffleFlags(cmd, tt.workloadType)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateReadShuffleFlags() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if err != nil && tt.errContains != "" && !strings.Contains(err.Error(), tt.errContains) {
+				t.Errorf("validateReadShuffleFlags() error = %v, want containing %q", err, tt.errContains)
 			}
 		})
 	}

--- a/cli/docs/SPT_SYNTAX.md
+++ b/cli/docs/SPT_SYNTAX.md
@@ -104,10 +104,14 @@ Required for S3 workloads, optional/ignored for `mock`.
 | `--object-data-dedupable` | | `true` | Whether generated data remains dedupe-friendly. Set `false` to stamp every 4KB with a 16-byte object-id + offset header that practically eliminates inline deduplication. Incompatible with file-based data input. (env: `SPT_OBJECT_DATA_DEDUPABLE`) |
 | `--save-items` | | `false` | Save `items.csv` listing created objects (`write` only) |
 | `--items-file` | | `""` | Path to a saved `items.csv` for `read` (skips seed phase) |
+| `--shuffle` | | `false` | `read` only. Shuffle items within each fetched read batch before issuing reads |
+| `--shuffle-batch-size` | | `0` | `read` only. Batch size override used with `--shuffle` (`0` = bounded default `512000`, max `1000000`) |
 
 *Typically specify either `--object-count` or `--duration`, not both.*
 
 **`--save-items` / `--items-file` workflow:** By default, `read` workloads seed their own objects via an internal write phase. When you need independent control over the write and read phases (different concurrency, duration, or to reuse a data set across multiple reads), use `--save-items` on a `write` run to persist the object list, then pass the resulting `items.csv` to a `read` run via `--items-file`. See [Write-Then-Read Workflow](#write-then-read-workflow) below for examples.
+
+**`--shuffle` / `--shuffle-batch-size` behavior:** These flags apply only to `read` workloads and only affect the `ReadLoad` phase. `--shuffle` enables engine-side item shuffling within each fetched batch. `--shuffle-batch-size` requires `--shuffle`, uses the bounded default when omitted, and is capped to avoid large buffer growth in seed/scatter/cleanup paths.
 
 #### 3. Test Behavior Options
 
@@ -465,7 +469,26 @@ spt run read \
     --seed-objects 5000 \
     --duration 5m \
     --cleanup
+
+# Same read pattern, but widen randomness within each fetched batch
+spt run read \
+    --endpoints https://s3.example.com \
+    --access-key "$S3_ACCESS_KEY" \
+    --secret-key "$S3_SECRET_KEY" \
+    --bucket benchmark-test \
+    --threads 16 \
+    --object-size 10KB \
+    --seed-objects 500000 \
+    --duration 5m \
+    --shuffle \
+    --shuffle-batch-size 512000 \
+    --cleanup
 ```
+
+Notes:
+- `--shuffle` only changes the read benchmark phase; it does not widen the seed or cleanup phases.
+- The default shuffle window is `512000` when `--shuffle` is enabled without `--shuffle-batch-size`.
+- `--shuffle-batch-size` is capped at `1000000` to keep engine buffer growth bounded.
 
 ### Write-Then-Read Workflow
 

--- a/cli/internal/constants/constants.go
+++ b/cli/internal/constants/constants.go
@@ -118,6 +118,14 @@ const (
 	EnginePlainLogArtifactMaxBytes = EngineLogArtifactPageSize - 1
 )
 
+// Read shuffle tuning constants
+const (
+	// ReadShuffleDefaultBatchSize is the implicit read-phase batch size when --shuffle is enabled without an explicit override.
+	ReadShuffleDefaultBatchSize = 512000
+	// ReadShuffleMaxBatchSize bounds --shuffle-batch-size to avoid pathological engine buffer growth.
+	ReadShuffleMaxBatchSize = 1000000
+)
+
 // Progress indicator constants
 const (
 	ProgressSpinner = "⏳"

--- a/cli/internal/scenario/constants.go
+++ b/cli/internal/scenario/constants.go
@@ -82,6 +82,8 @@ const (
 	templateKeyMaxKeys              = "MaxKeys"
 	templateKeySaveItems            = "SaveItems"
 	templateKeyItemsFile            = "ItemsFile"
+	templateKeyReadShuffle          = "ReadShuffle"
+	templateKeyReadShuffleBatchSize = "ReadShuffleBatchSize"
 
 	stepOpCreate = "create"
 	stepOpRead   = "read"

--- a/cli/internal/scenario/generator.go
+++ b/cli/internal/scenario/generator.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"text/template"
 	"time"
+
+	"github.com/dell/storage-performance-tool/cli/internal/constants"
 )
 
 const defaultListBatchSize = 1000
@@ -114,17 +116,30 @@ func GenerateReadScenario(params Params) (string, error) {
 		seedCount = 2500
 	}
 
+	readShuffleBatchSize := 0
+	if params.ReadShuffle {
+		readShuffleBatchSize = params.ReadShuffleBatchSize
+		switch {
+		case readShuffleBatchSize <= 0:
+			readShuffleBatchSize = constants.ReadShuffleDefaultBatchSize
+		case readShuffleBatchSize > constants.ReadShuffleMaxBatchSize:
+			readShuffleBatchSize = constants.ReadShuffleMaxBatchSize
+		}
+	}
+
 	data := map[string]interface{}{
-		templateKeyConcurrency:       params.Threads,
-		templateKeyItemSize:          fmt.Sprintf(`"%s"`, escapeJSONString(params.ObjectSize)),
-		templateKeyItemCount:         params.ObjectCount,
-		templateKeyOutputPath:        fmt.Sprintf(`"%s"`, escapeJSONString(bucketPath)),
-		templateKeyDuration:          fmt.Sprintf(`"%s"`, escapeJSONString(params.Duration)),
-		templateKeyPartSize:          fmt.Sprintf(`"%s"`, escapeJSONString(params.PartSize)),
-		templateKeyHasPartSize:       params.PartSize != "",
-		templateKeyTimestamp:         time.Now().Unix(),
-		templateKeyStorageDriverType: fmt.Sprintf(`"%s"`, driverType),
-		templateKeySeedCount:         seedCount,
+		templateKeyConcurrency:          params.Threads,
+		templateKeyItemSize:             fmt.Sprintf(`"%s"`, escapeJSONString(params.ObjectSize)),
+		templateKeyItemCount:            params.ObjectCount,
+		templateKeyOutputPath:           fmt.Sprintf(`"%s"`, escapeJSONString(bucketPath)),
+		templateKeyDuration:             fmt.Sprintf(`"%s"`, escapeJSONString(params.Duration)),
+		templateKeyPartSize:             fmt.Sprintf(`"%s"`, escapeJSONString(params.PartSize)),
+		templateKeyHasPartSize:          params.PartSize != "",
+		templateKeyTimestamp:            time.Now().Unix(),
+		templateKeyStorageDriverType:    fmt.Sprintf(`"%s"`, driverType),
+		templateKeySeedCount:            seedCount,
+		templateKeyReadShuffle:          params.ReadShuffle,
+		templateKeyReadShuffleBatchSize: readShuffleBatchSize,
 		// Step IDs: seed=1, read=2, delete=3 (read-from-file: read=1, delete=2)
 		templateKeyStepIDSeed:   formatStepID(1, ts, stepOpSeed),
 		templateKeyStepIDRead:   formatStepID(2, ts, stepOpRead),

--- a/cli/internal/scenario/generator_test.go
+++ b/cli/internal/scenario/generator_test.go
@@ -1,9 +1,12 @@
 package scenario
 
 import (
+	"fmt"
 	"regexp"
 	"strings"
 	"testing"
+
+	"github.com/dell/storage-performance-tool/cli/internal/constants"
 )
 
 // removed unused helper 'min' (no longer needed)
@@ -1645,6 +1648,90 @@ func TestGenerateReadScenario(t *testing.T) {
 				t.Error("Read scenario must contain ReadLoad")
 			}
 		})
+	}
+}
+
+func TestGenerateReadScenario_NoReadShuffleByDefault(t *testing.T) {
+	got, err := GenerateReadScenario(Params{
+		WorkloadType: "read",
+		Bucket:       "shuffle-bucket",
+		Threads:      8,
+		ObjectSize:   "10KB",
+		Duration:     "2m",
+		Cleanup:      true,
+		SeedCount:    64,
+	})
+	if err != nil {
+		t.Fatalf("GenerateReadScenario() unexpected error: %v", err)
+	}
+
+	if strings.Contains(got, `"shuffle": true`) {
+		t.Fatalf("expected read scenario without shuffle to omit shuffle toggle\nGot:\n%s", got)
+	}
+	if strings.Contains(got, `"batch": {`) {
+		t.Fatalf("expected read scenario without shuffle to omit read batch override\nGot:\n%s", got)
+	}
+}
+
+func TestGenerateReadScenario_ReadShuffleDefaultBatch(t *testing.T) {
+	got, err := GenerateReadScenario(Params{
+		WorkloadType: "read",
+		Bucket:       "shuffle-bucket",
+		Threads:      8,
+		ObjectSize:   "10KB",
+		Duration:     "2m",
+		Cleanup:      true,
+		SeedCount:    64,
+		ReadShuffle:  true,
+	})
+	if err != nil {
+		t.Fatalf("GenerateReadScenario() unexpected error: %v", err)
+	}
+
+	if !strings.Contains(got, `"shuffle": true`) {
+		t.Fatalf("expected read scenario to enable shuffle\nGot:\n%s", got)
+	}
+	if !strings.Contains(got, fmt.Sprintf(`"size": %d`, constants.ReadShuffleDefaultBatchSize)) {
+		t.Fatalf("expected read scenario to use default shuffle batch size %d\nGot:\n%s", constants.ReadShuffleDefaultBatchSize, got)
+	}
+	if count := strings.Count(got, `"batch": {`); count != 1 {
+		t.Fatalf("expected exactly one read batch override, got %d\n%s", count, got)
+	}
+	if count := strings.Count(got, `"shuffle": true`); count != 1 {
+		t.Fatalf("expected exactly one read shuffle toggle, got %d\n%s", count, got)
+	}
+}
+
+func TestGenerateReadScenario_FromFileShuffleBatchCap(t *testing.T) {
+	got, err := GenerateReadScenario(Params{
+		WorkloadType:         "read",
+		Bucket:               "shuffle-bucket",
+		Threads:              4,
+		ObjectSize:           "10KB",
+		ItemsFile:            "/data/items.csv",
+		ObjectCount:          500,
+		Cleanup:              true,
+		ReadShuffle:          true,
+		ReadShuffleBatchSize: constants.ReadShuffleMaxBatchSize + 1,
+	})
+	if err != nil {
+		t.Fatalf("GenerateReadScenario() unexpected error: %v", err)
+	}
+
+	if strings.Contains(got, "PreconditionLoad") {
+		t.Fatalf("read-from-file shuffle scenario should not contain a seed phase\n%s", got)
+	}
+	if !strings.Contains(got, fmt.Sprintf(`"size": %d`, constants.ReadShuffleMaxBatchSize)) {
+		t.Fatalf("expected read-from-file shuffle scenario to clamp batch size to %d\n%s", constants.ReadShuffleMaxBatchSize, got)
+	}
+	if count := strings.Count(got, `"batch": {`); count != 1 {
+		t.Fatalf("expected exactly one read batch override, got %d\n%s", count, got)
+	}
+	if count := strings.Count(got, `"shuffle": true`); count != 1 {
+		t.Fatalf("expected exactly one read shuffle toggle, got %d\n%s", count, got)
+	}
+	if !strings.Contains(got, "DeleteLoad") {
+		t.Fatalf("expected read-from-file cleanup scenario to retain cleanup phase\n%s", got)
 	}
 }
 

--- a/cli/internal/scenario/templates.go
+++ b/cli/internal/scenario/templates.go
@@ -586,8 +586,12 @@ ReadLoad
             }
         },
         "load": {
-            "op": {
-                "type": "read",
+{{if .ReadShuffle}}            "batch": {
+                "size": {{.ReadShuffleBatchSize}}
+            },
+{{end}}            "op": {
+                "type": "read",{{if .ReadShuffle}}
+                "shuffle": true,{{end}}
                 "recycle": {
                     "mode": true
                 }
@@ -726,8 +730,12 @@ ReadLoad
             }
         },
         "load": {
-            "op": {
-                "type": "read",
+{{if .ReadShuffle}}            "batch": {
+                "size": {{.ReadShuffleBatchSize}}
+            },
+{{end}}            "op": {
+                "type": "read",{{if .ReadShuffle}}
+                "shuffle": true,{{end}}
                 "recycle": {
                     "mode": true
                 },
@@ -859,8 +867,12 @@ ReadLoad
             }
         },
         "load": {
-            "op": {
-                "type": "read",
+{{if .ReadShuffle}}            "batch": {
+                "size": {{.ReadShuffleBatchSize}}
+            },
+{{end}}            "op": {
+                "type": "read",{{if .ReadShuffle}}
+                "shuffle": true,{{end}}
                 "recycle": {
                     "mode": true
                 }
@@ -969,8 +981,12 @@ ReadLoad
             }
         },
         "load": {
-            "op": {
-                "type": "read",
+{{if .ReadShuffle}}            "batch": {
+                "size": {{.ReadShuffleBatchSize}}
+            },
+{{end}}            "op": {
+                "type": "read",{{if .ReadShuffle}}
+                "shuffle": true,{{end}}
                 "recycle": {
                     "mode": true
                 },
@@ -1086,8 +1102,12 @@ ReadLoad
             }
         },
         "load": {
-            "op": {
-                "type": "read",
+{{if .ReadShuffle}}            "batch": {
+                "size": {{.ReadShuffleBatchSize}}
+            },
+{{end}}            "op": {
+                "type": "read",{{if .ReadShuffle}}
+                "shuffle": true,{{end}}
                 "recycle": {
                     "mode": true
                 }
@@ -1193,8 +1213,12 @@ ReadLoad
             }
         },
         "load": {
-            "op": {
-                "type": "read",
+{{if .ReadShuffle}}            "batch": {
+                "size": {{.ReadShuffleBatchSize}}
+            },
+{{end}}            "op": {
+                "type": "read",{{if .ReadShuffle}}
+                "shuffle": true,{{end}}
                 "recycle": {
                     "mode": true
                 }
@@ -1272,8 +1296,12 @@ ReadLoad
             }
         },
         "load": {
-            "op": {
-                "type": "read",
+{{if .ReadShuffle}}            "batch": {
+                "size": {{.ReadShuffleBatchSize}}
+            },
+{{end}}            "op": {
+                "type": "read",{{if .ReadShuffle}}
+                "shuffle": true,{{end}}
                 "recycle": {
                     "mode": true
                 },
@@ -1351,8 +1379,12 @@ ReadLoad
             }
         },
         "load": {
-            "op": {
-                "type": "read",
+{{if .ReadShuffle}}            "batch": {
+                "size": {{.ReadShuffleBatchSize}}
+            },
+{{end}}            "op": {
+                "type": "read",{{if .ReadShuffle}}
+                "shuffle": true,{{end}}
                 "recycle": {
                     "mode": true
                 }
@@ -1453,8 +1485,12 @@ ReadLoad
             }
         },
         "load": {
-            "op": {
-                "type": "read",
+{{if .ReadShuffle}}            "batch": {
+                "size": {{.ReadShuffleBatchSize}}
+            },
+{{end}}            "op": {
+                "type": "read",{{if .ReadShuffle}}
+                "shuffle": true,{{end}}
                 "recycle": {
                     "mode": true
                 },

--- a/cli/internal/scenario/types.go
+++ b/cli/internal/scenario/types.go
@@ -26,8 +26,10 @@ type Params struct {
 	SliceEndpoints bool // Partition endpoint list across nodes in distributed runs
 
 	// Read workload
-	SeedCount int    // Number of seed objects for read benchmark (default: 2500)
-	ItemsFile string // Path to a local items.csv for read workload (skips seed phase)
+	SeedCount            int    // Number of seed objects for read benchmark (default: 2500)
+	ItemsFile            string // Path to a local items.csv for read workload (skips seed phase)
+	ReadShuffle          bool   // Enable batch-local item shuffling for the read phase
+	ReadShuffleBatchSize int    // Read-phase batch size override used when ReadShuffle is enabled
 
 	// External item files bind-mounted into the engine container.
 	ItemFileMounts []FileMount

--- a/cli/tools/seeded-read.sh
+++ b/cli/tools/seeded-read.sh
@@ -30,6 +30,8 @@ SSH_OPTS=${SSH_OPTS:-"-o BatchMode=yes -o StrictHostKeyChecking=accept-new -o Co
 SPT_IMAGE=${SPT_IMAGE:-""}
 SKIP_IMAGE_PULL=${SPT_SKIP_IMAGE_PULL:-false}
 S3_DRIVER=${SPT_S3_DRIVER:-"default"}
+READ_SHUFFLE=${READ_SHUFFLE:-true}
+READ_SHUFFLE_BATCH_SIZE=${READ_SHUFFLE_BATCH_SIZE:-""}
 
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -47,6 +49,9 @@ while [ $# -gt 0 ]; do
     --results-dir) RESULTS_DIR="${2:-}"; shift 2 ;;
     --label-prefix) LABEL_PREFIX="${2:-}"; shift 2 ;;
     --s3-driver) S3_DRIVER="${2:-}"; shift 2 ;;
+    --shuffle) READ_SHUFFLE=true; shift 1 ;;
+    --no-shuffle) READ_SHUFFLE=false; shift 1 ;;
+    --shuffle-batch-size) READ_SHUFFLE_BATCH_SIZE="${2:-}"; shift 2 ;;
     --image) SPT_IMAGE="${2:-}"; shift 2 ;;
     --skip-image-pull) SKIP_IMAGE_PULL=true; shift 1 ;;
     --verbose) VERBOSE=true; shift 1 ;;
@@ -84,6 +89,8 @@ Workload:
   --object-count N         Objects to seed and default read count (default: $OBJECT_COUNT)
   --read-count N           Read operation count (default: object-count)
   --min-hosts N            Minimum hosts required (default: $MIN_HOSTS)
+  --[no-]shuffle           Enable batch-local shuffling for the read phase (default: $READ_SHUFFLE)
+  --shuffle-batch-size N   Optional read-phase shuffle batch size override (default: CLI bounded default)
 
 Output:
   --results-dir DIR        Auto-results root (default: $RESULTS_DIR)
@@ -113,6 +120,11 @@ EOF
     *) echo "Unknown arg: $1" >&2; exit 2 ;;
   esac
 done
+
+if [ "$READ_SHUFFLE" != true ] && [ -n "$READ_SHUFFLE_BATCH_SIZE" ]; then
+  echo "--shuffle-batch-size requires shuffle to be enabled" >&2
+  exit 2
+fi
 
 [ -n "$SPT_IMAGE" ] && export SPT_IMAGE
 if [ "$SKIP_IMAGE_PULL" = true ]; then
@@ -265,6 +277,15 @@ echo "Results: $RESULTS_DIR"
 if [ "$S3_DRIVER" != "default" ]; then
   echo "S3 Driver: $S3_DRIVER"
 fi
+if [ "$READ_SHUFFLE" = true ]; then
+  if [ -n "$READ_SHUFFLE_BATCH_SIZE" ]; then
+    echo "Read shuffle: enabled (batch size: $READ_SHUFFLE_BATCH_SIZE)"
+  else
+    echo "Read shuffle: enabled (batch size: CLI bounded default)"
+  fi
+else
+  echo "Read shuffle: disabled"
+fi
 [ -n "$SPT_IMAGE" ] && echo "Image: $SPT_IMAGE"
 [ "$SKIP_IMAGE_PULL" = true ] && echo "Skip image pull: true"
 $CLEANUP && echo "Cleanup: read phase will delete seeded objects" || echo "Cleanup: disabled"
@@ -301,6 +322,10 @@ read_cmd=("$ROOT_DIR"/spt --debug run read --headless
   --items-file "$ITEMS_FILE"
 )
 add_common_args read_cmd
+$READ_SHUFFLE && read_cmd+=(--shuffle) || true
+if [ -n "$READ_SHUFFLE_BATCH_SIZE" ]; then
+  read_cmd+=(--shuffle-batch-size "$READ_SHUFFLE_BATCH_SIZE")
+fi
 $CLEANUP && read_cmd+=(--cleanup) || true
 
 echo "=== Phase 2/2: read back $READ_COUNT objects from saved items.csv ==="


### PR DESCRIPTION
## Summary
- add `spt run read` shuffle controls (`--shuffle`, `--shuffle-batch-size`) with bounded defaults/caps and read-only validation
- wire read shuffle into generated read scenarios so only `ReadLoad` gets batch/shuffle overrides, and add coverage for on/off + cap behavior
- update docs/changelog for the new read-shuffle behavior and caveats
- enable shuffle by default in `cli/tools/seeded-read.sh`, with wrapper flags to disable or override the shuffle batch size
