### PR TITLE
Force static Linux CLI release builds

### DIFF
--- a/.github/workflows/release-artifacts.yaml
+++ b/.github/workflows/release-artifacts.yaml
@@ -172,6 +172,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    env:
+      CGO_ENABLED: "0"
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -190,6 +192,15 @@ jobs:
 
       - name: Verify Linux ARM64 binary
         run: test -s cli/build/spt-linux-arm64
+
+      - name: Verify Linux binaries are static
+        run: |
+          set -euo pipefail
+          file cli/build/spt-linux-amd64 | tee /tmp/spt-linux-amd64.file
+          file cli/build/spt-linux-arm64 | tee /tmp/spt-linux-arm64.file
+          grep -q 'statically linked' /tmp/spt-linux-amd64.file
+          grep -q 'statically linked' /tmp/spt-linux-arm64.file
+          ldd cli/build/spt-linux-amd64 2>&1 | grep -q 'not a dynamic executable'
 
       - name: Package binaries
         run: |


### PR DESCRIPTION
## Summary
- force `CGO_ENABLED=0` for the release workflow's CLI binary job so published Linux binaries do not pick up host glibc requirements
- add a release-workflow verification step that asserts the Linux amd64 and arm64 CLI artifacts are statically linked before packaging

## Why
- the published Linux release binaries were dynamically linked against newer glibc symbols (for example `GLIBC_2.32` and `GLIBC_2.34`), which breaks startup on older supported environments such as RHEL 8
- PR artifact builds already force `CGO_ENABLED=0`; this makes the release workflow consistent with that safer behavior

#### Test plan
- [x] reviewed the published `v5.11.1` and `v5.11.2` Linux amd64 release assets and confirmed they are dynamically linked and require newer glibc symbols
- [x] `CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "-s -w" -o /tmp/.../spt-linux-amd64 .` followed by `file` and `ldd` verification (`statically linked`, `not a dynamic executable`)
- [x] `CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -ldflags "-s -w" -o /tmp/.../spt-linux-arm64 .` followed by `file` verification (`statically linked`)