### PR TITLE
Fix local node log capture for auto-results

### DIFF
--- a/cli/cmd/envdefaults_test.go
+++ b/cli/cmd/envdefaults_test.go
@@ -41,16 +41,44 @@ func newVerifyLikeCmd() *cobra.Command {
 	return c
 }
 
+func clearEnvDefaultsTestEnv(t *testing.T) {
+	t.Helper()
+	for _, key := range []string{
+		"S3_ENDPOINT",
+		"S3_ENDPOINTS",
+		"S3_ACCESS_KEY",
+		"S3_SECRET_KEY",
+		"S3_BUCKET",
+		"HOSTS",
+		"THREADS",
+		constants.EnvSkipImagePull,
+		constants.EnvS3AuthVersion,
+		constants.EnvRdmaEnabled,
+		constants.EnvRdmaLocalIP,
+		constants.EnvRdmaDevice,
+		constants.EnvRdmaLogLevel,
+		constants.EnvRdmaThreshold,
+		constants.EnvRdmaTimeout,
+		constants.EnvRdmaFallback,
+		constants.EnvServiceThreads,
+		constants.EnvPartSize,
+		constants.EnvS3Driver,
+	} {
+		t.Setenv(key, "")
+	}
+}
+
 func TestApplyEnvDefaultsToRunFlags(t *testing.T) {
 	cmd := newRunLikeCmd()
+	clearEnvDefaultsTestEnv(t)
 
 	// Seed env
-	os.Setenv("S3_ENDPOINT", "http://env:9000")
-	os.Setenv("S3_ACCESS_KEY", "AKIA")
-	os.Setenv("S3_SECRET_KEY", "SECRET")
-	os.Setenv("S3_BUCKET", "bucket1")
-	os.Setenv("HOSTS", "h1,h2")
-	os.Setenv(constants.EnvSkipImagePull, "1")
+	t.Setenv("S3_ENDPOINT", "http://env:9000")
+	t.Setenv("S3_ACCESS_KEY", "AKIA")
+	t.Setenv("S3_SECRET_KEY", "SECRET")
+	t.Setenv("S3_BUCKET", "bucket1")
+	t.Setenv("HOSTS", "h1,h2")
+	t.Setenv(constants.EnvSkipImagePull, "1")
 	t.Cleanup(func() {
 		os.Unsetenv("S3_ENDPOINT")
 		os.Unsetenv("S3_ACCESS_KEY")
@@ -90,8 +118,9 @@ func TestApplyEnvDefaultsToRunFlags(t *testing.T) {
 
 func TestApplyEnvDefaultsToRunFlags_S3Endpoints(t *testing.T) {
 	cmd := newRunLikeCmd()
+	clearEnvDefaultsTestEnv(t)
 	// Only S3_ENDPOINTS is set; ensure endpoints are used and single endpoint not set
-	os.Setenv("S3_ENDPOINTS", "http://s3a:9000,http://s3b:9000")
+	t.Setenv("S3_ENDPOINTS", "http://s3a:9000,http://s3b:9000")
 	t.Cleanup(func() { os.Unsetenv("S3_ENDPOINTS") })
 
 	if err := applyEnvDefaultsToRunFlags(cmd); err != nil {
@@ -109,9 +138,10 @@ func TestApplyEnvDefaultsToRunFlags_S3Endpoints(t *testing.T) {
 
 func TestApplyEnvDefaultsToRunFlags_EndpointsFlagWins(t *testing.T) {
 	cmd := newRunLikeCmd()
+	clearEnvDefaultsTestEnv(t)
 	// User provided endpoints flag; env should not override
 	_ = cmd.Flags().Set("endpoints", "http://cli1:9000,http://cli2:9000")
-	os.Setenv("S3_ENDPOINTS", "http://env1:9000,http://env2:9000")
+	t.Setenv("S3_ENDPOINTS", "http://env1:9000,http://env2:9000")
 	t.Cleanup(func() { os.Unsetenv("S3_ENDPOINTS") })
 
 	if err := applyEnvDefaultsToRunFlags(cmd); err != nil {
@@ -125,11 +155,12 @@ func TestApplyEnvDefaultsToRunFlags_EndpointsFlagWins(t *testing.T) {
 
 func TestApplyEnvDefaults_RespectUserFlags(t *testing.T) {
 	cmd := newRunLikeCmd()
+	clearEnvDefaultsTestEnv(t)
 	// User provided an explicit flag
 	cmd.Flags().Set("endpoint", "http://cli:9000")
 	cmd.Flags().Set(flagSkipImagePull, "true")
-	os.Setenv("S3_ENDPOINT", "http://env:9000")
-	os.Setenv(constants.EnvSkipImagePull, "0")
+	t.Setenv("S3_ENDPOINT", "http://env:9000")
+	t.Setenv(constants.EnvSkipImagePull, "0")
 	t.Cleanup(func() {
 		os.Unsetenv("S3_ENDPOINT")
 		os.Unsetenv(constants.EnvSkipImagePull)
@@ -153,9 +184,10 @@ func TestApplyEnvDefaults_RespectUserFlags(t *testing.T) {
 
 func TestApplyEnvDefaultsToRunFlags_ThreadsFromEnv(t *testing.T) {
 	cmd := newRunLikeCmd()
+	clearEnvDefaultsTestEnv(t)
 	// Ensure user did not set --threads
 	// Provide THREADS through env
-	os.Setenv("THREADS", "16")
+	t.Setenv("THREADS", "16")
 	t.Cleanup(func() { os.Unsetenv("THREADS") })
 
 	if err := applyEnvDefaultsToRunFlags(cmd); err != nil {
@@ -169,7 +201,8 @@ func TestApplyEnvDefaultsToRunFlags_ThreadsFromEnv(t *testing.T) {
 
 func TestApplyEnvDefaultsToVerifyFlags(t *testing.T) {
 	cmd := newVerifyLikeCmd()
-	os.Setenv("HOSTS", "v1,v2")
+	clearEnvDefaultsTestEnv(t)
+	t.Setenv("HOSTS", "v1,v2")
 	t.Cleanup(func() { os.Unsetenv("HOSTS") })
 
 	if err := applyEnvDefaultsToVerifyFlags(cmd); err != nil {
@@ -192,14 +225,15 @@ func TestApplyEnvDefaultsToVerifyFlags(t *testing.T) {
 
 func TestApplyEnvDefaultsToRunFlags_RdmaFromEnv(t *testing.T) {
 	cmd := newRunLikeCmd()
+	clearEnvDefaultsTestEnv(t)
 
-	os.Setenv(constants.EnvRdmaEnabled, "true")
-	os.Setenv(constants.EnvRdmaLocalIP, "10.247.128.125")
-	os.Setenv(constants.EnvRdmaDevice, "mlx5_0")
-	os.Setenv(constants.EnvRdmaLogLevel, "DEBUG")
-	os.Setenv(constants.EnvRdmaThreshold, "4194304")
-	os.Setenv(constants.EnvRdmaTimeout, "60000")
-	os.Setenv(constants.EnvRdmaFallback, "false")
+	t.Setenv(constants.EnvRdmaEnabled, "true")
+	t.Setenv(constants.EnvRdmaLocalIP, "10.247.128.125")
+	t.Setenv(constants.EnvRdmaDevice, "mlx5_0")
+	t.Setenv(constants.EnvRdmaLogLevel, "DEBUG")
+	t.Setenv(constants.EnvRdmaThreshold, "4194304")
+	t.Setenv(constants.EnvRdmaTimeout, "60000")
+	t.Setenv(constants.EnvRdmaFallback, "false")
 	t.Cleanup(func() {
 		os.Unsetenv(constants.EnvRdmaEnabled)
 		os.Unsetenv(constants.EnvRdmaLocalIP)
@@ -239,12 +273,13 @@ func TestApplyEnvDefaultsToRunFlags_RdmaFromEnv(t *testing.T) {
 
 func TestApplyEnvDefaultsToRunFlags_RdmaFlagWinsOverEnv(t *testing.T) {
 	cmd := newRunLikeCmd()
+	clearEnvDefaultsTestEnv(t)
 
 	// User explicitly sets --use-rdma=false on CLI
 	_ = cmd.Flags().Set("use-rdma", "false")
 
 	// Env says true
-	os.Setenv(constants.EnvRdmaEnabled, "true")
+	t.Setenv(constants.EnvRdmaEnabled, "true")
 	t.Cleanup(func() { os.Unsetenv(constants.EnvRdmaEnabled) })
 
 	if err := applyEnvDefaultsToRunFlags(cmd); err != nil {
@@ -259,8 +294,9 @@ func TestApplyEnvDefaultsToRunFlags_RdmaFlagWinsOverEnv(t *testing.T) {
 
 func TestApplyEnvDefaultsToRunFlags_RdmaInvalidThreshold(t *testing.T) {
 	cmd := newRunLikeCmd()
+	clearEnvDefaultsTestEnv(t)
 
-	os.Setenv(constants.EnvRdmaThreshold, "not-a-number")
+	t.Setenv(constants.EnvRdmaThreshold, "not-a-number")
 	t.Cleanup(func() { os.Unsetenv(constants.EnvRdmaThreshold) })
 
 	err := applyEnvDefaultsToRunFlags(cmd)
@@ -274,8 +310,9 @@ func TestApplyEnvDefaultsToRunFlags_RdmaInvalidThreshold(t *testing.T) {
 
 func TestApplyEnvDefaultsToRunFlags_RdmaInvalidTimeout(t *testing.T) {
 	cmd := newRunLikeCmd()
+	clearEnvDefaultsTestEnv(t)
 
-	os.Setenv(constants.EnvRdmaTimeout, "abc")
+	t.Setenv(constants.EnvRdmaTimeout, "abc")
 	t.Cleanup(func() { os.Unsetenv(constants.EnvRdmaTimeout) })
 
 	err := applyEnvDefaultsToRunFlags(cmd)
@@ -289,8 +326,9 @@ func TestApplyEnvDefaultsToRunFlags_RdmaInvalidTimeout(t *testing.T) {
 
 func TestApplyEnvDefaultsToRunFlags_RdmaHumanizedThreshold(t *testing.T) {
 	cmd := newRunLikeCmd()
+	clearEnvDefaultsTestEnv(t)
 
-	os.Setenv(constants.EnvRdmaThreshold, "256KB")
+	t.Setenv(constants.EnvRdmaThreshold, "256KB")
 	t.Cleanup(func() { os.Unsetenv(constants.EnvRdmaThreshold) })
 
 	if err := applyEnvDefaultsToRunFlags(cmd); err != nil {
@@ -303,9 +341,10 @@ func TestApplyEnvDefaultsToRunFlags_RdmaHumanizedThreshold(t *testing.T) {
 
 func TestApplyEnvDefaultsToRunFlags_RdmaInvalidBoolIgnored(t *testing.T) {
 	cmd := newRunLikeCmd()
+	clearEnvDefaultsTestEnv(t)
 
 	// Invalid bool for SPT_RDMA should be silently ignored (not error)
-	os.Setenv(constants.EnvRdmaEnabled, "maybe")
+	t.Setenv(constants.EnvRdmaEnabled, "maybe")
 	t.Cleanup(func() { os.Unsetenv(constants.EnvRdmaEnabled) })
 
 	if err := applyEnvDefaultsToRunFlags(cmd); err != nil {
@@ -320,9 +359,10 @@ func TestApplyEnvDefaultsToRunFlags_RdmaInvalidBoolIgnored(t *testing.T) {
 
 func TestApplyEnvDefaultsToRunFlags_RdmaInvalidFallbackIgnored(t *testing.T) {
 	cmd := newRunLikeCmd()
+	clearEnvDefaultsTestEnv(t)
 
 	// Invalid bool for RDMA_FALLBACK_ENABLED should be silently ignored
-	os.Setenv(constants.EnvRdmaFallback, "sometimes")
+	t.Setenv(constants.EnvRdmaFallback, "sometimes")
 	t.Cleanup(func() { os.Unsetenv(constants.EnvRdmaFallback) })
 
 	if err := applyEnvDefaultsToRunFlags(cmd); err != nil {
@@ -337,8 +377,9 @@ func TestApplyEnvDefaultsToRunFlags_RdmaInvalidFallbackIgnored(t *testing.T) {
 
 func TestApplyEnvDefaultsToVerifyFlags_RdmaFromEnv(t *testing.T) {
 	cmd := newVerifyLikeCmd()
+	clearEnvDefaultsTestEnv(t)
 
-	os.Setenv(constants.EnvRdmaEnabled, "1")
+	t.Setenv(constants.EnvRdmaEnabled, "1")
 	t.Cleanup(func() { os.Unsetenv(constants.EnvRdmaEnabled) })
 
 	if err := applyEnvDefaultsToVerifyFlags(cmd); err != nil {
@@ -352,8 +393,9 @@ func TestApplyEnvDefaultsToVerifyFlags_RdmaFromEnv(t *testing.T) {
 
 func TestApplyEnvDefaultsToRunFlags_ServiceThreadsFromEnv(t *testing.T) {
 	cmd := newRunLikeCmd()
+	clearEnvDefaultsTestEnv(t)
 
-	os.Setenv(constants.EnvServiceThreads, "32")
+	t.Setenv(constants.EnvServiceThreads, "32")
 	t.Cleanup(func() { os.Unsetenv(constants.EnvServiceThreads) })
 
 	if err := applyEnvDefaultsToRunFlags(cmd); err != nil {
@@ -367,8 +409,9 @@ func TestApplyEnvDefaultsToRunFlags_ServiceThreadsFromEnv(t *testing.T) {
 
 func TestApplyEnvDefaultsToRunFlags_ServiceThreadsFlagOverridesEnv(t *testing.T) {
 	cmd := newRunLikeCmd()
+	clearEnvDefaultsTestEnv(t)
 
-	os.Setenv(constants.EnvServiceThreads, "32")
+	t.Setenv(constants.EnvServiceThreads, "32")
 	t.Cleanup(func() { os.Unsetenv(constants.EnvServiceThreads) })
 
 	// Simulate explicit flag usage
@@ -385,8 +428,9 @@ func TestApplyEnvDefaultsToRunFlags_ServiceThreadsFlagOverridesEnv(t *testing.T)
 
 func TestApplyEnvDefaultsToRunFlags_ServiceThreadsInvalidEnv(t *testing.T) {
 	cmd := newRunLikeCmd()
+	clearEnvDefaultsTestEnv(t)
 
-	os.Setenv(constants.EnvServiceThreads, "not-a-number")
+	t.Setenv(constants.EnvServiceThreads, "not-a-number")
 	t.Cleanup(func() { os.Unsetenv(constants.EnvServiceThreads) })
 
 	err := applyEnvDefaultsToRunFlags(cmd)
@@ -400,8 +444,9 @@ func TestApplyEnvDefaultsToRunFlags_ServiceThreadsInvalidEnv(t *testing.T) {
 
 func TestApplyEnvDefaultsToRunFlags_PartSizeFromEnv(t *testing.T) {
 	cmd := newRunLikeCmd()
+	clearEnvDefaultsTestEnv(t)
 
-	os.Setenv(constants.EnvPartSize, "64MB")
+	t.Setenv(constants.EnvPartSize, "64MB")
 	t.Cleanup(func() { os.Unsetenv(constants.EnvPartSize) })
 
 	if err := applyEnvDefaultsToRunFlags(cmd); err != nil {
@@ -415,10 +460,11 @@ func TestApplyEnvDefaultsToRunFlags_PartSizeFromEnv(t *testing.T) {
 
 func TestApplyEnvDefaultsToRunFlags_PartSizeFlagWinsOverEnv(t *testing.T) {
 	cmd := newRunLikeCmd()
+	clearEnvDefaultsTestEnv(t)
 
 	_ = cmd.Flags().Set("part-size", "32MB")
 
-	os.Setenv(constants.EnvPartSize, "64MB")
+	t.Setenv(constants.EnvPartSize, "64MB")
 	t.Cleanup(func() { os.Unsetenv(constants.EnvPartSize) })
 
 	if err := applyEnvDefaultsToRunFlags(cmd); err != nil {
@@ -432,8 +478,9 @@ func TestApplyEnvDefaultsToRunFlags_PartSizeFlagWinsOverEnv(t *testing.T) {
 
 func TestApplyEnvDefaultsToRunFlags_PartSizeInvalidEnv(t *testing.T) {
 	cmd := newRunLikeCmd()
+	clearEnvDefaultsTestEnv(t)
 
-	os.Setenv(constants.EnvPartSize, "not-a-size")
+	t.Setenv(constants.EnvPartSize, "not-a-size")
 	t.Cleanup(func() { os.Unsetenv(constants.EnvPartSize) })
 
 	err := applyEnvDefaultsToRunFlags(cmd)
@@ -447,8 +494,9 @@ func TestApplyEnvDefaultsToRunFlags_PartSizeInvalidEnv(t *testing.T) {
 
 func TestApplyEnvDefaultsToRunFlags_S3DriverFromEnv(t *testing.T) {
 	cmd := newRunLikeCmd()
+	clearEnvDefaultsTestEnv(t)
 
-	os.Setenv(constants.EnvS3Driver, "aws")
+	t.Setenv(constants.EnvS3Driver, "aws")
 	t.Cleanup(func() { os.Unsetenv(constants.EnvS3Driver) })
 
 	if err := applyEnvDefaultsToRunFlags(cmd); err != nil {
@@ -463,8 +511,9 @@ func TestApplyEnvDefaultsToRunFlags_S3DriverFromEnv(t *testing.T) {
 
 func TestApplyEnvDefaultsToRunFlags_S3DriverFlagWinsOverEnv(t *testing.T) {
 	cmd := newRunLikeCmd()
+	clearEnvDefaultsTestEnv(t)
 
-	os.Setenv(constants.EnvS3Driver, "aws")
+	t.Setenv(constants.EnvS3Driver, "aws")
 	t.Cleanup(func() { os.Unsetenv(constants.EnvS3Driver) })
 
 	_ = cmd.Flags().Set("s3-driver", "rdma") // explicit flag

--- a/cli/cmd/replay.go
+++ b/cli/cmd/replay.go
@@ -332,6 +332,7 @@ func runReplay(cmd *cobra.Command, _ []string) error {
 		verbose, _ := cmd.Flags().GetBool("verbose")
 		options := buildHeadlessOptions(traceOpts, verbose, apiPort, autoTerminate, false, replayStepIDs(generated))
 		options.NetworkMode = networkMode
+		options.ResultsRoot = plannedResultsRoot
 		if autoTerminate > 0 {
 			_, _ = fmt.Fprintf(out, "Auto-terminate: will stop after %d seconds\n", autoTerminate)
 		}
@@ -344,12 +345,12 @@ func runReplay(cmd *cobra.Command, _ []string) error {
 	_, _ = fmt.Fprintln(out, "Starting TUI...")
 	if autoTerminate > 0 {
 		_, _ = fmt.Fprintf(out, "Auto-terminate: will stop after %d seconds\n", autoTerminate)
-		err := tui.StartTUIWithScenarioContentAndParamsTimeoutWithTrace(sptImage, paths.Scenario, params, apiPort, networkMode, autoTerminate, nil, traceOpts.Path, traceOpts.Append, generated.ScenarioJS, generated.DefaultsYAML)
+		err := tui.StartTUIWithScenarioContentAndParamsTimeoutWithTrace(sptImage, paths.Scenario, params, apiPort, networkMode, plannedResultsRoot, autoTerminate, nil, traceOpts.Path, traceOpts.Append, generated.ScenarioJS, generated.DefaultsYAML)
 		waitForAutoResults()
 		finalizeTraceArtifact()
 		return err
 	}
-	err = tui.StartTUIWithScenarioContentAndParamsWithTrace(sptImage, paths.Scenario, params, apiPort, networkMode, nil, traceOpts.Path, traceOpts.Append, generated.ScenarioJS, generated.DefaultsYAML)
+	err = tui.StartTUIWithScenarioContentAndParamsWithTrace(sptImage, paths.Scenario, params, apiPort, networkMode, plannedResultsRoot, nil, traceOpts.Path, traceOpts.Append, generated.ScenarioJS, generated.DefaultsYAML)
 	waitForAutoResults()
 	finalizeTraceArtifact()
 	return err

--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -1040,6 +1040,7 @@ Available workload types:
 
 			options := buildHeadlessOptions(traceOpts, verbose, apiPort, autoTerminate, false, nil)
 			options.NetworkMode = networkMode
+			options.ResultsRoot = plannedResultsRoot
 			// KeepScenario is now passed via params, not options.
 			if autoTerminate > 0 {
 				fmt.Printf("Auto-terminate: will stop after %d seconds\n", autoTerminate)
@@ -1055,9 +1056,9 @@ Available workload types:
 		// Launch TUI with the scenario file
 		if autoTerminate > 0 {
 			fmt.Printf("Auto-terminate: will stop after %d seconds\n", autoTerminate)
-			err = tui.StartTUIWithScenarioAndParamsNetworkModeTimeoutWithTrace(sptImage, scenarioPath, params, apiPort, networkMode, autoTerminate, setSummarySink, traceOpts.Path, traceOpts.Append)
+			err = tui.StartTUIWithScenarioAndParamsNetworkModeTimeoutWithTrace(sptImage, scenarioPath, params, apiPort, networkMode, plannedResultsRoot, autoTerminate, setSummarySink, traceOpts.Path, traceOpts.Append)
 		} else {
-			err = tui.StartTUIWithScenarioAndParamsNetworkModeWithTrace(sptImage, scenarioPath, params, apiPort, networkMode, setSummarySink, traceOpts.Path, traceOpts.Append)
+			err = tui.StartTUIWithScenarioAndParamsNetworkModeWithTrace(sptImage, scenarioPath, params, apiPort, networkMode, plannedResultsRoot, setSummarySink, traceOpts.Path, traceOpts.Append)
 		}
 		waitForAutoResults(false)
 		finalizeTraceArtifact()

--- a/cli/tui/api_integration_test.go
+++ b/cli/tui/api_integration_test.go
@@ -186,7 +186,7 @@ func TestAPIIntegrationFullFlow(t *testing.T) {
 	mockDM := NewMockDockerManager()
 
 	// Create orchestrator
-	orchestrator := NewTestOrchestrator(mockDM, constants.SptAPIPort)
+	orchestrator := NewTestOrchestrator(mockDM, constants.SptAPIPort, "")
 
 	// Track all interactions
 	var statusUpdates []string

--- a/cli/tui/docker.go
+++ b/cli/tui/docker.go
@@ -217,7 +217,7 @@ func (dm *DockerManager) prepareNodeLogCapture() ([]string, []string) {
 			logging.LogWarn("docker", "failed to reset node log capture directory", "path", dir, "error", err.Error())
 			return nil, nil
 		}
-		err = os.MkdirAll(dir, 0o777)
+		err = os.MkdirAll(dir, 0o777) // #nosec G301 -- container user must be able to traverse and write the bind mount
 	} else {
 		dir, err = os.MkdirTemp("", nodeLogDirPattern)
 	}

--- a/cli/tui/docker.go
+++ b/cli/tui/docker.go
@@ -35,13 +35,14 @@ import (
 )
 
 const (
-	dockerBindAllInterfaces    = "0.0.0.0"
-	dockerCgroupPermissionsRWM = "rwm"
-	dockerLabelTrue            = "true"
-	dockerMemlockUlimitName    = "memlock"
-	dockerNodeModeArg          = "--run-node=true"
-	dockerNodeLogMount         = "/spt-node-logs"
-	nodeLogDirPattern          = "spt-node-logs-*"
+	dockerBindAllInterfaces     = "0.0.0.0"
+	dockerCgroupPermissionsRWM  = "rwm"
+	dockerLabelTrue             = "true"
+	dockerMemlockUlimitName     = "memlock"
+	dockerNodeModeArg           = "--run-node=true"
+	dockerNodeLogMount          = "/spt-node-logs"
+	dockerNodeLogResultsDirName = ".node-home"
+	nodeLogDirPattern           = "spt-node-logs-*"
 )
 
 // DockerManager handles Docker operations for the TUI
@@ -62,14 +63,16 @@ type dockerClient interface {
 // dockerClient interface for easier testing and can delegate to a
 // RemoteDockerManager when managing remote hosts.
 type DockerManager struct {
-	client      dockerClient
-	containerID string
-	ctx         context.Context
-	cancel      context.CancelFunc
-	hostInfo    *hostparse.HostInfo  // New field to track host information
-	remote      *RemoteDockerManager // When non-nil, delegate operations to remote CLI manager
-	nodeLogDir  string               // Host-side temp dir mounted for node startup diagnostics
-	fileMounts  []scenario.FileMount
+	client             dockerClient
+	containerID        string
+	ctx                context.Context
+	cancel             context.CancelFunc
+	hostInfo           *hostparse.HostInfo  // New field to track host information
+	remote             *RemoteDockerManager // When non-nil, delegate operations to remote CLI manager
+	nodeLogDir         string
+	nodeLogResultsRoot string
+	preserveNodeLogDir bool
+	fileMounts         []scenario.FileMount
 }
 
 func skipImagePull(image string) bool {
@@ -191,22 +194,46 @@ func (dm *DockerManager) pullImage(imageName string) error {
 	return nil
 }
 
+func (dm *DockerManager) setNodeLogResultsRoot(resultsRoot string) {
+	dm.nodeLogResultsRoot = strings.TrimSpace(resultsRoot)
+}
+
 func (dm *DockerManager) prepareNodeLogCapture() ([]string, []string) {
 	if dm.nodeLogDir != "" {
 		_ = os.RemoveAll(dm.nodeLogDir)
 		dm.nodeLogDir = ""
 	}
-	dir, err := os.MkdirTemp("", nodeLogDirPattern)
+	preserve := dm.nodeLogResultsRoot != ""
+	var (
+		dir string
+		err error
+	)
+	if preserve {
+		if dir, err = filepath.Abs(filepath.Join(dm.nodeLogResultsRoot, dockerNodeLogResultsDirName)); err != nil {
+			logging.LogWarn("docker", "failed to resolve node log capture directory", "path", dm.nodeLogResultsRoot, "error", err.Error())
+			return nil, nil
+		}
+		if err = os.RemoveAll(dir); err != nil {
+			logging.LogWarn("docker", "failed to reset node log capture directory", "path", dir, "error", err.Error())
+			return nil, nil
+		}
+		err = os.MkdirAll(dir, 0o777)
+	} else {
+		dir, err = os.MkdirTemp("", nodeLogDirPattern)
+	}
 	if err != nil {
 		logging.LogWarn("docker", "failed to create node log capture directory", "error", err.Error())
 		return nil, nil
 	}
-	if err := os.Chmod(dir, 0o700); err != nil { // #nosec G302 -- directory requires owner execute bit for traversal
-		_ = os.RemoveAll(dir)
-		logging.LogWarn("docker", "failed to secure node log capture directory", "error", err.Error())
+	if err := os.Chmod(dir, 0o777); err != nil { // #nosec G302 -- container user must be able to traverse and write the bind mount
+		if !preserve {
+			_ = os.RemoveAll(dir)
+		}
+		logging.LogWarn("docker", "failed to prepare node log capture directory permissions", "path", dir, "error", err.Error())
 		return nil, nil
 	}
 	dm.nodeLogDir = dir
+	dm.preserveNodeLogDir = preserve
 	return []string{fmt.Sprintf("%s:%s", dir, dockerNodeLogMount)}, []string{"SPT_LOG_DIR=" + dockerNodeLogMount}
 }
 
@@ -916,6 +943,10 @@ func (dm *DockerManager) Cleanup() error {
 
 func (dm *DockerManager) cleanupNodeLogDir() {
 	if dm.nodeLogDir == "" {
+		return
+	}
+	if dm.preserveNodeLogDir {
+		dm.nodeLogDir = ""
 		return
 	}
 	if err := os.RemoveAll(dm.nodeLogDir); err != nil {

--- a/cli/tui/docker_client_shim_test.go
+++ b/cli/tui/docker_client_shim_test.go
@@ -24,15 +24,16 @@ import (
 
 // fakeDockerClient implements dockerClient for tests
 type fakeDockerClient struct {
-	pulled           bool
-	stopped, removed int
-	ver              types.Version
-	inspectErr       error
-	logBody          []byte
-	logOptions       container.LogsOptions
-	stopErr          error
-	removeErr        error
-	createHostConfig *container.HostConfig
+	pulled                bool
+	stopped, removed      int
+	ver                   types.Version
+	inspectErr            error
+	logBody               []byte
+	logOptions            container.LogsOptions
+	stopErr               error
+	removeErr             error
+	createHostConfig      *container.HostConfig
+	createContainerConfig *container.Config
 }
 
 func (f *fakeDockerClient) ImageInspect(ctx context.Context, imageID string, _ ...client.ImageInspectOption) (image.InspectResponse, error) {
@@ -52,6 +53,7 @@ func (f *fakeDockerClient) ContainerLogs(ctx context.Context, container string, 
 	return io.NopCloser(bytes.NewReader(logs.Bytes())), nil
 }
 func (f *fakeDockerClient) ContainerCreate(ctx context.Context, config *container.Config, hostConfig *container.HostConfig, networkingConfig *network.NetworkingConfig, platform *ocispec.Platform, containerName string) (container.CreateResponse, error) {
+	f.createContainerConfig = config
 	f.createHostConfig = hostConfig
 	return container.CreateResponse{ID: "abc"}, nil
 }
@@ -236,5 +238,112 @@ func TestContainerDiagnosticTailIncludesDockerAndEngineErrors(t *testing.T) {
 	}
 	if f.logOptions.Tail != "7" {
 		t.Fatalf("docker log tail = %q, want 7", f.logOptions.Tail)
+	}
+}
+
+func TestDockerManager_PrepareNodeLogCaptureUsesConfiguredResultsRoot(t *testing.T) {
+	resultsRoot := t.TempDir()
+	dm := &DockerManager{}
+	dm.setNodeLogResultsRoot(resultsRoot)
+
+	binds, env := dm.prepareNodeLogCapture()
+	wantDir := filepath.Join(resultsRoot, dockerNodeLogResultsDirName)
+	if dm.nodeLogDir != wantDir {
+		t.Fatalf("nodeLogDir = %q, want %q", dm.nodeLogDir, wantDir)
+	}
+	if !dm.preserveNodeLogDir {
+		t.Fatal("preserveNodeLogDir = false, want true")
+	}
+	if len(binds) != 1 || binds[0] != wantDir+":"+dockerNodeLogMount {
+		t.Fatalf("binds = %v, want %q", binds, wantDir+":"+dockerNodeLogMount)
+	}
+	if len(env) != 1 || env[0] != "SPT_LOG_DIR="+dockerNodeLogMount {
+		t.Fatalf("env = %v", env)
+	}
+	info, err := os.Stat(wantDir)
+	if err != nil {
+		t.Fatalf("stat node log dir: %v", err)
+	}
+	if info.Mode().Perm()&0o003 != 0o003 {
+		t.Fatalf("node log dir perms = %o, want other write+execute set", info.Mode().Perm())
+	}
+}
+
+func TestDockerManager_PrepareNodeLogCaptureResolvesRelativeResultsRoot(t *testing.T) {
+	t.Chdir(t.TempDir())
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd() error = %v", err)
+	}
+
+	dm := &DockerManager{}
+	relativeRoot := filepath.Join("results", "run-123")
+	dm.setNodeLogResultsRoot(relativeRoot)
+
+	binds, _ := dm.prepareNodeLogCapture()
+	wantDir := filepath.Join(cwd, relativeRoot, dockerNodeLogResultsDirName)
+	if dm.nodeLogDir != wantDir {
+		t.Fatalf("nodeLogDir = %q, want %q", dm.nodeLogDir, wantDir)
+	}
+	if len(binds) != 1 || binds[0] != wantDir+":"+dockerNodeLogMount {
+		t.Fatalf("binds = %v, want %q", binds, wantDir+":"+dockerNodeLogMount)
+	}
+}
+
+func TestDockerManager_CleanupRemovesTemporaryNodeLogDir(t *testing.T) {
+	dm := &DockerManager{}
+	dm.prepareNodeLogCapture()
+	logDir := dm.nodeLogDir
+	if logDir == "" {
+		t.Fatal("nodeLogDir not set")
+	}
+	if err := dm.Cleanup(); err != nil {
+		t.Fatalf("Cleanup() error = %v", err)
+	}
+	if _, err := os.Stat(logDir); !os.IsNotExist(err) {
+		t.Fatalf("temp node log dir still exists, stat err = %v", err)
+	}
+}
+
+func TestDockerManager_CleanupPreservesConfiguredNodeLogDir(t *testing.T) {
+	resultsRoot := t.TempDir()
+	dm := &DockerManager{}
+	dm.setNodeLogResultsRoot(resultsRoot)
+	dm.prepareNodeLogCapture()
+	logDir := dm.nodeLogDir
+	marker := filepath.Join(logDir, "marker.txt")
+	if err := os.WriteFile(marker, []byte("ok"), 0o600); err != nil {
+		t.Fatalf("write marker: %v", err)
+	}
+	if err := dm.Cleanup(); err != nil {
+		t.Fatalf("Cleanup() error = %v", err)
+	}
+	if _, err := os.Stat(marker); err != nil {
+		t.Fatalf("marker missing after cleanup: %v", err)
+	}
+}
+
+func TestStartContainerInNodeModeUsesConfiguredNodeLogDir(t *testing.T) {
+	resultsRoot := t.TempDir()
+	f := &fakeDockerClient{}
+	dm := &DockerManager{client: f, ctx: context.Background()}
+	dm.setNodeLogResultsRoot(resultsRoot)
+
+	if _, err := dm.StartContainerInNodeMode("test-image", "10080", constants.BridgeNetworkMode); err != nil {
+		t.Fatalf("StartContainerInNodeMode() error = %v", err)
+	}
+	wantDir := filepath.Join(resultsRoot, dockerNodeLogResultsDirName)
+	wantBind := wantDir + ":" + dockerNodeLogMount
+	if f.createHostConfig == nil {
+		t.Fatal("ContainerCreate host config was nil")
+	}
+	if !containsString(f.createHostConfig.Binds, wantBind) {
+		t.Fatalf("host binds = %v, want %q", f.createHostConfig.Binds, wantBind)
+	}
+	if f.createContainerConfig == nil {
+		t.Fatal("ContainerCreate container config was nil")
+	}
+	if !containsString(f.createContainerConfig.Env, "SPT_LOG_DIR="+dockerNodeLogMount) {
+		t.Fatalf("env = %v, want SPT_LOG_DIR", f.createContainerConfig.Env)
 	}
 }

--- a/cli/tui/headless/runner.go
+++ b/cli/tui/headless/runner.go
@@ -39,6 +39,7 @@ type HeadlessRunner struct {
 	scenarioPath  string
 	apiPort       string
 	networkMode   string
+	resultsRoot   string
 }
 
 // HeadlessOptions holds configuration for headless mode
@@ -53,6 +54,7 @@ type HeadlessOptions struct {
 	JSONMode    bool
 	MetricsOnly bool
 	DryRun      bool
+	ResultsRoot string
 	// KeepScenario removed - this belongs in scenario.Params
 	AutoTerminateSeconds int // 0 = unlimited
 	// In multi-host runs, let auto-results fetch artifacts and request shutdown
@@ -102,6 +104,7 @@ func NewHeadlessRunner(dockerManager tui.DockerInterface, options HeadlessOption
 		dryRun:        options.DryRun,
 		apiPort:       apiPort,
 		networkMode:   networkMode,
+		resultsRoot:   options.ResultsRoot,
 		// keepScenario will be set when RunWithScenario is called
 	}
 
@@ -463,7 +466,7 @@ func (r *HeadlessRunner) runBenchmarkWithContent(ctx context.Context, image stri
 
 func (r *HeadlessRunner) runBenchmark(ctx context.Context, scenarioPath string, startTest func(*tui.TestOrchestrator) error) error {
 	// Create the orchestrator for API-based control
-	r.orchestrator = tui.NewTestOrchestrator(r.dockerManager, r.apiPort)
+	r.orchestrator = tui.NewTestOrchestrator(r.dockerManager, r.apiPort, r.resultsRoot)
 	r.orchestrator.SetNetworkMode(r.networkMode)
 
 	// Set up callbacks to handle orchestrator events

--- a/cli/tui/json_metrics_test.go
+++ b/cli/tui/json_metrics_test.go
@@ -443,7 +443,7 @@ func TestOrchestratorJSONMetricsRetrieval(t *testing.T) {
 			defer server.Close()
 
 			// Create orchestrator with test API client
-			orchestrator := NewTestOrchestrator(nil, constants.SptAPIPort)
+			orchestrator := NewTestOrchestrator(nil, constants.SptAPIPort, "")
 			orchestrator.apiClient = NewSptAPIClient(server.URL)
 
 			// Call the optimized metrics method

--- a/cli/tui/model.go
+++ b/cli/tui/model.go
@@ -953,20 +953,20 @@ func StartTUIWithScenarioAndParams(image string, scenarioPath string, params sce
 
 // StartTUIWithScenarioAndParamsWithTrace starts the TUI with optional full-output trace capture.
 func StartTUIWithScenarioAndParamsWithTrace(image string, scenarioPath string, params scenario.ScenarioParams, apiPort string, setSummarySink func(func(string)), tracePath string, traceAppend bool) error {
-	return StartTUIWithScenarioAndParamsNetworkModeWithTrace(image, scenarioPath, params, apiPort, constants.DefaultNetworkMode, setSummarySink, tracePath, traceAppend)
+	return StartTUIWithScenarioAndParamsNetworkModeWithTrace(image, scenarioPath, params, apiPort, constants.DefaultNetworkMode, "", setSummarySink, tracePath, traceAppend)
 }
 
 // StartTUIWithScenarioAndParamsNetworkModeWithTrace starts the TUI with a selected Docker network mode.
-func StartTUIWithScenarioAndParamsNetworkModeWithTrace(image string, scenarioPath string, params scenario.ScenarioParams, apiPort string, networkMode string, setSummarySink func(func(string)), tracePath string, traceAppend bool) error {
-	return startTUIWithScenarioAndParamsWithNetworkModeTrace(image, scenarioPath, params, apiPort, networkMode, setSummarySink, tracePath, traceAppend, nil, nil)
+func StartTUIWithScenarioAndParamsNetworkModeWithTrace(image string, scenarioPath string, params scenario.ScenarioParams, apiPort string, networkMode string, resultsRoot string, setSummarySink func(func(string)), tracePath string, traceAppend bool) error {
+	return startTUIWithScenarioAndParamsWithNetworkModeTrace(image, scenarioPath, params, apiPort, networkMode, resultsRoot, setSummarySink, tracePath, traceAppend, nil, nil)
 }
 
 // StartTUIWithScenarioContentAndParamsWithTrace starts the TUI with caller-provided scenario/defaults content.
-func StartTUIWithScenarioContentAndParamsWithTrace(image string, scenarioPath string, params scenario.ScenarioParams, apiPort string, networkMode string, setSummarySink func(func(string)), tracePath string, traceAppend bool, scenarioContent, defaultsContent []byte) error {
-	return startTUIWithScenarioAndParamsWithNetworkModeTrace(image, scenarioPath, params, apiPort, networkMode, setSummarySink, tracePath, traceAppend, scenarioContent, defaultsContent)
+func StartTUIWithScenarioContentAndParamsWithTrace(image string, scenarioPath string, params scenario.ScenarioParams, apiPort string, networkMode string, resultsRoot string, setSummarySink func(func(string)), tracePath string, traceAppend bool, scenarioContent, defaultsContent []byte) error {
+	return startTUIWithScenarioAndParamsWithNetworkModeTrace(image, scenarioPath, params, apiPort, networkMode, resultsRoot, setSummarySink, tracePath, traceAppend, scenarioContent, defaultsContent)
 }
 
-func startTUIWithScenarioAndParamsWithNetworkModeTrace(image string, scenarioPath string, params scenario.ScenarioParams, apiPort string, networkMode string, setSummarySink func(func(string)), tracePath string, traceAppend bool, scenarioContent, defaultsContent []byte) error {
+func startTUIWithScenarioAndParamsWithNetworkModeTrace(image string, scenarioPath string, params scenario.ScenarioParams, apiPort string, networkMode string, resultsRoot string, setSummarySink func(func(string)), tracePath string, traceAppend bool, scenarioContent, defaultsContent []byte) error {
 	model := InitialModel()
 	if params.MinimalTUI {
 		model.processOutputHidden = true
@@ -988,7 +988,7 @@ func startTUIWithScenarioAndParamsWithNetworkModeTrace(image string, scenarioPat
 	defer dm.Close()
 
 	// Create the orchestrator for API-based control
-	orchestrator := NewTestOrchestrator(dm, apiPort)
+	orchestrator := NewTestOrchestrator(dm, apiPort, resultsRoot)
 	orchestrator.SetNetworkMode(networkMode)
 	model.orchestrator = orchestrator
 
@@ -1258,26 +1258,26 @@ func StartTUIWithScenarioAndParamsTimeout(image string, scenarioPath string, par
 
 // StartTUIWithScenarioAndParamsTimeoutWithTrace starts the TUI (single host), exits after timeout, and can capture full output.
 func StartTUIWithScenarioAndParamsTimeoutWithTrace(image string, scenarioPath string, params scenario.ScenarioParams, apiPort string, autoTerminateSeconds int, setSummarySink func(func(string)), tracePath string, traceAppend bool) error {
-	return StartTUIWithScenarioAndParamsNetworkModeTimeoutWithTrace(image, scenarioPath, params, apiPort, constants.DefaultNetworkMode, autoTerminateSeconds, setSummarySink, tracePath, traceAppend)
+	return StartTUIWithScenarioAndParamsNetworkModeTimeoutWithTrace(image, scenarioPath, params, apiPort, constants.DefaultNetworkMode, "", autoTerminateSeconds, setSummarySink, tracePath, traceAppend)
 }
 
 // StartTUIWithScenarioAndParamsNetworkModeTimeoutWithTrace starts the TUI with a selected Docker network mode and optional timeout.
-func StartTUIWithScenarioAndParamsNetworkModeTimeoutWithTrace(image string, scenarioPath string, params scenario.ScenarioParams, apiPort string, networkMode string, autoTerminateSeconds int, setSummarySink func(func(string)), tracePath string, traceAppend bool) error {
+func StartTUIWithScenarioAndParamsNetworkModeTimeoutWithTrace(image string, scenarioPath string, params scenario.ScenarioParams, apiPort string, networkMode string, resultsRoot string, autoTerminateSeconds int, setSummarySink func(func(string)), tracePath string, traceAppend bool) error {
 	if autoTerminateSeconds <= 0 {
-		return StartTUIWithScenarioAndParamsNetworkModeWithTrace(image, scenarioPath, params, apiPort, networkMode, setSummarySink, tracePath, traceAppend)
+		return StartTUIWithScenarioAndParamsNetworkModeWithTrace(image, scenarioPath, params, apiPort, networkMode, resultsRoot, setSummarySink, tracePath, traceAppend)
 	}
-	return startTUIWithScenarioAndParamsNetworkModeTimeoutTrace(image, scenarioPath, params, apiPort, networkMode, autoTerminateSeconds, setSummarySink, tracePath, traceAppend, nil, nil)
+	return startTUIWithScenarioAndParamsNetworkModeTimeoutTrace(image, scenarioPath, params, apiPort, networkMode, resultsRoot, autoTerminateSeconds, setSummarySink, tracePath, traceAppend, nil, nil)
 }
 
 // StartTUIWithScenarioContentAndParamsTimeoutWithTrace starts the TUI with caller-provided content and optional timeout.
-func StartTUIWithScenarioContentAndParamsTimeoutWithTrace(image string, scenarioPath string, params scenario.ScenarioParams, apiPort string, networkMode string, autoTerminateSeconds int, setSummarySink func(func(string)), tracePath string, traceAppend bool, scenarioContent, defaultsContent []byte) error {
+func StartTUIWithScenarioContentAndParamsTimeoutWithTrace(image string, scenarioPath string, params scenario.ScenarioParams, apiPort string, networkMode string, resultsRoot string, autoTerminateSeconds int, setSummarySink func(func(string)), tracePath string, traceAppend bool, scenarioContent, defaultsContent []byte) error {
 	if autoTerminateSeconds <= 0 {
-		return StartTUIWithScenarioContentAndParamsWithTrace(image, scenarioPath, params, apiPort, networkMode, setSummarySink, tracePath, traceAppend, scenarioContent, defaultsContent)
+		return StartTUIWithScenarioContentAndParamsWithTrace(image, scenarioPath, params, apiPort, networkMode, resultsRoot, setSummarySink, tracePath, traceAppend, scenarioContent, defaultsContent)
 	}
-	return startTUIWithScenarioAndParamsNetworkModeTimeoutTrace(image, scenarioPath, params, apiPort, networkMode, autoTerminateSeconds, setSummarySink, tracePath, traceAppend, scenarioContent, defaultsContent)
+	return startTUIWithScenarioAndParamsNetworkModeTimeoutTrace(image, scenarioPath, params, apiPort, networkMode, resultsRoot, autoTerminateSeconds, setSummarySink, tracePath, traceAppend, scenarioContent, defaultsContent)
 }
 
-func startTUIWithScenarioAndParamsNetworkModeTimeoutTrace(image string, scenarioPath string, params scenario.ScenarioParams, apiPort string, networkMode string, autoTerminateSeconds int, setSummarySink func(func(string)), tracePath string, traceAppend bool, scenarioContent, defaultsContent []byte) error {
+func startTUIWithScenarioAndParamsNetworkModeTimeoutTrace(image string, scenarioPath string, params scenario.ScenarioParams, apiPort string, networkMode string, resultsRoot string, autoTerminateSeconds int, setSummarySink func(func(string)), tracePath string, traceAppend bool, scenarioContent, defaultsContent []byte) error {
 	model := InitialModel()
 	if params.MinimalTUI {
 		model.processOutputHidden = true
@@ -1295,7 +1295,7 @@ func startTUIWithScenarioAndParamsNetworkModeTimeoutTrace(image string, scenario
 	}
 	defer dm.Close()
 
-	orchestrator := NewTestOrchestrator(dm, apiPort)
+	orchestrator := NewTestOrchestrator(dm, apiPort, resultsRoot)
 	orchestrator.SetNetworkMode(networkMode)
 	model.orchestrator = orchestrator
 	model.dockerManager = dm

--- a/cli/tui/orchestrator.go
+++ b/cli/tui/orchestrator.go
@@ -69,6 +69,10 @@ type fileMountConfigurer interface {
 	SetFileMounts([]scenario.FileMount) error
 }
 
+type nodeLogResultsRootConfigurer interface {
+	setNodeLogResultsRoot(string)
+}
+
 func configureDockerFileMounts(dm DockerInterface, mounts []scenario.FileMount) error {
 	if len(mounts) == 0 {
 		return nil
@@ -81,9 +85,12 @@ func configureDockerFileMounts(dm DockerInterface, mounts []scenario.FileMount) 
 }
 
 // NewTestOrchestrator creates a new test orchestrator
-func NewTestOrchestrator(dm DockerInterface, apiPort string) *TestOrchestrator {
+func NewTestOrchestrator(dm DockerInterface, apiPort string, nodeLogResultsRoot string) *TestOrchestrator {
 	if apiPort == "" {
 		apiPort = constants.SptAPIPort
+	}
+	if configurer, ok := dm.(nodeLogResultsRootConfigurer); ok {
+		configurer.setNodeLogResultsRoot(nodeLogResultsRoot)
 	}
 	return &TestOrchestrator{
 		dockerManager:         dm,

--- a/cli/tui/orchestrator_test.go
+++ b/cli/tui/orchestrator_test.go
@@ -21,6 +21,18 @@ import (
 	"github.com/dell/storage-performance-tool/cli/internal/scenario"
 )
 
+func TestNewTestOrchestratorConfiguresNodeLogResultsRoot(t *testing.T) {
+	resultsRoot := t.TempDir()
+	dm := &DockerManager{}
+	_ = NewTestOrchestrator(dm, constants.SptAPIPort, resultsRoot)
+	if dm.nodeLogResultsRoot != resultsRoot {
+		t.Fatalf("nodeLogResultsRoot = %q, want %q", dm.nodeLogResultsRoot, resultsRoot)
+	}
+	if dm.preserveNodeLogDir {
+		t.Fatal("preserveNodeLogDir should remain false until capture is prepared")
+	}
+}
+
 // TestOrchestratorStartTest tests the complete test start flow
 func TestOrchestratorStartTest(t *testing.T) {
 	// Create a mock API server
@@ -92,7 +104,7 @@ func TestOrchestratorStartTest(t *testing.T) {
 	mockDM := NewMockDockerManager()
 
 	// Create orchestrator
-	orchestrator := NewTestOrchestrator(mockDM, constants.SptAPIPort)
+	orchestrator := NewTestOrchestrator(mockDM, constants.SptAPIPort, "")
 
 	// Track callbacks
 	var statusUpdates []*TestStatus
@@ -291,7 +303,7 @@ func TestOrchestratorStartTestWithContentPostsProvidedArtifacts(t *testing.T) {
 	defer server.Close()
 
 	mockDM := NewMockDockerManager()
-	orchestrator := NewTestOrchestrator(mockDM, constants.SptAPIPort)
+	orchestrator := NewTestOrchestrator(mockDM, constants.SptAPIPort, "")
 	orchestrator.apiClient = NewSptAPIClient(server.URL)
 	defer orchestrator.StopTest()
 
@@ -353,7 +365,7 @@ func TestOrchestratorStartTestConfiguresItemFileMounts(t *testing.T) {
 	defer server.Close()
 
 	mockDM := NewMockDockerManager()
-	orchestrator := NewTestOrchestrator(mockDM, constants.SptAPIPort)
+	orchestrator := NewTestOrchestrator(mockDM, constants.SptAPIPort, "")
 	orchestrator.apiClient = NewSptAPIClient(server.URL)
 	mounts := []scenario.FileMount{{HostPath: "/host/items.csv", ContainerPath: "/spt-input/items/read-items.csv"}}
 	params := scenario.ScenarioParams{WorkloadType: scenario.WorkloadTypeRead, ItemFileMounts: mounts}
@@ -422,7 +434,7 @@ func TestOrchestratorStartTestUsesConfiguredNetworkMode(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			mockDM := NewMockDockerManager()
-			orchestrator := NewTestOrchestrator(mockDM, constants.SptAPIPort)
+			orchestrator := NewTestOrchestrator(mockDM, constants.SptAPIPort, "")
 			orchestrator.apiClient = NewSptAPIClient(server.URL)
 			if tt.configureMode != nil {
 				tt.configureMode(orchestrator)
@@ -454,7 +466,7 @@ func TestOrchestratorContainerStartFailure(t *testing.T) {
 	mockDM := NewMockDockerManager()
 	mockDM.SetFailOnStart(true)
 
-	orchestrator := NewTestOrchestrator(mockDM, constants.SptAPIPort)
+	orchestrator := NewTestOrchestrator(mockDM, constants.SptAPIPort, "")
 
 	params := scenario.ScenarioParams{
 		WorkloadType: "mock",
@@ -482,7 +494,7 @@ func TestOrchestratorAPIReadyTimeout(t *testing.T) {
 	defer server.Close()
 
 	mockDM := NewMockDockerManager()
-	orchestrator := NewTestOrchestrator(mockDM, constants.SptAPIPort)
+	orchestrator := NewTestOrchestrator(mockDM, constants.SptAPIPort, "")
 
 	// Set up the orchestrator with test server BEFORE trying to connect
 	orchestrator.containerID = "test-container"
@@ -534,7 +546,7 @@ func TestOrchestratorStopTest(t *testing.T) {
 	defer server.Close()
 
 	mockDM := NewMockDockerManager()
-	orchestrator := NewTestOrchestrator(mockDM, constants.SptAPIPort)
+	orchestrator := NewTestOrchestrator(mockDM, constants.SptAPIPort, "")
 
 	// Set up callbacks
 	var outputLines []string
@@ -585,7 +597,7 @@ func TestOrchestratorStopTest(t *testing.T) {
 // TestOrchestratorScenarioFilePersistence tests scenario file handling
 func TestOrchestratorScenarioFilePersistence(t *testing.T) {
 	mockDM := NewMockDockerManager()
-	orchestrator := NewTestOrchestrator(mockDM, constants.SptAPIPort)
+	orchestrator := NewTestOrchestrator(mockDM, constants.SptAPIPort, "")
 
 	// Test with KeepScenario = true
 	params := scenario.ScenarioParams{
@@ -656,7 +668,7 @@ func TestOrchestratorCallbacks(t *testing.T) {
 	defer server.Close()
 
 	mockDM := NewMockDockerManager()
-	orchestrator := NewTestOrchestrator(mockDM, constants.SptAPIPort)
+	orchestrator := NewTestOrchestrator(mockDM, constants.SptAPIPort, "")
 
 	// Track all callbacks
 	var statusCount, metricsCount, outputCount, errorCount int
@@ -714,7 +726,7 @@ func TestOrchestratorCallbacks(t *testing.T) {
 // TestOrchestratorConcurrentOperations tests concurrent goroutine safety
 func TestOrchestratorConcurrentOperations(t *testing.T) {
 	mockDM := NewMockDockerManager()
-	orchestrator := NewTestOrchestrator(mockDM, constants.SptAPIPort)
+	orchestrator := NewTestOrchestrator(mockDM, constants.SptAPIPort, "")
 
 	// Set up a simple test server
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -801,7 +813,7 @@ func TestOrchestratorMetricsParsing(t *testing.T) {
 	}))
 	defer server.Close()
 
-	orchestrator := NewTestOrchestrator(nil, constants.SptAPIPort)
+	orchestrator := NewTestOrchestrator(nil, constants.SptAPIPort, "")
 	orchestrator.apiClient = NewSptAPIClient(server.URL)
 
 	// Track metrics received
@@ -852,7 +864,7 @@ func TestOrchestratorMetricsCompatibilityWarning(t *testing.T) {
 	}))
 	defer server.Close()
 
-	orchestrator := NewTestOrchestrator(nil, constants.SptAPIPort)
+	orchestrator := NewTestOrchestrator(nil, constants.SptAPIPort, "")
 	orchestrator.apiClient = NewSptAPIClient(server.URL)
 
 	var outputs []string
@@ -899,7 +911,7 @@ func TestOrchestratorFetchesVerbosePayloadOnParseError(t *testing.T) {
 	}))
 	defer server.Close()
 
-	orchestrator := NewTestOrchestrator(nil, constants.SptAPIPort)
+	orchestrator := NewTestOrchestrator(nil, constants.SptAPIPort, "")
 	orchestrator.apiClient = NewSptAPIClient(server.URL)
 
 	metric, source, err := orchestrator.tryJSONMetrics()
@@ -933,7 +945,7 @@ func TestOrchestratorIdleNodeMarkedInactive(t *testing.T) {
 	}))
 	defer server.Close()
 
-	orchestrator := NewTestOrchestrator(nil, constants.SptAPIPort)
+	orchestrator := NewTestOrchestrator(nil, constants.SptAPIPort, "")
 	orchestrator.apiClient = NewSptAPIClient(server.URL)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -992,7 +1004,7 @@ func TestOrchestratorTestCompletion(t *testing.T) {
 			}))
 			defer server.Close()
 
-			orchestrator := NewTestOrchestrator(nil, constants.SptAPIPort)
+			orchestrator := NewTestOrchestrator(nil, constants.SptAPIPort, "")
 			orchestrator.apiClient = NewSptAPIClient(server.URL)
 
 			// Track output
@@ -1030,7 +1042,7 @@ func TestOrchestratorTestCompletion(t *testing.T) {
 // TestOrchestratorCleanupOnError tests cleanup when operations fail
 func TestOrchestratorCleanupOnError(t *testing.T) {
 	mockDM := NewMockDockerManager()
-	orchestrator := NewTestOrchestrator(mockDM, constants.SptAPIPort)
+	orchestrator := NewTestOrchestrator(mockDM, constants.SptAPIPort, "")
 
 	// Create a scenario file to test cleanup
 	tmpFile, err := os.CreateTemp("", "test-scenario-*.js")


### PR DESCRIPTION
## Summary
- use a writable results-backed `.node-home` bind mount for single-host local runs so the containerized engine can write logs and `items.csv`
- resolve results-root-backed bind sources to absolute host paths and preserve the raw engine log tree alongside fetched auto-results artifacts
- add regression coverage for DockerManager/orchestrator wiring and harden env-default tests so ambient env or working directory state does not make the CLI suite flaky