### PR TITLE
Remote diagnostics collection, engine overrides, and lifecycle correctness fixes

### DIFF
--- a/cli/cmd/envdefaults.go
+++ b/cli/cmd/envdefaults.go
@@ -124,6 +124,17 @@ func applyEnvDefaultsToRunFlags(cmd *cobra.Command) error {
 		}
 	}
 
+	// Advanced engine config overrides. Multiple env values are separated by semicolons or newlines.
+	if f := cmd.Flags().Lookup(flagEngineOverride); f != nil && !cmd.Flags().Changed(flagEngineOverride) {
+		if v := strings.TrimSpace(os.Getenv(constants.EnvEngineOverrides)); v != "" {
+			for _, override := range splitEngineOverridesEnv(v) {
+				if err := cmd.Flags().Set(flagEngineOverride, override); err != nil {
+					return err
+				}
+			}
+		}
+	}
+
 	// RDMA string settings
 	_ = setIf("rdma-local-ip", constants.EnvRdmaLocalIP)
 	_ = setIf("rdma-device", constants.EnvRdmaDevice)
@@ -182,6 +193,20 @@ func applyEnvDefaultsToRunFlags(cmd *cobra.Command) error {
 	}
 
 	return nil
+}
+
+func splitEngineOverridesEnv(value string) []string {
+	fields := strings.FieldsFunc(value, func(r rune) bool {
+		return r == ';' || r == '\n' || r == '\r'
+	})
+	overrides := make([]string, 0, len(fields))
+	for _, field := range fields {
+		field = strings.TrimSpace(field)
+		if field != "" {
+			overrides = append(overrides, field)
+		}
+	}
+	return overrides
 }
 
 // applyEnvDefaultsToVerifyFlags injects HOSTS env into verify flags when not provided.

--- a/cli/cmd/envdefaults.go
+++ b/cli/cmd/envdefaults.go
@@ -11,6 +11,23 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// envAppliedAnnotationPrefix marks cmd.Annotations entries recording which
+// flags applyEnvDefaultsToRunFlags set from .env/OS env rather than an
+// explicit CLI argument. pflag's FlagSet.Set() marks a flag Changed=true
+// regardless of who called it, so without this, spt_run_params.json's
+// captured "changed flags" can't distinguish what the user actually typed
+// from what env defaults silently injected (see captureChangedFlags).
+const envAppliedAnnotationPrefix = "envApplied."
+
+// markEnvApplied records that flag's value came from an env default, not an
+// explicit CLI argument.
+func markEnvApplied(cmd *cobra.Command, flag, value string) {
+	if cmd.Annotations == nil {
+		cmd.Annotations = map[string]string{}
+	}
+	cmd.Annotations[envAppliedAnnotationPrefix+flag] = value
+}
+
 // applyEnvDefaultsToRunFlags injects environment-provided defaults into run flags
 // when the user did not explicitly set them. This allows .env/OS env to satisfy
 // required S3 settings and optional multi-host inputs.
@@ -21,13 +38,23 @@ import (
 //	S3_ACCESS_KEY, S3_SECRET_KEY, S3_BUCKET
 //	HOSTS (equivalent to --test-hosts)
 func applyEnvDefaultsToRunFlags(cmd *cobra.Command) error {
+	// setFromEnv sets a flag's value and records that it came from env, not
+	// an explicit CLI argument (see markEnvApplied).
+	setFromEnv := func(flag, value string) error {
+		if err := cmd.Flags().Set(flag, value); err != nil {
+			return err
+		}
+		markEnvApplied(cmd, flag, value)
+		return nil
+	}
+
 	// Helper to set simple string flags if not changed
 	setIf := func(flag, envKey string) error {
 		if cmd.Flags().Lookup(flag) == nil || cmd.Flags().Changed(flag) {
 			return nil
 		}
 		if v := strings.TrimSpace(os.Getenv(envKey)); v != "" {
-			return cmd.Flags().Set(flag, v)
+			return setFromEnv(flag, v)
 		}
 		return nil
 	}
@@ -37,11 +64,11 @@ func applyEnvDefaultsToRunFlags(cmd *cobra.Command) error {
 		if !cmd.Flags().Changed("endpoint") {
 			if v := strings.TrimSpace(os.Getenv("S3_ENDPOINTS")); v != "" {
 				// Cobra accepts CSV for StringSlice Set
-				if err := cmd.Flags().Set("endpoints", v); err != nil {
+				if err := setFromEnv("endpoints", v); err != nil {
 					return err
 				}
 			} else if v := strings.TrimSpace(os.Getenv("S3_ENDPOINT")); v != "" {
-				if err := cmd.Flags().Set("endpoints", v); err != nil {
+				if err := setFromEnv("endpoints", v); err != nil {
 					return err
 				}
 			}
@@ -58,7 +85,7 @@ func applyEnvDefaultsToRunFlags(cmd *cobra.Command) error {
 			if _, err := strconv.Atoi(v); err != nil {
 				return fmt.Errorf("invalid S3_AUTH_VERSION value %q: %w", v, err)
 			}
-			if err := cmd.Flags().Set("auth-version", v); err != nil {
+			if err := setFromEnv("auth-version", v); err != nil {
 				return err
 			}
 		}
@@ -71,7 +98,7 @@ func applyEnvDefaultsToRunFlags(cmd *cobra.Command) error {
 	if f := cmd.Flags().Lookup(flagSkipImagePull); f != nil && !cmd.Flags().Changed(flagSkipImagePull) {
 		if v := strings.TrimSpace(os.Getenv(constants.EnvSkipImagePull)); v != "" {
 			if b, err := strconv.ParseBool(v); err == nil {
-				if err := cmd.Flags().Set(flagSkipImagePull, strconv.FormatBool(b)); err != nil {
+				if err := setFromEnv(flagSkipImagePull, strconv.FormatBool(b)); err != nil {
 					return err
 				}
 			}
@@ -84,7 +111,7 @@ func applyEnvDefaultsToRunFlags(cmd *cobra.Command) error {
 			if _, err := strconv.Atoi(v); err != nil {
 				return fmt.Errorf("invalid THREADS value %q: %w", v, err)
 			}
-			if err := cmd.Flags().Set("threads", v); err != nil {
+			if err := setFromEnv("threads", v); err != nil {
 				return err
 			}
 		}
@@ -94,7 +121,7 @@ func applyEnvDefaultsToRunFlags(cmd *cobra.Command) error {
 	if f := cmd.Flags().Lookup("use-rdma"); f != nil && !cmd.Flags().Changed("use-rdma") {
 		if v := strings.TrimSpace(os.Getenv(constants.EnvRdmaEnabled)); v != "" {
 			if b, err := strconv.ParseBool(v); err == nil {
-				_ = cmd.Flags().Set("use-rdma", strconv.FormatBool(b))
+				_ = setFromEnv("use-rdma", strconv.FormatBool(b))
 			}
 		}
 	}
@@ -108,7 +135,7 @@ func applyEnvDefaultsToRunFlags(cmd *cobra.Command) error {
 			if _, err := sizeparse.Parse(v); err != nil {
 				return fmt.Errorf("invalid %s value %q: %w", constants.EnvPartSize, v, err)
 			}
-			_ = cmd.Flags().Set("part-size", v)
+			_ = setFromEnv("part-size", v)
 		}
 	}
 
@@ -118,7 +145,7 @@ func applyEnvDefaultsToRunFlags(cmd *cobra.Command) error {
 			if _, err := strconv.Atoi(v); err != nil {
 				return fmt.Errorf("invalid %s value %q: %w", constants.EnvServiceThreads, v, err)
 			}
-			if err := cmd.Flags().Set("service-threads", v); err != nil {
+			if err := setFromEnv("service-threads", v); err != nil {
 				return err
 			}
 		}
@@ -127,10 +154,14 @@ func applyEnvDefaultsToRunFlags(cmd *cobra.Command) error {
 	// Advanced engine config overrides. Multiple env values are separated by semicolons or newlines.
 	if f := cmd.Flags().Lookup(flagEngineOverride); f != nil && !cmd.Flags().Changed(flagEngineOverride) {
 		if v := strings.TrimSpace(os.Getenv(constants.EnvEngineOverrides)); v != "" {
-			for _, override := range splitEngineOverridesEnv(v) {
+			overrides := splitEngineOverridesEnv(v)
+			for _, override := range overrides {
 				if err := cmd.Flags().Set(flagEngineOverride, override); err != nil {
 					return err
 				}
+			}
+			if len(overrides) > 0 {
+				markEnvApplied(cmd, flagEngineOverride, strings.Join(overrides, "; "))
 			}
 		}
 	}
@@ -146,7 +177,7 @@ func applyEnvDefaultsToRunFlags(cmd *cobra.Command) error {
 			if _, err := sizeparse.Parse(v); err != nil {
 				return fmt.Errorf("invalid %s value %q: %w", constants.EnvRdmaThreshold, v, err)
 			}
-			_ = cmd.Flags().Set("rdma-threshold", v)
+			_ = setFromEnv("rdma-threshold", v)
 		}
 	}
 	// RDMA timeout (milliseconds, integer only)
@@ -155,7 +186,7 @@ func applyEnvDefaultsToRunFlags(cmd *cobra.Command) error {
 			if _, err := strconv.ParseInt(v, 10, 64); err != nil {
 				return fmt.Errorf("invalid %s value %q: %w", constants.EnvRdmaTimeout, v, err)
 			}
-			_ = cmd.Flags().Set("rdma-timeout-ms", v)
+			_ = setFromEnv("rdma-timeout-ms", v)
 		}
 	}
 
@@ -163,7 +194,7 @@ func applyEnvDefaultsToRunFlags(cmd *cobra.Command) error {
 	if f := cmd.Flags().Lookup("rdma-fallback"); f != nil && !cmd.Flags().Changed("rdma-fallback") {
 		if v := strings.TrimSpace(os.Getenv(constants.EnvRdmaFallback)); v != "" {
 			if b, err := strconv.ParseBool(v); err == nil {
-				_ = cmd.Flags().Set("rdma-fallback", strconv.FormatBool(b))
+				_ = setFromEnv("rdma-fallback", strconv.FormatBool(b))
 			}
 		}
 	}
@@ -177,7 +208,7 @@ func applyEnvDefaultsToRunFlags(cmd *cobra.Command) error {
 			if _, err := strconv.ParseFloat(v, 64); err != nil {
 				return fmt.Errorf("invalid %s value %q: %w", constants.EnvObjectDataCompressibility, v, err)
 			}
-			if err := cmd.Flags().Set("object-data-compressibility", v); err != nil {
+			if err := setFromEnv("object-data-compressibility", v); err != nil {
 				return err
 			}
 		}
@@ -185,7 +216,7 @@ func applyEnvDefaultsToRunFlags(cmd *cobra.Command) error {
 	if f := cmd.Flags().Lookup("object-data-dedupable"); f != nil && !cmd.Flags().Changed("object-data-dedupable") {
 		if v := strings.TrimSpace(os.Getenv(constants.EnvObjectDataDedupable)); v != "" {
 			if b, err := strconv.ParseBool(v); err == nil {
-				if err := cmd.Flags().Set("object-data-dedupable", strconv.FormatBool(b)); err != nil {
+				if err := setFromEnv("object-data-dedupable", strconv.FormatBool(b)); err != nil {
 					return err
 				}
 			}

--- a/cli/cmd/envdefaults_test.go
+++ b/cli/cmd/envdefaults_test.go
@@ -28,6 +28,7 @@ func newRunLikeCmd() *cobra.Command {
 	c.Flags().String("rdma-log-level", "WARN", "")
 	c.Flags().Int64("rdma-timeout-ms", 30000, "")
 	c.Flags().Int("service-threads", 0, "")
+	c.Flags().StringArray(flagEngineOverride, []string{}, "")
 	c.Flags().String("s3-driver", "default", "")
 	c.Flags().String("part-size", "", "")
 	c.Flags().Int("auth-version", 4, "")
@@ -61,6 +62,7 @@ func clearEnvDefaultsTestEnv(t *testing.T) {
 		constants.EnvRdmaTimeout,
 		constants.EnvRdmaFallback,
 		constants.EnvServiceThreads,
+		constants.EnvEngineOverrides,
 		constants.EnvPartSize,
 		constants.EnvS3Driver,
 	} {
@@ -439,6 +441,47 @@ func TestApplyEnvDefaultsToRunFlags_ServiceThreadsInvalidEnv(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), constants.EnvServiceThreads) {
 		t.Errorf("error should mention env var name, got: %v", err)
+	}
+}
+
+func TestApplyEnvDefaultsToRunFlags_EngineOverridesFromEnv(t *testing.T) {
+	cmd := newRunLikeCmd()
+	clearEnvDefaultsTestEnv(t)
+
+	t.Setenv(constants.EnvEngineOverrides, "storage.driver.threads=6; storage.net.http.max.chunk.size=1048576")
+	t.Cleanup(func() { os.Unsetenv(constants.EnvEngineOverrides) })
+
+	if err := applyEnvDefaultsToRunFlags(cmd); err != nil {
+		t.Fatalf("applyEnvDefaultsToRunFlags error: %v", err)
+	}
+
+	got, _ := cmd.Flags().GetStringArray(flagEngineOverride)
+	want := []string{"storage.driver.threads=6", "storage.net.http.max.chunk.size=1048576"}
+	if len(got) != len(want) {
+		t.Fatalf("engine overrides = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("engine overrides = %v, want %v", got, want)
+		}
+	}
+}
+
+func TestApplyEnvDefaultsToRunFlags_EngineOverrideFlagWinsOverEnv(t *testing.T) {
+	cmd := newRunLikeCmd()
+	clearEnvDefaultsTestEnv(t)
+
+	_ = cmd.Flags().Set(flagEngineOverride, "storage.driver.threads=8")
+	t.Setenv(constants.EnvEngineOverrides, "storage.driver.threads=6")
+	t.Cleanup(func() { os.Unsetenv(constants.EnvEngineOverrides) })
+
+	if err := applyEnvDefaultsToRunFlags(cmd); err != nil {
+		t.Fatalf("applyEnvDefaultsToRunFlags error: %v", err)
+	}
+
+	got, _ := cmd.Flags().GetStringArray(flagEngineOverride)
+	if len(got) != 1 || got[0] != "storage.driver.threads=8" {
+		t.Fatalf("engine override flag should win over env, got %v", got)
 	}
 }
 

--- a/cli/cmd/replay.go
+++ b/cli/cmd/replay.go
@@ -249,7 +249,11 @@ func runReplay(cmd *cobra.Command, _ []string) error {
 		if autoResultsDone != nil || !resultsOpts.AutoResults {
 			return
 		}
-		autoResultsDone = startAutoResults(metadata.BaseURL, resultsOpts.Label, resultsOpts.ResultsDir, replayStepIDs(generated), resultsOpts.Debug, hostInfos, apiPort, resultsOpts.ShutdownOnComplete, resultsOpts.ShutdownLingerSec, paths.Scenario, metadata, out, out, traceOpts.Path)
+		// Replay does not currently wire a pre-summary diagnostics/cleanup hook
+		// (see run.go's finalizeMultiHost for the run-command equivalent); its
+		// own StopAllContainers-based cleanup (below) still runs after
+		// waitForAutoResults, same as before.
+		autoResultsDone = startAutoResults(metadata.BaseURL, resultsOpts.Label, resultsOpts.ResultsDir, replayStepIDs(generated), resultsOpts.Debug, hostInfos, apiPort, resultsOpts.ShutdownOnComplete, resultsOpts.ShutdownLingerSec, paths.Scenario, metadata, out, out, traceOpts.Path, nil)
 	}
 	waitForAutoResults := func() bool {
 		if autoResultsDone == nil {

--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -972,7 +972,18 @@ Available workload types:
 			// Provide image to orchestrator for preflight image checks
 			orchestrator.SetImage(sptImage)
 			orchestrator.SetAttachExistingWorkers(attachExisting)
+			orchestrator.SetResultsRoot(plannedResultsRoot)
 			ctx := context.Background()
+			collectDiagnostics := func() {
+				if plannedResultsRoot == "" {
+					return
+				}
+				diagCtx, diagCancel := context.WithTimeout(context.Background(), constants.DiagnosticsCollectionTimeout)
+				defer diagCancel()
+				if err := orchestrator.CollectDiagnostics(diagCtx); err != nil {
+					logger.Warn("Diagnostics collection completed with warnings", "error", err.Error())
+				}
+			}
 
 			// Respect force cleanup for preflight conflicts
 			forceMode, _ := cmd.Flags().GetBool("force")
@@ -1007,7 +1018,11 @@ Available workload types:
 					finalizeTraceArtifact()
 					return normalizedErr
 				}
-				if !waitForAutoResults(delegateShutdownToAutoResults) && delegateShutdownToAutoResults {
+				autoResultsComplete := waitForAutoResults(delegateShutdownToAutoResults)
+				if autoResultsComplete && delegateShutdownToAutoResults {
+					collectDiagnostics()
+				}
+				if !autoResultsComplete && delegateShutdownToAutoResults {
 					logger.Warn("Timed out waiting for auto-results; forcing container cleanup")
 					cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 30*time.Second)
 					if stopErr := orchestrator.StopAllContainers(cleanupCtx); stopErr != nil {
@@ -1023,12 +1038,18 @@ Available workload types:
 			if autoTerminate > 0 {
 				fmt.Printf("Auto-terminate: will stop after %d seconds\n", autoTerminate)
 				err = tui.StartTUIWithMultiHostOrchestratorTimeoutWithTrace(orchestrator, sptImage, scenarioPath, params, autoTerminate, setSummarySink, traceOpts.Path, traceOpts.Append)
-				waitForAutoResults(false)
+				autoResultsComplete := waitForAutoResults(false)
+				if autoResultsComplete && resultsOpts.AutoResults && resultsOpts.ShutdownOnComplete {
+					collectDiagnostics()
+				}
 				finalizeTraceArtifact()
 				return err
 			}
 			err = tui.StartTUIWithMultiHostOrchestratorWithTrace(orchestrator, sptImage, scenarioPath, params, setSummarySink, traceOpts.Path, traceOpts.Append)
-			waitForAutoResults(false)
+			autoResultsComplete := waitForAutoResults(false)
+			if autoResultsComplete && resultsOpts.AutoResults && resultsOpts.ShutdownOnComplete {
+				collectDiagnostics()
+			}
 			finalizeTraceArtifact()
 			return err
 		}

--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -34,6 +34,7 @@ const (
 	flagAttachExistingWorkers = "attach-existing"
 	flagReadShuffle           = "shuffle"
 	flagReadShuffleBatchSize  = "shuffle-batch-size"
+	flagEngineOverride        = "engine-override"
 )
 
 // resolvePortConflictFunc is a test seam for port conflict resolution.
@@ -1137,6 +1138,7 @@ func init() {
 	runCmd.Flags().String("read-items-file", "", "Items file for mixed workload READ pool (skips seed phase; --cleanup not allowed)")
 	runCmd.Flags().String("delete-items-file", "", "Items file to pre-populate mixed workload DELETE queue (relaxes delete<=put constraint; --cleanup not allowed)")
 	runCmd.Flags().Int("service-threads", 0, "Engine virtual-thread carrier parallelism (0 = JVM default, env: SPT_SERVICE_THREADS)")
+	runCmd.Flags().StringArray(flagEngineOverride, []string{}, "Advanced engine defaults override as path=value; repeat for multiple overrides (for example: storage.driver.threads=6, env: SPT_ENGINE_OVERRIDES)")
 	runCmd.Flags().String("api-port", "", "Spt API port (defaults to 9999, legacy: 43234)")
 	runCmd.Flags().Bool(flagSkipImagePull, false, "Use the locally cached Docker image without pulling the latest tag (env: SPT_SKIP_IMAGE_PULL)")
 	runCmd.Flags().String(flagSptImage, "", "Override the engine image ref (default: matches the CLI version, e.g. ...:v5.10.3; dev builds use ...:spt_dev; env: SPT_IMAGE)")
@@ -1339,6 +1341,11 @@ func buildScenarioParams(workloadType string, cmd *cobra.Command) (scenario.Para
 
 	serviceThreads, _ := cmd.Flags().GetInt("service-threads")
 	params.ServiceThreads = serviceThreads
+
+	engineOverrides, _ := cmd.Flags().GetStringArray(flagEngineOverride)
+	if len(engineOverrides) > 0 {
+		params.EngineOverrides = engineOverrides
+	}
 
 	// S3 Tables parameters
 	if workloadType == WorkloadTypeTables {

--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -122,7 +122,9 @@ func deriveBaseURL(apiPort string, hosts []*hostparse.HostInfo) string {
 
 // startAutoResults kicks off background completion tracking and artifact fetching.
 // After successful fetch, optionally requests /shutdown across all hosts and waits for API linger.
-func startAutoResults(baseURL, label, resultsDir string, expectedStepIDs []string, debug bool, allHosts []*hostparse.HostInfo, apiPort string, shutdownOn bool, lingerSec int, scenarioPath string, metadata *runMetadata, progressOut io.Writer, summaryOut io.Writer, traceFile string) chan struct{} {
+// preSummaryHook, if non-nil, runs after shutdown completes but before the run
+// summary is generated — see its call site below for why that ordering matters.
+func startAutoResults(baseURL, label, resultsDir string, expectedStepIDs []string, debug bool, allHosts []*hostparse.HostInfo, apiPort string, shutdownOn bool, lingerSec int, scenarioPath string, metadata *runMetadata, progressOut io.Writer, summaryOut io.Writer, traceFile string, preSummaryHook func()) chan struct{} {
 	done := make(chan struct{}, 1)
 	go func() {
 		defer func() { done <- struct{}{} }()
@@ -174,7 +176,10 @@ func startAutoResults(baseURL, label, resultsDir string, expectedStepIDs []strin
 		seen := make(map[string]struct{})
 		fleetSeen := make(map[string]struct{})
 		stopCh := make(chan struct{})
+		var pollWG sync.WaitGroup
+		pollWG.Add(1)
 		go func() {
+			defer pollWG.Done()
 			ticker := time.NewTicker(500 * time.Millisecond)
 			defer ticker.Stop()
 			for {
@@ -228,6 +233,12 @@ func startAutoResults(baseURL, label, resultsDir string, expectedStepIDs []strin
 		}()
 		_, _ = tracker.WaitForCompletion(ctx, expectedStepIDs)
 		close(stopCh)
+		// Wait for the polling goroutine to actually observe stopCh and return
+		// before touching discoverStepIDsFunc/discoverFleetStepIDsFunc below —
+		// otherwise a still-in-flight tick could race a caller's test-time
+		// reassignment of those (package-level, test-injectable) function
+		// variables once this function's goroutine finishes.
+		pollWG.Wait()
 		// One final fleet discovery after completion (may not have been picked up during polling)
 		if fids, err := discoverFleetStepIDsFunc(baseURL); err == nil && len(fids) > 0 {
 			mu.Lock()
@@ -329,6 +340,16 @@ func startAutoResults(baseURL, label, resultsDir string, expectedStepIDs []strin
 				writeProgress("Shutdown completed with warnings; see logs for details.\n")
 			} else {
 				writeProgress("Shutdown completed successfully.\n")
+			}
+
+			// Diagnostics collection and full container/staging cleanup must
+			// happen before the summary below, not after: a consumer that
+			// treats the summary (or its results_summary.txt file) as "the
+			// run is done" should not be able to observe it before
+			// diagnostics/diagnostics_manifest.json and copied GC/JFR files
+			// exist.
+			if preSummaryHook != nil {
+				preSummaryHook()
 			}
 		}
 
@@ -909,10 +930,39 @@ Available workload types:
 			setSummarySink = summaryWriter.SetSink
 		}
 
+		// Construct the multi-host orchestrator now (before starting the
+		// auto-results background tracker below) so FinalizeDiagnosticsAndCleanup
+		// can run as startAutoResults' pre-summary hook. Construction itself is
+		// cheap (no I/O) — ConnectHosts and everything else that actually talks
+		// to the hosts still happens later, in its original place.
+		var multiHostOrchestrator *tui.MultiHostOrchestrator
+		if len(hostInfos) > 1 {
+			rmiConfig := tui.RMIConfig{
+				NetworkMode: networkMode,
+				PortStart:   rmiPortStart,
+				PortCount:   rmiPortCount,
+			}
+			multiHostOrchestrator = tui.NewMultiHostOrchestratorWithRMI(hostInfos, minHosts, rmiConfig)
+			// Provide image to orchestrator for preflight image checks
+			multiHostOrchestrator.SetImage(sptImage)
+			multiHostOrchestrator.SetAttachExistingWorkers(attachExisting)
+			multiHostOrchestrator.SetResultsRoot(plannedResultsRoot)
+		}
+		finalizeMultiHost := func() {
+			if multiHostOrchestrator == nil || plannedResultsRoot == "" {
+				return
+			}
+			diagCtx, diagCancel := context.WithTimeout(context.Background(), constants.DiagnosticsCollectionTimeout)
+			defer diagCancel()
+			if err := multiHostOrchestrator.FinalizeDiagnosticsAndCleanup(diagCtx); err != nil {
+				logger.Warn("Diagnostics collection/cleanup completed with warnings", "error", err.Error())
+			}
+		}
+
 		// Start background auto-results tracker/fetcher if enabled
 		var autoResultsDone chan struct{}
 		if resultsOpts.AutoResults {
-			autoResultsDone = startAutoResults(baseURL, resultsOpts.Label, resultsOpts.ResultsDir, expectedStepIDs, resultsOpts.Debug, hostInfos, apiPort, resultsOpts.ShutdownOnComplete, resultsOpts.ShutdownLingerSec, scenarioPath, metadata, progressOut, summaryWriter, traceOpts.Path)
+			autoResultsDone = startAutoResults(baseURL, resultsOpts.Label, resultsOpts.ResultsDir, expectedStepIDs, resultsOpts.Debug, hostInfos, apiPort, resultsOpts.ShutdownOnComplete, resultsOpts.ShutdownLingerSec, scenarioPath, metadata, progressOut, summaryWriter, traceOpts.Path, finalizeMultiHost)
 		}
 		waitForAutoResults := func(required bool) bool {
 			if autoResultsDone != nil {
@@ -963,28 +1013,10 @@ Available workload types:
 				fmt.Println("Attach mode enabled: expecting worker nodes prestarted with --run-node; spt will launch the entry node.")
 			}
 
-			rmiConfig := tui.RMIConfig{
-				NetworkMode: networkMode,
-				PortStart:   rmiPortStart,
-				PortCount:   rmiPortCount,
-			}
-
-			orchestrator := tui.NewMultiHostOrchestratorWithRMI(hostInfos, minHosts, rmiConfig)
-			// Provide image to orchestrator for preflight image checks
-			orchestrator.SetImage(sptImage)
-			orchestrator.SetAttachExistingWorkers(attachExisting)
-			orchestrator.SetResultsRoot(plannedResultsRoot)
+			// Already constructed above (before startAutoResults) so its
+			// FinalizeDiagnosticsAndCleanup could be wired in as a pre-summary hook.
+			orchestrator := multiHostOrchestrator
 			ctx := context.Background()
-			collectDiagnostics := func() {
-				if plannedResultsRoot == "" {
-					return
-				}
-				diagCtx, diagCancel := context.WithTimeout(context.Background(), constants.DiagnosticsCollectionTimeout)
-				defer diagCancel()
-				if err := orchestrator.CollectDiagnostics(diagCtx); err != nil {
-					logger.Warn("Diagnostics collection completed with warnings", "error", err.Error())
-				}
-			}
 
 			// Respect force cleanup for preflight conflicts
 			forceMode, _ := cmd.Flags().GetBool("force")
@@ -1020,16 +1052,24 @@ Available workload types:
 					return normalizedErr
 				}
 				autoResultsComplete := waitForAutoResults(delegateShutdownToAutoResults)
+				// finalizeMultiHost normally already ran as startAutoResults'
+				// pre-summary hook by the time we get here; calling it again
+				// is a safe, near-instant no-op (FinalizeDiagnosticsAndCleanup
+				// runs at most once). This remains the fallback path for
+				// AutoResults-without-ShutdownOnComplete, and for auto-terminate
+				// (which bypasses startAutoResults' shutdown step below via the
+				// autoTerminated return above).
 				if autoResultsComplete && delegateShutdownToAutoResults {
-					collectDiagnostics()
+					finalizeMultiHost()
 				}
 				if !autoResultsComplete && delegateShutdownToAutoResults {
-					logger.Warn("Timed out waiting for auto-results; forcing container cleanup")
-					cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 30*time.Second)
-					if stopErr := orchestrator.StopAllContainers(cleanupCtx); stopErr != nil {
-						logger.Error("Failed to clean up containers after auto-results timeout", "error", stopErr.Error())
-					}
-					cleanupCancel()
+					// The pre-summary hook may still be running (e.g. a slow
+					// diagnostics copy) — finalizeMultiHost/
+					// FinalizeDiagnosticsAndCleanup is safe to call concurrently
+					// with it and will simply wait for that single execution
+					// rather than duplicating it.
+					logger.Warn("Timed out waiting for auto-results; forcing diagnostics collection and container cleanup")
+					finalizeMultiHost()
 				}
 				finalizeTraceArtifact()
 				return normalizedErr
@@ -1041,7 +1081,7 @@ Available workload types:
 				err = tui.StartTUIWithMultiHostOrchestratorTimeoutWithTrace(orchestrator, sptImage, scenarioPath, params, autoTerminate, setSummarySink, traceOpts.Path, traceOpts.Append)
 				autoResultsComplete := waitForAutoResults(false)
 				if autoResultsComplete && resultsOpts.AutoResults && resultsOpts.ShutdownOnComplete {
-					collectDiagnostics()
+					finalizeMultiHost()
 				}
 				finalizeTraceArtifact()
 				return err
@@ -1049,7 +1089,7 @@ Available workload types:
 			err = tui.StartTUIWithMultiHostOrchestratorWithTrace(orchestrator, sptImage, scenarioPath, params, setSummarySink, traceOpts.Path, traceOpts.Append)
 			autoResultsComplete := waitForAutoResults(false)
 			if autoResultsComplete && resultsOpts.AutoResults && resultsOpts.ShutdownOnComplete {
-				collectDiagnostics()
+				finalizeMultiHost()
 			}
 			finalizeTraceArtifact()
 			return err

--- a/cli/cmd/run_auto_results_test.go
+++ b/cli/cmd/run_auto_results_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -172,7 +173,7 @@ func TestStartAutoResults_StaleDiscoveredIDsFromPriorRun(t *testing.T) {
 	generateRunSummaryFunc = func(ctx context.Context, runDir string, out io.Writer) error { return nil }
 
 	tmpDir := t.TempDir()
-	done := startAutoResults("http://example", "mt", tmpDir, currentIDs, false, nil, "", false, 0, "", nil, io.Discard, io.Discard, "")
+	done := startAutoResults("http://example", "mt", tmpDir, currentIDs, false, nil, "", false, 0, "", nil, io.Discard, io.Discard, "", nil)
 
 	select {
 	case <-done:
@@ -254,7 +255,7 @@ func TestStartAutoResults_DiscoveredIDsFilteredToExpectedSet(t *testing.T) {
 	}
 
 	tmpDir := t.TempDir()
-	done := startAutoResults("http://example", "mt", tmpDir, []string{"expected-create"}, false, nil, "", false, 0, "", nil, io.Discard, io.Discard, "")
+	done := startAutoResults("http://example", "mt", tmpDir, []string{"expected-create"}, false, nil, "", false, 0, "", nil, io.Discard, io.Discard, "", nil)
 
 	select {
 	case <-done:
@@ -341,7 +342,7 @@ func TestStartAutoResults_FleetDiscoveryPreferred(t *testing.T) {
 	generateRunSummaryFunc = func(ctx context.Context, runDir string, out io.Writer) error { return nil }
 
 	tmpDir := t.TempDir()
-	done := startAutoResults("http://example", "mt", tmpDir, expectedIDs, false, nil, "", false, 0, "", nil, io.Discard, io.Discard, "")
+	done := startAutoResults("http://example", "mt", tmpDir, expectedIDs, false, nil, "", false, 0, "", nil, io.Discard, io.Discard, "", nil)
 
 	select {
 	case <-done:
@@ -409,7 +410,7 @@ func TestStartAutoResults_FleetUnavailableFallback(t *testing.T) {
 	generateRunSummaryFunc = func(ctx context.Context, runDir string, out io.Writer) error { return nil }
 
 	tmpDir := t.TempDir()
-	done := startAutoResults("http://example", "mt", tmpDir, expectedIDs, false, nil, "", false, 0, "", nil, io.Discard, io.Discard, "")
+	done := startAutoResults("http://example", "mt", tmpDir, expectedIDs, false, nil, "", false, 0, "", nil, io.Discard, io.Discard, "", nil)
 
 	select {
 	case <-done:
@@ -496,7 +497,7 @@ func TestStartAutoResults_AppendsTraceArtifactToManifest(t *testing.T) {
 	generateRunSummaryFunc = func(ctx context.Context, runDir string, out io.Writer) error { return nil }
 
 	tmpDir := t.TempDir()
-	done := startAutoResults("http://example", "mt", tmpDir, []string{stepID}, false, nil, "", false, 0, "", nil, io.Discard, io.Discard, traceFile)
+	done := startAutoResults("http://example", "mt", tmpDir, []string{stepID}, false, nil, "", false, 0, "", nil, io.Discard, io.Discard, traceFile, nil)
 
 	select {
 	case <-done:
@@ -561,6 +562,11 @@ func TestStartAutoResults_EmitsSummaryAfterShutdown(t *testing.T) {
 	}
 
 	events := &eventWriter{}
+	var hookCalled int32
+	preSummaryHook := func() {
+		atomic.AddInt32(&hookCalled, 1)
+		_, _ = events.Write([]byte("PRE-SUMMARY HOOK RAN\n"))
+	}
 	done := startAutoResults(
 		"http://example",
 		"mt",
@@ -576,6 +582,7 @@ func TestStartAutoResults_EmitsSummaryAfterShutdown(t *testing.T) {
 		events,
 		events,
 		"",
+		preSummaryHook,
 	)
 
 	select {
@@ -584,16 +591,77 @@ func TestStartAutoResults_EmitsSummaryAfterShutdown(t *testing.T) {
 		t.Fatal("startAutoResults did not complete in time")
 	}
 
+	if atomic.LoadInt32(&hookCalled) != 1 {
+		t.Fatalf("preSummaryHook called %d times, want exactly 1", hookCalled)
+	}
+
 	got := events.snapshot()
 	summaryIndex := indexOfEventContaining(got, "FINAL SUMMARY")
 	shutdownIndex := indexOfEventContaining(got, "Shutdown completed successfully.")
+	hookIndex := indexOfEventContaining(got, "PRE-SUMMARY HOOK RAN")
 	if summaryIndex < 0 {
 		t.Fatalf("summary was not emitted; events=%v", got)
 	}
 	if shutdownIndex < 0 {
 		t.Fatalf("shutdown completion was not emitted; events=%v", got)
 	}
+	if hookIndex < 0 {
+		t.Fatalf("pre-summary hook was not run; events=%v", got)
+	}
 	if summaryIndex <= shutdownIndex {
 		t.Fatalf("summary should be emitted after shutdown completion; events=%v", got)
+	}
+	if hookIndex <= shutdownIndex {
+		t.Fatalf("pre-summary hook should run after shutdown completion; events=%v", got)
+	}
+	if summaryIndex <= hookIndex {
+		t.Fatalf("summary should be emitted after the pre-summary hook runs (this is the whole point of "+
+			"the hook: diagnostics/cleanup must be observable before the summary is); events=%v", got)
+	}
+}
+
+// TestStartAutoResults_SkipsPreSummaryHookWhenShutdownDisabled guards the
+// other half of the contract: the hook drives diagnostics collection and
+// full container/staging cleanup, which must only happen when the run
+// actually asked for delegated shutdown (shutdownOn/--shutdown-on-complete).
+// Running it unconditionally would tear down containers out from under a
+// user who explicitly asked to keep them running after completion.
+func TestStartAutoResults_SkipsPreSummaryHookWhenShutdownDisabled(t *testing.T) {
+	origRunTracker := newRunTrackerFunc
+	origDiscover := discoverStepIDsFunc
+	origFleetDiscover := discoverFleetStepIDsFunc
+	origFetcher := newResultsFetcherFunc
+	origSummary := generateRunSummaryFunc
+	defer func() {
+		newRunTrackerFunc = origRunTracker
+		discoverStepIDsFunc = origDiscover
+		discoverFleetStepIDsFunc = origFleetDiscover
+		newResultsFetcherFunc = origFetcher
+		generateRunSummaryFunc = origSummary
+	}()
+
+	stepID := "mt-001-20260604.195722.504-mixed"
+	newRunTrackerFunc = func(baseURL string) autoResultsRunTracker { return &fakeRunTracker{} }
+	discoverStepIDsFunc = func(baseURL string) ([]string, error) { return []string{stepID}, nil }
+	discoverFleetStepIDsFunc = func(baseURL string) ([]string, error) { return nil, nil }
+	newResultsFetcherFunc = func(baseURL, outputDir string) autoResultsFetcher {
+		return &fakeFetcher{output: outputDir}
+	}
+	generateRunSummaryFunc = func(ctx context.Context, runDir string, out io.Writer) error { return nil }
+
+	var hookCalled int32
+	preSummaryHook := func() { atomic.AddInt32(&hookCalled, 1) }
+
+	// shutdownOn = false
+	done := startAutoResults("http://example", "mt", t.TempDir(), []string{stepID}, false, nil, "", false, 0, "", nil, io.Discard, io.Discard, "", preSummaryHook)
+
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("startAutoResults did not complete in time")
+	}
+
+	if atomic.LoadInt32(&hookCalled) != 0 {
+		t.Fatalf("preSummaryHook called %d times with shutdown disabled, want 0", hookCalled)
 	}
 }

--- a/cli/cmd/run_metadata.go
+++ b/cli/cmd/run_metadata.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/dell/storage-performance-tool/cli/internal/cmdline"
@@ -60,8 +61,15 @@ type resultsOptionsSnapshot struct {
 }
 
 type runCLIInfo struct {
-	Command      []string          `json:"command"`
-	ChangedFlags map[string]string `json:"changedFlags,omitempty"`
+	Command []string `json:"command"`
+	// ChangedFlags holds only flags the user explicitly passed on the
+	// command line. EnvAppliedFlags holds flags applyEnvDefaultsToRunFlags
+	// injected from .env/OS env because the user did not — pflag's
+	// FlagSet.Set() marks a flag Changed=true regardless of caller, so
+	// these must be tracked separately to keep this distinction (see
+	// markEnvApplied/captureChangedFlags).
+	ChangedFlags    map[string]string `json:"changedFlags,omitempty"`
+	EnvAppliedFlags map[string]string `json:"envAppliedFlags,omitempty"`
 }
 
 type runMultiHostMetadata struct {
@@ -113,8 +121,9 @@ func buildRunMetadata(in runMetadataInput) *runMetadata {
 	expected := append([]string(nil), in.ExpectedStepIDs...)
 
 	cliInfo := runCLIInfo{
-		Command:      sanitizeCommandArgs(os.Args),
-		ChangedFlags: captureChangedFlags(in.Command),
+		Command:         sanitizeCommandArgs(os.Args),
+		ChangedFlags:    captureChangedFlags(in.Command),
+		EnvAppliedFlags: captureEnvAppliedFlags(in.Command),
 	}
 
 	meta := &runMetadata{
@@ -177,6 +186,11 @@ func maskSecret(v string) string {
 	return v[:3] + maskedPlaceholder
 }
 
+// captureChangedFlags returns only flags the user explicitly passed on the
+// command line. pflag's FlagSet.Set() marks a flag Changed=true regardless
+// of who called it, so flags applyEnvDefaultsToRunFlags injected from
+// .env/OS env (recorded via markEnvApplied) are excluded here — see
+// captureEnvAppliedFlags for those.
 func captureChangedFlags(cmd *cobra.Command) map[string]string {
 	if cmd == nil {
 		return nil
@@ -184,6 +198,9 @@ func captureChangedFlags(cmd *cobra.Command) map[string]string {
 	changed := map[string]string{}
 	cmd.Flags().VisitAll(func(f *pflag.Flag) {
 		if !f.Changed {
+			return
+		}
+		if _, envApplied := cmd.Annotations[envAppliedAnnotationPrefix+f.Name]; envApplied {
 			return
 		}
 		val := f.Value.String()
@@ -196,6 +213,29 @@ func captureChangedFlags(cmd *cobra.Command) map[string]string {
 		return nil
 	}
 	return changed
+}
+
+// captureEnvAppliedFlags returns flags applyEnvDefaultsToRunFlags injected
+// from .env/OS env because the user did not pass them explicitly.
+func captureEnvAppliedFlags(cmd *cobra.Command) map[string]string {
+	if cmd == nil || len(cmd.Annotations) == 0 {
+		return nil
+	}
+	applied := map[string]string{}
+	for key, val := range cmd.Annotations {
+		name, ok := strings.CutPrefix(key, envAppliedAnnotationPrefix)
+		if !ok {
+			continue
+		}
+		if isSensitiveFlag(name) {
+			val = maskSecret(val)
+		}
+		applied[name] = val
+	}
+	if len(applied) == 0 {
+		return nil
+	}
+	return applied
 }
 
 func isSensitiveFlag(name string) bool {

--- a/cli/cmd/run_metadata_test.go
+++ b/cli/cmd/run_metadata_test.go
@@ -106,6 +106,86 @@ func TestCaptureChangedFlagsMasksSensitiveValues(t *testing.T) {
 	}
 }
 
+// TestCaptureChangedFlagsExcludesEnvApplied guards spt_run_params.json's
+// core purpose here: pflag's FlagSet.Set() marks a flag Changed=true
+// regardless of who called it, so without markEnvApplied/this exclusion,
+// an env-injected default would be indistinguishable from something the
+// user actually typed on the command line.
+func TestCaptureChangedFlagsExcludesEnvApplied(t *testing.T) {
+	cmd := &cobra.Command{Use: "test"}
+	cmd.Flags().Int("threads", 1, "")
+	cmd.Flags().String("bucket", "", "")
+
+	_ = cmd.Flags().Set("threads", "16") // explicit CLI flag
+	markEnvApplied(cmd, "bucket", "env-bucket")
+	_ = cmd.Flags().Set("bucket", "env-bucket") // env default, via setFromEnv in practice
+
+	changed := captureChangedFlags(cmd)
+	if changed["threads"] != "16" {
+		t.Fatalf("threads stored as %q, want 16", changed["threads"])
+	}
+	if _, ok := changed["bucket"]; ok {
+		t.Fatalf("env-applied bucket should not appear in changedFlags: %+v", changed)
+	}
+
+	applied := captureEnvAppliedFlags(cmd)
+	if applied["bucket"] != "env-bucket" {
+		t.Fatalf("envAppliedFlags[bucket] = %q, want env-bucket", applied["bucket"])
+	}
+	if _, ok := applied["threads"]; ok {
+		t.Fatalf("explicit threads flag should not appear in envAppliedFlags: %+v", applied)
+	}
+}
+
+func TestCaptureEnvAppliedFlagsMasksSensitiveValues(t *testing.T) {
+	cmd := &cobra.Command{Use: "test"}
+	cmd.Flags().String("secret-key", "", "")
+	markEnvApplied(cmd, "secret-key", "supersecret")
+
+	applied := captureEnvAppliedFlags(cmd)
+	if applied["secret-key"] != "sup***" {
+		t.Fatalf("secret-key stored as %q, want sup***", applied["secret-key"])
+	}
+}
+
+// TestBuildRunMetadata_DistinguishesExplicitFromEnvAppliedFlags is an
+// end-to-end check through the real applyEnvDefaultsToRunFlags +
+// buildRunMetadata path, not just the two capture helpers in isolation.
+func TestBuildRunMetadata_DistinguishesExplicitFromEnvAppliedFlags(t *testing.T) {
+	cmd := newRunLikeCmd()
+	clearEnvDefaultsTestEnv(t)
+	_ = cmd.Flags().Set("threads", "8") // explicit CLI flag
+
+	t.Setenv("S3_BUCKET", "env-bucket")
+	if err := applyEnvDefaultsToRunFlags(cmd); err != nil {
+		t.Fatalf("applyEnvDefaultsToRunFlags error: %v", err)
+	}
+
+	meta := buildRunMetadata(runMetadataInput{
+		WorkloadType: "write",
+		Params:       scenario.Params{},
+		ScenarioPath: "./tmp/scenario.js",
+		ResultsOptions: ResultsOptions{
+			ResultsDir: "./results",
+			Label:      "mt",
+		},
+		Command: cmd,
+	})
+
+	if meta.CLI.ChangedFlags["threads"] != "8" {
+		t.Fatalf("ChangedFlags[threads] = %q, want 8", meta.CLI.ChangedFlags["threads"])
+	}
+	if _, ok := meta.CLI.ChangedFlags["bucket"]; ok {
+		t.Fatalf("env-applied bucket leaked into ChangedFlags: %+v", meta.CLI.ChangedFlags)
+	}
+	if meta.CLI.EnvAppliedFlags["bucket"] != "env-bucket" {
+		t.Fatalf("EnvAppliedFlags[bucket] = %q, want env-bucket", meta.CLI.EnvAppliedFlags["bucket"])
+	}
+	if _, ok := meta.CLI.EnvAppliedFlags["threads"]; ok {
+		t.Fatalf("explicit threads flag leaked into EnvAppliedFlags: %+v", meta.CLI.EnvAppliedFlags)
+	}
+}
+
 func TestCopyScenarioForResults(t *testing.T) {
 	dir := t.TempDir()
 	src := filepath.Join(dir, "scenario.js")

--- a/cli/internal/constants/envvars.go
+++ b/cli/internal/constants/envvars.go
@@ -2,19 +2,20 @@ package constants
 
 // Environment variable keys used by spt
 const (
-	EnvSptImage       = "SPT_IMAGE"
-	EnvSptGitHubToken = "SPT_GITHUB_TOKEN" // #nosec G101 -- env var name only
-	EnvHosts          = "HOSTS"
-	EnvS3Endpoint     = "S3_ENDPOINT"
-	EnvS3AccessKey    = "S3_ACCESS_KEY" // #nosec G101 -- env var names only
-	EnvS3SecretKey    = "S3_SECRET_KEY" // #nosec G101 -- env var names only
-	EnvS3Bucket       = "S3_BUCKET"
-	EnvS3AuthVersion  = "S3_AUTH_VERSION"
-	EnvSkipImagePull  = "SPT_SKIP_IMAGE_PULL"
-	EnvSptJavaOpts    = "SPT_JAVA_OPTS"
-	EnvRdmaEnabled    = "SPT_RDMA"
-	EnvS3Driver       = "SPT_S3_DRIVER"
-	EnvServiceThreads = "SPT_SERVICE_THREADS"
+	EnvSptImage        = "SPT_IMAGE"
+	EnvSptGitHubToken  = "SPT_GITHUB_TOKEN" // #nosec G101 -- env var name only
+	EnvHosts           = "HOSTS"
+	EnvS3Endpoint      = "S3_ENDPOINT"
+	EnvS3AccessKey     = "S3_ACCESS_KEY" // #nosec G101 -- env var names only
+	EnvS3SecretKey     = "S3_SECRET_KEY" // #nosec G101 -- env var names only
+	EnvS3Bucket        = "S3_BUCKET"
+	EnvS3AuthVersion   = "S3_AUTH_VERSION"
+	EnvSkipImagePull   = "SPT_SKIP_IMAGE_PULL"
+	EnvSptJavaOpts     = "SPT_JAVA_OPTS"
+	EnvRdmaEnabled     = "SPT_RDMA"
+	EnvS3Driver        = "SPT_S3_DRIVER"
+	EnvServiceThreads  = "SPT_SERVICE_THREADS"
+	EnvEngineOverrides = "SPT_ENGINE_OVERRIDES"
 
 	// Multipart upload configuration
 	EnvPartSize = "SPT_PART_SIZE"

--- a/cli/internal/constants/envvars.go
+++ b/cli/internal/constants/envvars.go
@@ -11,6 +11,7 @@ const (
 	EnvS3Bucket       = "S3_BUCKET"
 	EnvS3AuthVersion  = "S3_AUTH_VERSION"
 	EnvSkipImagePull  = "SPT_SKIP_IMAGE_PULL"
+	EnvSptJavaOpts    = "SPT_JAVA_OPTS"
 	EnvRdmaEnabled    = "SPT_RDMA"
 	EnvS3Driver       = "SPT_S3_DRIVER"
 	EnvServiceThreads = "SPT_SERVICE_THREADS"

--- a/cli/internal/constants/timing.go
+++ b/cli/internal/constants/timing.go
@@ -14,8 +14,9 @@ const (
 	PortCheckTimeout    = 2 * time.Second        // Timeout for checking if a port is open
 
 	// Container lifecycle timeouts
-	ContainerShutdownGrace = 2 * time.Second // Grace period for container graceful shutdown
-	APILingerDefault       = 5 * time.Second // Default /status linger window after /shutdown
+	ContainerShutdownGrace       = 2 * time.Second // Grace period for container graceful shutdown
+	APILingerDefault             = 5 * time.Second // Default /status linger window after /shutdown
+	DiagnosticsCollectionTimeout = 5 * time.Minute // Per-host timeout for copying JVM diagnostics artifacts
 
 	// Metrics collection intervals
 	DefaultMetricsInterval = 500 * time.Millisecond // Default interval for metrics collection

--- a/cli/internal/docker/command/builder.go
+++ b/cli/internal/docker/command/builder.go
@@ -46,6 +46,10 @@ func (b *DockerCommandBuilderImpl) BuildRunCommand(config ContainerConfig) []str
 		}
 	}
 
+	for _, envFile := range config.EnvFiles {
+		dockerArgs = append(dockerArgs, "--env-file", envFile)
+	}
+
 	// Labels (stable order for testability)
 	if len(config.Labels) > 0 {
 		labelKeys := make([]string, 0, len(config.Labels))

--- a/cli/internal/docker/command/builder_test.go
+++ b/cli/internal/docker/command/builder_test.go
@@ -159,6 +159,16 @@ func TestDockerCommandBuilderImpl_BuildRunCommand(t *testing.T) {
 			},
 		},
 		{
+			name: "container with env-file",
+			config: ContainerConfig{
+				Image:    constants.DefaultSptImage,
+				EnvFiles: []string{"/tmp/spt.env"},
+			},
+			expected: []string{
+				"docker", "run", "--env-file", "/tmp/spt.env", constants.DefaultSptImage,
+			},
+		},
+		{
 			name: "empty container name",
 			config: ContainerConfig{
 				Image:    constants.DefaultSptImage,

--- a/cli/internal/docker/command/executor.go
+++ b/cli/internal/docker/command/executor.go
@@ -23,6 +23,9 @@ type Executor interface {
 
 	// CopyFile copies a local file to the given host path.
 	CopyFile(ctx context.Context, host *hostparse.HostInfo, localPath, remotePath string) error
+
+	// CopyFromHost copies a file from the given host path to a local path.
+	CopyFromHost(ctx context.Context, host *hostparse.HostInfo, remotePath, localPath string) error
 }
 
 // RealCommandExecutor implements Executor using actual system commands
@@ -96,6 +99,28 @@ func (r *RealCommandExecutor) CopyFile(ctx context.Context, host *hostparse.Host
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("copy %s to %s:%s failed: %w: %s", localPath, host.Original, remotePath, err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+// CopyFromHost copies a file from the target host to a local path.
+func (r *RealCommandExecutor) CopyFromHost(ctx context.Context, host *hostparse.HostInfo, remotePath, localPath string) error {
+	var cmd *exec.Cmd
+	if host.IsLocal {
+		cmd = exec.CommandContext(ctx, "cp", remotePath, localPath) // #nosec G204 -- paths are user-selected SPT artifacts.
+	} else {
+		sshSource := host.GetSSHTarget() + ":" + remotePath
+		scpArgs := []string{
+			"-o", constants.SSHConnectTimeout,
+			"-o", constants.SSHBatchMode,
+			sshSource,
+			localPath,
+		}
+		cmd = exec.CommandContext(ctx, constants.SCPCommand, scpArgs...) // #nosec G204 -- SCP source is built from parsed host info.
+	}
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("copy %s:%s to %s failed: %w: %s", host.Original, remotePath, localPath, err, strings.TrimSpace(string(out)))
 	}
 	return nil
 }

--- a/cli/internal/docker/command/test_helpers.go
+++ b/cli/internal/docker/command/test_helpers.go
@@ -7,6 +7,8 @@ package command
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -22,6 +24,7 @@ type MockCommandExecutor struct {
 	// ExecutedCommands tracks what commands were executed
 	ExecutedCommands []ExecutedCommand
 	CopiedFiles      []CopiedFile
+	CopiedFromFiles  []CopiedFile
 
 	// FailureMode simulates specific failures
 	FailureMode string
@@ -50,6 +53,7 @@ type CopiedFile struct {
 	Host       *hostparse.HostInfo
 	LocalPath  string
 	RemotePath string
+	Content    string
 }
 
 // NewMockCommandExecutor creates a new MockCommandExecutor
@@ -112,11 +116,27 @@ func (m *MockCommandExecutor) ExecuteCommand(ctx context.Context, host *hostpars
 
 // CopyFile simulates copying a local file to a host.
 func (m *MockCommandExecutor) CopyFile(_ context.Context, host *hostparse.HostInfo, localPath, remotePath string) error {
-	m.CopiedFiles = append(m.CopiedFiles, CopiedFile{Host: host, LocalPath: localPath, RemotePath: remotePath})
+	copied := CopiedFile{Host: host, LocalPath: localPath, RemotePath: remotePath}
+	if data, err := os.ReadFile(localPath); err == nil {
+		copied.Content = string(data)
+	}
+	m.CopiedFiles = append(m.CopiedFiles, copied)
 	if m.FailureMode == "copy_failure" {
 		return fmt.Errorf("copy failed")
 	}
 	return nil
+}
+
+// CopyFromHost simulates copying a file from a host to the local filesystem.
+func (m *MockCommandExecutor) CopyFromHost(_ context.Context, host *hostparse.HostInfo, remotePath, localPath string) error {
+	m.CopiedFromFiles = append(m.CopiedFromFiles, CopiedFile{Host: host, LocalPath: localPath, RemotePath: remotePath})
+	if m.FailureMode == "copy_from_failure" {
+		return fmt.Errorf("copy from host failed")
+	}
+	if err := os.MkdirAll(filepath.Dir(localPath), 0o750); err != nil {
+		return err
+	}
+	return os.WriteFile(localPath, []byte("mock remote file\n"), 0o600)
 }
 
 // SetCommandResponse sets the response for a specific command

--- a/cli/internal/docker/command/test_helpers.go
+++ b/cli/internal/docker/command/test_helpers.go
@@ -117,7 +117,7 @@ func (m *MockCommandExecutor) ExecuteCommand(ctx context.Context, host *hostpars
 // CopyFile simulates copying a local file to a host.
 func (m *MockCommandExecutor) CopyFile(_ context.Context, host *hostparse.HostInfo, localPath, remotePath string) error {
 	copied := CopiedFile{Host: host, LocalPath: localPath, RemotePath: remotePath}
-	if data, err := os.ReadFile(localPath); err == nil {
+	if data, err := os.ReadFile(localPath); err == nil { // #nosec G304 -- test mock; localPath is caller-controlled in tests
 		copied.Content = string(data)
 	}
 	m.CopiedFiles = append(m.CopiedFiles, copied)

--- a/cli/internal/docker/command/types.go
+++ b/cli/internal/docker/command/types.go
@@ -37,6 +37,7 @@ type ContainerConfig struct {
 	PortMappings []PortMapping     // Port mappings for bridge mode
 	Labels       map[string]string // Optional labels to tag the container
 	Environment  map[string]string // Environment variables
+	EnvFiles     []string          // Docker env-file paths
 	Command      []string          // Container command to run
 	ExposedPorts []int             // Ports to expose
 	Detached     bool              // Run in detached mode

--- a/cli/internal/netprobe/netprobe_test.go
+++ b/cli/internal/netprobe/netprobe_test.go
@@ -40,6 +40,10 @@ func (m *mockExec) CopyFile(context.Context, *hostparse.HostInfo, string, string
 	return nil
 }
 
+func (m *mockExec) CopyFromHost(context.Context, *hostparse.HostInfo, string, string) error {
+	return nil
+}
+
 func (m *mockExec) ExecuteCommand(ctx context.Context, host *hostparse.HostInfo, cmd []string) (string, string, error) {
 	key := strings.Join(cmd, " ")
 	m.calls = append(m.calls, key)

--- a/cli/internal/replay/convert_javascript.go
+++ b/cli/internal/replay/convert_javascript.go
@@ -29,29 +29,29 @@ var (
 	jsPathKeyRe               = regexp.MustCompile(`"path"\s*:`)
 	jsIdentifierRe            = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
 	jsParentConfigAllowedKeys = map[string]struct{}{
-		"storage":      {},
-		"net":          {},
-		"node":         {},
-		"port":         {},
-		"driver":       {},
-		"type":         {},
-		"ssl":          {},
-		"enabled":      {},
-		"ciphers":      {},
-		"protocols":    {},
-		"provider":     {},
-		"jsseProvider": {},
-		"namedGroups":  {},
-		"pqcMode":      {},
+		"storage":        {},
+		legacyKeyNet:     {},
+		"node":           {},
+		"port":           {},
+		"driver":         {},
+		"type":           {},
+		legacyKeySSL:     {},
+		legacyKeyEnabled: {},
+		"ciphers":        {},
+		"protocols":      {},
+		"provider":       {},
+		"jsseProvider":   {},
+		"namedGroups":    {},
+		"pqcMode":        {},
 	}
 	jsParentSSLAllowedKeys = map[string]struct{}{
-		"enabled":      {},
-		"ciphers":      {},
-		"protocols":    {},
-		"provider":     {},
-		"jsseProvider": {},
-		"namedGroups":  {},
-		"pqcMode":      {},
+		legacyKeyEnabled: {},
+		"ciphers":        {},
+		"protocols":      {},
+		"provider":       {},
+		"jsseProvider":   {},
+		"namedGroups":    {},
+		"pqcMode":        {},
 	}
 )
 
@@ -497,7 +497,7 @@ func rewriteJSParentConfigs(source string, opts Options, bucket string, vars map
 		}
 		configText := source[open : closeIdx+1]
 		sslConfig, unsupportedSSLKeys := extractJSParentSSLConfig(configText, vars)
-		if enabled, ok := sslConfig["enabled"].(bool); ok {
+		if enabled, ok := sslConfig[legacyKeyEnabled].(bool); ok {
 			if warning, mismatch := archivedSSLMismatchWarning(enabled, opts.Endpoints, name); mismatch {
 				diagnostics = append(diagnostics, Diagnostic{Severity: severityWarning, Message: warning})
 			}
@@ -545,7 +545,7 @@ func parentConfigHasExtraKeys(configText string) bool {
 func sanitizedJSParentConfig(name string, opts Options, bucket string, sslConfig map[string]any) string {
 	config := map[string]any{
 		"item": map[string]any{
-			"output": map[string]any{
+			legacyKeyOutput: map[string]any{
 				"path": jsBucketPath(bucket),
 			},
 		},
@@ -556,7 +556,7 @@ func sanitizedJSParentConfig(name string, opts Options, bucket string, sslConfig
 		},
 	}
 	if len(sslConfig) > 0 {
-		setPath(config, sslConfig, "storage", "net", "ssl")
+		setPath(config, sslConfig, "storage", legacyKeyNet, legacyKeySSL)
 	}
 	configJS, err := marshalJSConfig(config)
 	if err != nil {
@@ -581,21 +581,21 @@ func extractJSParentSSLConfig(configText string, vars map[string]string) (map[st
 	if storageText == "" {
 		return nil, nil
 	}
-	netText := jsObjectForKey(storageText, "net")
+	netText := jsObjectForKey(storageText, legacyKeyNet)
 	if netText == "" {
 		return nil, nil
 	}
-	sslText := jsObjectForKey(netText, "ssl")
+	sslText := jsObjectForKey(netText, legacyKeySSL)
 	if sslText == "" {
-		if enabled, ok := boolValue(jsFieldValue(netText, "ssl", vars), vars); ok {
-			return map[string]any{"enabled": enabled}, nil
+		if enabled, ok := boolValue(jsFieldValue(netText, legacyKeySSL, vars), vars); ok {
+			return map[string]any{legacyKeyEnabled: enabled}, nil
 		}
 		return nil, nil
 	}
 
 	sslConfig := map[string]any{}
-	if enabled, ok := boolValue(jsFieldValue(sslText, "enabled", vars), vars); ok {
-		sslConfig["enabled"] = enabled
+	if enabled, ok := boolValue(jsFieldValue(sslText, legacyKeyEnabled, vars), vars); ok {
+		sslConfig[legacyKeyEnabled] = enabled
 	}
 	if ciphers, ok := jsStringListField(sslText, "ciphers", vars); ok {
 		sslConfig["ciphers"] = ciphers

--- a/cli/internal/replay/convert_json.go
+++ b/cli/internal/replay/convert_json.go
@@ -53,7 +53,13 @@ const (
 	legacyKeyCount       = "count"
 	legacyKeyDriver      = "driver"
 	legacyKeyLimit       = "limit"
+	legacyKeyNet         = "net"
+	legacyKeyOutput      = "output"
+	legacyKeySSL         = "ssl"
+	legacyKeyEnabled     = "enabled"
+	legacyKeyStep        = "step"
 	legacyKeyStorage     = "storage"
+	legacyKeyTest        = "test"
 	legacyKeyType        = "type"
 
 	opTypeCreate = "create"
@@ -302,9 +308,9 @@ func convertLoadStep(step legacyStep, index, stepNumber int, label, baseTS, buck
 	)
 	concurrency := intValue(concurrencyRaw, vars)
 	itemSize := resolveString(getPath(step.Config, "item", "data", "size"), vars)
-	limitTimeRaw := getPath(step.Config, "test", "step", legacyKeyLimit, "time")
+	limitTimeRaw := getPath(step.Config, legacyKeyTest, legacyKeyStep, legacyKeyLimit, "time")
 	limitCountRaw := firstPath(step.Config,
-		[]string{"test", "step", legacyKeyLimit, legacyKeyCount},
+		[]string{legacyKeyTest, legacyKeyStep, legacyKeyLimit, legacyKeyCount},
 		[]string{legacyStepTypeLoad, "op", legacyKeyLimit, legacyKeyCount},
 		[]string{legacyStepTypeLoad, legacyKeyLimit, legacyKeyCount},
 	)
@@ -327,7 +333,7 @@ func convertLoadStep(step legacyStep, index, stepNumber int, label, baseTS, buck
 			},
 		},
 		"item": map[string]any{
-			"output": map[string]any{
+			legacyKeyOutput: map[string]any{
 				"path": "/" + strings.TrimPrefix(bucket, "/"),
 			},
 		},
@@ -335,7 +341,7 @@ func convertLoadStep(step legacyStep, index, stepNumber int, label, baseTS, buck
 			"op": map[string]any{
 				legacyKeyType: opType,
 			},
-			"step": map[string]any{
+			legacyKeyStep: map[string]any{
 				"id": stepID,
 			},
 		},
@@ -357,12 +363,12 @@ func convertLoadStep(step legacyStep, index, stepNumber int, label, baseTS, buck
 	}
 	if failCount := int64Value(firstPath(step.Config,
 		[]string{legacyStepTypeLoad, "op", legacyKeyLimit, "fail", legacyKeyCount},
-		[]string{"test", "step", legacyKeyLimit, "fail", legacyKeyCount},
+		[]string{legacyKeyTest, legacyKeyStep, legacyKeyLimit, "fail", legacyKeyCount},
 	), vars); failCount > 0 {
 		setPath(config, failCount, legacyStepTypeLoad, "op", legacyKeyLimit, "fail", legacyKeyCount)
 	}
 	if duration != "" {
-		setPath(config, duration, legacyStepTypeLoad, "step", legacyKeyLimit, "time")
+		setPath(config, duration, legacyStepTypeLoad, legacyKeyStep, legacyKeyLimit, "time")
 	}
 	if count > 0 {
 		setPath(config, count, legacyStepTypeLoad, "op", legacyKeyLimit, legacyKeyCount)
@@ -374,53 +380,53 @@ func convertLoadStep(step legacyStep, index, stepNumber int, label, baseTS, buck
 		setPath(config, shuffle, legacyStepTypeLoad, "op", "shuffle")
 	}
 	if threshold, ok := floatValue(firstPath(step.Config,
-		[]string{"output", "metrics", "threshold"},
-		[]string{"test", "step", "metrics", "threshold"},
+		[]string{legacyKeyOutput, "metrics", "threshold"},
+		[]string{legacyKeyTest, legacyKeyStep, "metrics", "threshold"},
 	), vars); ok {
-		setPath(config, threshold, "output", "metrics", "threshold")
+		setPath(config, threshold, legacyKeyOutput, "metrics", "threshold")
 	}
 	if enabled, ok := boolValue(firstPath(step.Config,
-		[]string{legacyKeyStorage, "net", "ssl", "enabled"},
-		[]string{legacyKeyStorage, "net", "ssl"},
+		[]string{legacyKeyStorage, legacyKeyNet, legacyKeySSL, legacyKeyEnabled},
+		[]string{legacyKeyStorage, legacyKeyNet, legacyKeySSL},
 	), vars); ok {
-		setPath(config, enabled, legacyKeyStorage, "net", "ssl", "enabled")
+		setPath(config, enabled, legacyKeyStorage, legacyKeyNet, legacyKeySSL, legacyKeyEnabled)
 		if warning, mismatch := archivedSSLMismatchWarning(enabled, opts.Endpoints, archiveID); mismatch {
 			diagnostics = append(diagnostics, Diagnostic{Severity: severityWarning, Message: warning})
 		}
 	}
-	if ciphers, ok := stringListValue(getPath(step.Config, legacyKeyStorage, "net", "ssl", "ciphers"), vars); ok {
-		setPath(config, ciphers, legacyKeyStorage, "net", "ssl", "ciphers")
+	if ciphers, ok := stringListValue(getPath(step.Config, legacyKeyStorage, legacyKeyNet, legacyKeySSL, "ciphers"), vars); ok {
+		setPath(config, ciphers, legacyKeyStorage, legacyKeyNet, legacyKeySSL, "ciphers")
 	}
-	if protocols, ok := stringListValue(getPath(step.Config, legacyKeyStorage, "net", "ssl", "protocols"), vars); ok {
-		setPath(config, protocols, legacyKeyStorage, "net", "ssl", "protocols")
+	if protocols, ok := stringListValue(getPath(step.Config, legacyKeyStorage, legacyKeyNet, legacyKeySSL, "protocols"), vars); ok {
+		setPath(config, protocols, legacyKeyStorage, legacyKeyNet, legacyKeySSL, "protocols")
 	}
-	if namedGroups, ok := stringListValue(getPath(step.Config, legacyKeyStorage, "net", "ssl", "namedGroups"), vars); ok {
-		setPath(config, namedGroups, legacyKeyStorage, "net", "ssl", "namedGroups")
+	if namedGroups, ok := stringListValue(getPath(step.Config, legacyKeyStorage, legacyKeyNet, legacyKeySSL, "namedGroups"), vars); ok {
+		setPath(config, namedGroups, legacyKeyStorage, legacyKeyNet, legacyKeySSL, "namedGroups")
 	}
-	if provider := resolveString(getPath(step.Config, legacyKeyStorage, "net", "ssl", "provider"), vars); provider != "" {
-		setPath(config, provider, legacyKeyStorage, "net", "ssl", "provider")
+	if provider := resolveString(getPath(step.Config, legacyKeyStorage, legacyKeyNet, legacyKeySSL, "provider"), vars); provider != "" {
+		setPath(config, provider, legacyKeyStorage, legacyKeyNet, legacyKeySSL, "provider")
 	}
-	if jsseProvider := resolveString(getPath(step.Config, legacyKeyStorage, "net", "ssl", "jsseProvider"), vars); jsseProvider != "" {
-		setPath(config, jsseProvider, legacyKeyStorage, "net", "ssl", "jsseProvider")
+	if jsseProvider := resolveString(getPath(step.Config, legacyKeyStorage, legacyKeyNet, legacyKeySSL, "jsseProvider"), vars); jsseProvider != "" {
+		setPath(config, jsseProvider, legacyKeyStorage, legacyKeyNet, legacyKeySSL, "jsseProvider")
 	}
-	if pqcMode := resolveString(getPath(step.Config, legacyKeyStorage, "net", "ssl", "pqcMode"), vars); pqcMode != "" {
-		setPath(config, pqcMode, legacyKeyStorage, "net", "ssl", "pqcMode")
+	if pqcMode := resolveString(getPath(step.Config, legacyKeyStorage, legacyKeyNet, legacyKeySSL, "pqcMode"), vars); pqcMode != "" {
+		setPath(config, pqcMode, legacyKeyStorage, legacyKeyNet, legacyKeySSL, "pqcMode")
 	}
 
 	var rewrites []PathRewrite
-	if rawOutput := itemPathString(getPath(step.Config, "item", "output", "file"), vars); rawOutput != "" {
+	if rawOutput := itemPathString(getPath(step.Config, "item", legacyKeyOutput, "file"), vars); rawOutput != "" {
 		item := itemFileVariable(rawOutput, archiveToStepID, itemVars, itemVarOrder)
 		if item.VarName != "" {
-			setPath(config, exprPlaceholder(item.VarName), "item", "output", "file")
+			setPath(config, exprPlaceholder(item.VarName), "item", legacyKeyOutput, "file")
 			rewrites = append(rewrites, PathRewrite{ArchiveID: item.ArchiveID, StepID: item.StepID, From: item.From, To: item.To})
 		} else if pathLabel, _, ok := parseItemFile(rawOutput); ok {
 			return convertedStep{}, fmt.Errorf("step %s references unknown item-file path label %s", archiveID, pathLabel)
 		} else if item := mongoosePathVariable(rawOutput, itemVars, itemVarOrder); item.VarName != "" {
-			setPath(config, exprPlaceholder(item.VarName), "item", "output", "file")
+			setPath(config, exprPlaceholder(item.VarName), "item", legacyKeyOutput, "file")
 		} else if strings.Contains(rawOutput, "${") {
 			return convertedStep{}, fmt.Errorf("step %s has unresolved item output file path %q", archiveID, rawOutput)
 		} else {
-			setPath(config, rawOutput, "item", "output", "file")
+			setPath(config, rawOutput, "item", legacyKeyOutput, "file")
 		}
 	}
 	if rawInput := itemPathString(getPath(step.Config, "item", "input", "file"), vars); rawInput != "" {
@@ -487,7 +493,7 @@ func precomputeArchiveStepIDs(steps []legacyStep, baseConfig map[string]any, lab
 }
 
 func loadStepIdentity(step legacyStep, index int, vars map[string]string) (string, string, string, string, error) {
-	archiveID := resolveString(getPath(step.Config, "test", "step", "id"), vars)
+	archiveID := resolveString(getPath(step.Config, legacyKeyTest, legacyKeyStep, "id"), vars)
 	if archiveID == "" {
 		archiveID = fmt.Sprintf("archive-step-%03d", index+1)
 	}

--- a/cli/internal/scenario/defaults.go
+++ b/cli/internal/scenario/defaults.go
@@ -412,5 +412,102 @@ func GenerateDefaults(params Params) ([]byte, error) {
 		return nil, fmt.Errorf("failed to marshal defaults config: %w", err)
 	}
 
+	if len(params.EngineOverrides) > 0 {
+		data, err = applyEngineOverrides(data, params.EngineOverrides)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	return data, nil
+}
+
+func applyEngineOverrides(data []byte, overrides []string) ([]byte, error) {
+	var root map[string]any
+	if err := yaml.Unmarshal(data, &root); err != nil {
+		return nil, fmt.Errorf("failed to parse defaults before applying engine overrides: %w", err)
+	}
+
+	for _, override := range overrides {
+		if err := applyEngineOverride(root, override); err != nil {
+			return nil, err
+		}
+	}
+
+	merged, err := yaml.Marshal(root)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal defaults after applying engine overrides: %w", err)
+	}
+	return merged, nil
+}
+
+func applyEngineOverride(root map[string]any, override string) error {
+	rawPath, rawValue, ok := strings.Cut(override, "=")
+	if !ok {
+		return fmt.Errorf("invalid engine override %q: expected path=value", override)
+	}
+
+	parts := splitEngineOverridePath(rawPath)
+	if len(parts) == 0 {
+		return fmt.Errorf("invalid engine override %q: path is empty", override)
+	}
+
+	value, err := parseEngineOverrideValue(rawValue)
+	if err != nil {
+		return fmt.Errorf("invalid engine override %q: %w", override, err)
+	}
+
+	node := root
+	for _, part := range parts[:len(parts)-1] {
+		next, ok := node[part]
+		if !ok || next == nil {
+			child := map[string]any{}
+			node[part] = child
+			node = child
+			continue
+		}
+		child, ok := next.(map[string]any)
+		if !ok {
+			return fmt.Errorf("invalid engine override %q: %s already contains a scalar value", override, part)
+		}
+		node = child
+	}
+
+	node[parts[len(parts)-1]] = value
+	return nil
+}
+
+func splitEngineOverridePath(path string) []string {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return nil
+	}
+	separator := "."
+	if !strings.Contains(path, ".") {
+		separator = "-"
+	}
+
+	rawParts := strings.Split(path, separator)
+	parts := make([]string, 0, len(rawParts))
+	for _, part := range rawParts {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			return nil
+		}
+		parts = append(parts, part)
+	}
+	return parts
+}
+
+func parseEngineOverrideValue(raw string) (any, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "", nil
+	}
+
+	var value any
+	if err := yaml.Unmarshal([]byte(raw), &value); err != nil {
+		return nil, err
+	}
+	return value, nil
 }

--- a/cli/internal/scenario/defaults_test.go
+++ b/cli/internal/scenario/defaults_test.go
@@ -1258,3 +1258,89 @@ func TestGenerateDefaults(t *testing.T) {
 		})
 	}
 }
+
+func TestGenerateDefaultsAppliesEngineOverrides(t *testing.T) {
+	data, err := GenerateDefaults(Params{
+		WorkloadType: "write",
+		Endpoint:     "http://minio:9000",
+		AccessKey:    "testkey",
+		SecretKey:    "testsecret",
+		Bucket:       "testbucket",
+		Threads:      4,
+		EngineOverrides: []string{
+			"storage.driver.threads=6",
+			"storage.net.http.max.chunk.size=1048576",
+			"storage.net.ioRatio=80",
+			"storage.net.ssl.protocols=[TLSv1.3,TLSv1.2]",
+		},
+	})
+	if err != nil {
+		t.Fatalf("GenerateDefaults() error = %v", err)
+	}
+
+	var root map[string]any
+	if err := yaml.Unmarshal(data, &root); err != nil {
+		t.Fatalf("unmarshal defaults: %v", err)
+	}
+	storage := root["storage"].(map[string]any)
+	driver := storage["driver"].(map[string]any)
+	netCfg := storage["net"].(map[string]any)
+	http := netCfg["http"].(map[string]any)
+	max := http["max"].(map[string]any)
+	chunk := max["chunk"].(map[string]any)
+	ssl := netCfg["ssl"].(map[string]any)
+
+	if got := driver["threads"]; got != 6 {
+		t.Errorf("storage.driver.threads = %v, want 6", got)
+	}
+	if got := chunk["size"]; got != 1048576 {
+		t.Errorf("storage.net.http.max.chunk.size = %v, want 1048576", got)
+	}
+	if got := netCfg["ioRatio"]; got != 80 {
+		t.Errorf("storage.net.ioRatio = %v, want 80", got)
+	}
+	protocols, ok := ssl["protocols"].([]any)
+	if !ok || len(protocols) != 2 || protocols[0] != "TLSv1.3" || protocols[1] != "TLSv1.2" {
+		t.Errorf("storage.net.ssl.protocols = %#v, want TLSv1.3,TLSv1.2", ssl["protocols"])
+	}
+}
+
+func TestGenerateDefaultsAppliesDashSeparatedEngineOverrides(t *testing.T) {
+	data, err := GenerateDefaults(Params{
+		WorkloadType: "write",
+		Endpoint:     "http://minio:9000",
+		AccessKey:    "testkey",
+		SecretKey:    "testsecret",
+		Bucket:       "testbucket",
+		Threads:      4,
+		EngineOverrides: []string{
+			"storage-net-http-max-chunk-size=131072",
+		},
+	})
+	if err != nil {
+		t.Fatalf("GenerateDefaults() error = %v", err)
+	}
+	if !strings.Contains(string(data), "size: 131072") {
+		t.Fatalf("expected dash-separated override to write nested max.chunk.size, got:\n%s", string(data))
+	}
+}
+
+func TestGenerateDefaultsRejectsInvalidEngineOverrides(t *testing.T) {
+	_, err := GenerateDefaults(Params{
+		WorkloadType: "write",
+		Endpoint:     "http://minio:9000",
+		AccessKey:    "testkey",
+		SecretKey:    "testsecret",
+		Bucket:       "testbucket",
+		Threads:      4,
+		EngineOverrides: []string{
+			"storage.driver.threads",
+		},
+	})
+	if err == nil {
+		t.Fatal("expected invalid engine override to fail")
+	}
+	if !strings.Contains(err.Error(), "path=value") {
+		t.Fatalf("expected path=value error, got %v", err)
+	}
+}

--- a/cli/internal/scenario/types.go
+++ b/cli/internal/scenario/types.go
@@ -20,7 +20,8 @@ type Params struct {
 	Cleanup      bool // Automatically delete created objects after test
 	KeepScenario bool // Keep the scenario file after test completes
 	// Engine tuning
-	ServiceThreads int // VT carrier thread parallelism (0 = JVM default)
+	ServiceThreads  int      // VT carrier thread parallelism (0 = JVM default)
+	EngineOverrides []string // Advanced engine defaults overrides as YAML path=value entries
 
 	// Multi-endpoint controls
 	SliceEndpoints bool // Partition endpoint list across nodes in distributed runs

--- a/cli/internal/verification/conflicts_snapshot_test.go
+++ b/cli/internal/verification/conflicts_snapshot_test.go
@@ -48,6 +48,10 @@ func (m *miniExec) CopyFile(context.Context, *hostparse.HostInfo, string, string
 	return nil
 }
 
+func (m *miniExec) CopyFromHost(context.Context, *hostparse.HostInfo, string, string) error {
+	return nil
+}
+
 func (m *miniExec) ExecuteCommand(ctx context.Context, host *hostparse.HostInfo, command []string) (string, string, error) {
 	m.cmds = append(m.cmds, command)
 	key := strings.Join(command, " ")

--- a/cli/internal/verification/mocks.go
+++ b/cli/internal/verification/mocks.go
@@ -84,6 +84,11 @@ func (m *MockCommandExecutor) CopyFile(context.Context, *hostparse.HostInfo, str
 	return nil
 }
 
+// CopyFromHost records no reverse file copy behavior for verification tests.
+func (m *MockCommandExecutor) CopyFromHost(context.Context, *hostparse.HostInfo, string, string) error {
+	return nil
+}
+
 // SetupDockerSuccess configures mock to return successful Docker responses
 func (m *MockCommandExecutor) SetupDockerSuccess() {
 	m.mu.Lock()

--- a/cli/internal/verification/verifier_test.go
+++ b/cli/internal/verification/verifier_test.go
@@ -719,6 +719,10 @@ func (m *FlexibleMockCommandExecutor) CopyFile(context.Context, *hostparse.HostI
 	return nil
 }
 
+func (m *FlexibleMockCommandExecutor) CopyFromHost(context.Context, *hostparse.HostInfo, string, string) error {
+	return nil
+}
+
 func (m *FlexibleMockCommandExecutor) ExecuteCommand(ctx context.Context, host *hostparse.HostInfo, command []string) (stdout, stderr string, err error) {
 	// Record the execution
 	m.ExecutedCommands = append(m.ExecutedCommands, MockCommandExecution{
@@ -755,6 +759,10 @@ type cleanupOnFailureExecutor struct {
 }
 
 func (m *cleanupOnFailureExecutor) CopyFile(context.Context, *hostparse.HostInfo, string, string) error {
+	return nil
+}
+
+func (m *cleanupOnFailureExecutor) CopyFromHost(context.Context, *hostparse.HostInfo, string, string) error {
 	return nil
 }
 

--- a/cli/tui/diagnostics.go
+++ b/cli/tui/diagnostics.go
@@ -1,0 +1,144 @@
+package tui
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/dell/storage-performance-tool/cli/internal/constants"
+)
+
+const (
+	dockerDiagnosticsMount              = "/spt-diagnostics"
+	dockerDiagnosticsResultsDirName     = "diagnostics"
+	dockerDiagnosticsManifestFileName   = "diagnostics_manifest.json"
+	dockerDiagnosticsStopTimeoutSeconds = 60
+	diagnosticsDefaultHost              = "localhost"
+	remoteDiagnosticsBaseDir            = "/tmp/spt-diagnostics"
+)
+
+type diagnosticsRecord struct {
+	Host               string   `json:"host"`
+	Role               string   `json:"role"`
+	ContainerID        string   `json:"containerId,omitempty"`
+	ContainerDir       string   `json:"containerDir"`
+	RemoteDir          string   `json:"remoteDir,omitempty"`
+	LocalDir           string   `json:"localDir,omitempty"`
+	Files              []string `json:"files,omitempty"`
+	Collected          bool     `json:"collected"`
+	RemoteDirRemoved   bool     `json:"remoteDirRemoved,omitempty"`
+	PreservedRemoteDir bool     `json:"preservedRemoteDir,omitempty"`
+	Error              string   `json:"error,omitempty"`
+}
+
+type diagnosticsManifest struct {
+	SchemaVersion int                 `json:"schemaVersion"`
+	GeneratedAt   string              `json:"generatedAt"`
+	ContainerDir  string              `json:"containerDir"`
+	Records       []diagnosticsRecord `json:"records"`
+}
+
+type diagnosticsCollector interface {
+	collectDiagnostics(context.Context) (*diagnosticsRecord, error)
+	diagnosticsRecord() *diagnosticsRecord
+}
+
+func diagnosticsEnabled() bool {
+	return strings.TrimSpace(os.Getenv(constants.EnvSptJavaOpts)) != ""
+}
+
+func diagnosticsHostComponent(host string) string {
+	host = strings.TrimSpace(host)
+	if host == "" {
+		host = diagnosticsDefaultHost
+	}
+	return sanitizeHostComponent(host)
+}
+
+func diagnosticsRunID(resultsRoot string) string {
+	if strings.TrimSpace(resultsRoot) == "" {
+		return fmt.Sprintf("run-%d", time.Now().UnixNano())
+	}
+	return sanitizeHostComponent(filepath.Base(resultsRoot))
+}
+
+func diagnosticsLocalDir(resultsRoot, host, role string) string {
+	return filepath.Join(
+		resultsRoot,
+		dockerDiagnosticsResultsDirName,
+		diagnosticsHostComponent(host),
+		diagnosticsHostComponent(role),
+	)
+}
+
+func listDiagnosticFiles(dir string) ([]string, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, err
+	}
+	files := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		if entry.Name() == dockerDiagnosticsManifestFileName {
+			continue
+		}
+		files = append(files, entry.Name())
+	}
+	sort.Strings(files)
+	return files, nil
+}
+
+func writeDiagnosticsRecordManifest(localDir string, record diagnosticsRecord) error {
+	if strings.TrimSpace(localDir) == "" {
+		return nil
+	}
+	if err := os.MkdirAll(localDir, 0o750); err != nil {
+		return err
+	}
+	manifest := diagnosticsManifest{
+		SchemaVersion: 1,
+		GeneratedAt:   time.Now().UTC().Format(time.RFC3339Nano),
+		ContainerDir:  dockerDiagnosticsMount,
+		Records:       []diagnosticsRecord{record},
+	}
+	return writeDiagnosticsManifestFile(filepath.Join(localDir, dockerDiagnosticsManifestFileName), manifest)
+}
+
+func writeDiagnosticsAggregateManifest(resultsRoot string, records []diagnosticsRecord) error {
+	if strings.TrimSpace(resultsRoot) == "" || len(records) == 0 {
+		return nil
+	}
+	root := filepath.Join(resultsRoot, dockerDiagnosticsResultsDirName)
+	if err := os.MkdirAll(root, 0o750); err != nil {
+		return err
+	}
+	sort.Slice(records, func(i, j int) bool {
+		if records[i].Host == records[j].Host {
+			return records[i].Role < records[j].Role
+		}
+		return records[i].Host < records[j].Host
+	})
+	manifest := diagnosticsManifest{
+		SchemaVersion: 1,
+		GeneratedAt:   time.Now().UTC().Format(time.RFC3339Nano),
+		ContainerDir:  dockerDiagnosticsMount,
+		Records:       records,
+	}
+	return writeDiagnosticsManifestFile(filepath.Join(root, dockerDiagnosticsManifestFileName), manifest)
+}
+
+func writeDiagnosticsManifestFile(path string, manifest diagnosticsManifest) error {
+	data, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	return os.WriteFile(path, data, 0o600)
+}

--- a/cli/tui/diagnostics.go
+++ b/cli/tui/diagnostics.go
@@ -44,6 +44,12 @@ type diagnosticsManifest struct {
 }
 
 type diagnosticsCollector interface {
+	// gracefulStopForDiagnostics stops the container (if still running) before
+	// diagnostics are collected. JFR/GC artifacts (dumponexit) are only
+	// guaranteed to exist once the JVM has actually exited, so this must run
+	// before collectDiagnostics regardless of call site (Cleanup or a
+	// standalone diagnostics-only collection pass).
+	gracefulStopForDiagnostics(context.Context) error
 	collectDiagnostics(context.Context) (*diagnosticsRecord, error)
 	diagnosticsRecord() *diagnosticsRecord
 }

--- a/cli/tui/docker.go
+++ b/cli/tui/docker.go
@@ -64,21 +64,22 @@ type dockerClient interface {
 // dockerClient interface for easier testing and can delegate to a
 // RemoteDockerManager when managing remote hosts.
 type DockerManager struct {
-	client             dockerClient
-	containerID        string
-	ctx                context.Context
-	cancel             context.CancelFunc
-	hostInfo           *hostparse.HostInfo  // New field to track host information
-	remote             *RemoteDockerManager // When non-nil, delegate operations to remote CLI manager
-	nodeLogDir         string
-	nodeLogResultsRoot string
-	preserveNodeLogDir bool
-	diagnosticsRoot    string
-	diagnosticsDir     string
-	diagnosticsRole    string
-	diagnosticsDone    bool
-	diagnosticsRec     *diagnosticsRecord
-	fileMounts         []scenario.FileMount
+	client              dockerClient
+	containerID         string
+	ctx                 context.Context
+	cancel              context.CancelFunc
+	hostInfo            *hostparse.HostInfo  // New field to track host information
+	remote              *RemoteDockerManager // When non-nil, delegate operations to remote CLI manager
+	nodeLogDir          string
+	nodeLogResultsRoot  string
+	preserveNodeLogDir  bool
+	diagnosticsRoot     string
+	diagnosticsDir      string
+	diagnosticsRole     string
+	diagnosticsDone     bool
+	diagnosticsRec      *diagnosticsRecord
+	diagnosticsStopDone bool
+	fileMounts          []scenario.FileMount
 }
 
 func skipImagePull(image string) bool {
@@ -295,6 +296,7 @@ func (dm *DockerManager) prepareDiagnosticsCapture(role string) []string {
 	dm.diagnosticsRole = role
 	dm.diagnosticsDone = false
 	dm.diagnosticsRec = nil
+	dm.diagnosticsStopDone = false
 	return []string{fmt.Sprintf("%s:%s", dir, dockerDiagnosticsMount)}
 }
 
@@ -313,6 +315,7 @@ func (dm *DockerManager) cleanupDiagnosticsDir() {
 	dm.diagnosticsRole = ""
 	dm.diagnosticsDone = false
 	dm.diagnosticsRec = nil
+	dm.diagnosticsStopDone = false
 }
 
 func (dm *DockerManager) collectDiagnostics(ctx context.Context) (*diagnosticsRecord, error) {
@@ -359,6 +362,32 @@ func (dm *DockerManager) diagnosticsRecord() *diagnosticsRecord {
 		return dm.remote.diagnosticsRecord()
 	}
 	return dm.diagnosticsRec
+}
+
+// gracefulStopForDiagnostics stops the container (if still running) before
+// diagnostics are collected. JFR/GC artifacts (dumponexit) are only
+// guaranteed to exist once the JVM has exited, so this must run before
+// collectDiagnostics regardless of call site (Cleanup or a standalone
+// diagnostics-only collection pass, e.g. MultiHostOrchestrator.CollectDiagnostics).
+func (dm *DockerManager) gracefulStopForDiagnostics(ctx context.Context) error {
+	if dm.remote != nil {
+		return dm.remote.gracefulStopForDiagnostics(ctx)
+	}
+	if dm.diagnosticsDone || dm.diagnosticsStopDone {
+		return nil
+	}
+	if dm.containerID == "" || dm.diagnosticsDir == "" {
+		return nil
+	}
+	timeout := dockerDiagnosticsStopTimeoutSeconds
+	err := dm.client.ContainerStop(dm.ctx, dm.containerID, container.StopOptions{
+		Timeout: &timeout,
+	})
+	if err != nil && !isContainerAlreadyStoppedOrGone(err) {
+		return fmt.Errorf("failed to stop container for diagnostics: %w", err)
+	}
+	dm.diagnosticsStopDone = true
+	return nil
 }
 
 // ContainerDiagnosticTail returns recent container startup diagnostics from Docker logs
@@ -1079,6 +1108,7 @@ func (dm *DockerManager) Cleanup() error {
 		logging.LogError("docker", "failed to stop container", err, "container_id", dm.containerID)
 		return fmt.Errorf("failed to stop container: %w", err)
 	}
+	dm.diagnosticsStopDone = true
 
 	logging.LogContainerEvent("stopped", dm.containerID)
 

--- a/cli/tui/docker.go
+++ b/cli/tui/docker.go
@@ -7,6 +7,7 @@ package tui
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -72,6 +73,11 @@ type DockerManager struct {
 	nodeLogDir         string
 	nodeLogResultsRoot string
 	preserveNodeLogDir bool
+	diagnosticsRoot    string
+	diagnosticsDir     string
+	diagnosticsRole    string
+	diagnosticsDone    bool
+	diagnosticsRec     *diagnosticsRecord
 	fileMounts         []scenario.FileMount
 }
 
@@ -125,7 +131,7 @@ func (dm *DockerManager) HostInfo() *hostparse.HostInfo {
 }
 
 func (dm *DockerManager) baseLabels(role string) map[string]string {
-	hostName := "localhost"
+	hostName := diagnosticsDefaultHost
 	if dm.hostInfo != nil && strings.TrimSpace(dm.hostInfo.Host) != "" {
 		hostName = dm.hostInfo.Host
 	}
@@ -196,6 +202,14 @@ func (dm *DockerManager) pullImage(imageName string) error {
 
 func (dm *DockerManager) setNodeLogResultsRoot(resultsRoot string) {
 	dm.nodeLogResultsRoot = strings.TrimSpace(resultsRoot)
+	dm.setDiagnosticsResultsRoot(resultsRoot)
+}
+
+func (dm *DockerManager) setDiagnosticsResultsRoot(resultsRoot string) {
+	dm.diagnosticsRoot = strings.TrimSpace(resultsRoot)
+	if dm.remote != nil {
+		dm.remote.setDiagnosticsResultsRoot(resultsRoot)
+	}
 }
 
 func (dm *DockerManager) prepareNodeLogCapture() ([]string, []string) {
@@ -235,6 +249,116 @@ func (dm *DockerManager) prepareNodeLogCapture() ([]string, []string) {
 	dm.nodeLogDir = dir
 	dm.preserveNodeLogDir = preserve
 	return []string{fmt.Sprintf("%s:%s", dir, dockerNodeLogMount)}, []string{"SPT_LOG_DIR=" + dockerNodeLogMount}
+}
+
+func (dm *DockerManager) prepareDiagnosticsCapture(role string) []string {
+	if !diagnosticsEnabled() {
+		return nil
+	}
+	if dm.diagnosticsDir != "" {
+		dm.cleanupDiagnosticsDir()
+	}
+	host := diagnosticsDefaultHost
+	if dm.hostInfo != nil {
+		host = dm.hostInfo.Host
+	}
+	preserve := dm.diagnosticsRoot != ""
+	var (
+		dir string
+		err error
+	)
+	if preserve {
+		if dir, err = filepath.Abs(diagnosticsLocalDir(dm.diagnosticsRoot, host, role)); err != nil {
+			logging.LogWarn("docker", "failed to resolve diagnostics directory", "path", dm.diagnosticsRoot, "error", err.Error())
+			return nil
+		}
+		if err = os.RemoveAll(dir); err != nil {
+			logging.LogWarn("docker", "failed to reset diagnostics directory", "path", dir, "error", err.Error())
+			return nil
+		}
+		err = os.MkdirAll(dir, 0o777) // #nosec G301 -- container user must be able to write JVM diagnostics.
+	} else {
+		dir, err = os.MkdirTemp("", "spt-diagnostics-*")
+	}
+	if err != nil {
+		logging.LogWarn("docker", "failed to create diagnostics directory", "error", err.Error())
+		return nil
+	}
+	if err := os.Chmod(dir, 0o777); err != nil { // #nosec G302 -- container user must be able to write JVM diagnostics.
+		if !preserve {
+			_ = os.RemoveAll(dir)
+		}
+		logging.LogWarn("docker", "failed to prepare diagnostics directory permissions", "path", dir, "error", err.Error())
+		return nil
+	}
+	dm.diagnosticsDir = dir
+	dm.diagnosticsRole = role
+	dm.diagnosticsDone = false
+	dm.diagnosticsRec = nil
+	return []string{fmt.Sprintf("%s:%s", dir, dockerDiagnosticsMount)}
+}
+
+func (dm *DockerManager) cleanupDiagnosticsDir() {
+	if dm.diagnosticsDir == "" {
+		return
+	}
+	if dm.diagnosticsRoot != "" {
+		dm.diagnosticsDir = ""
+		return
+	}
+	if err := os.RemoveAll(dm.diagnosticsDir); err != nil {
+		logging.LogWarn("docker", "failed to remove diagnostics directory", "path", dm.diagnosticsDir, "error", err.Error())
+	}
+	dm.diagnosticsDir = ""
+	dm.diagnosticsRole = ""
+	dm.diagnosticsDone = false
+	dm.diagnosticsRec = nil
+}
+
+func (dm *DockerManager) collectDiagnostics(ctx context.Context) (*diagnosticsRecord, error) {
+	if dm.remote != nil {
+		return dm.remote.collectDiagnostics(ctx)
+	}
+	if dm.diagnosticsDir == "" {
+		return nil, nil
+	}
+	if dm.diagnosticsDone && dm.diagnosticsRec != nil {
+		return dm.diagnosticsRec, nil
+	}
+	host := diagnosticsDefaultHost
+	if dm.hostInfo != nil {
+		host = dm.hostInfo.Original
+	}
+	record := diagnosticsRecord{
+		Host:         host,
+		Role:         dm.diagnosticsRole,
+		ContainerID:  dm.containerID,
+		ContainerDir: dockerDiagnosticsMount,
+		LocalDir:     dm.diagnosticsDir,
+	}
+	files, err := listDiagnosticFiles(dm.diagnosticsDir)
+	if err != nil {
+		record.Error = err.Error()
+		_ = writeDiagnosticsRecordManifest(dm.diagnosticsDir, record)
+		dm.diagnosticsRec = &record
+		return &record, fmt.Errorf("list local diagnostics: %w", err)
+	}
+	record.Files = files
+	record.Collected = true
+	if err := writeDiagnosticsRecordManifest(dm.diagnosticsDir, record); err != nil {
+		dm.diagnosticsRec = &record
+		return &record, fmt.Errorf("write diagnostics manifest: %w", err)
+	}
+	dm.diagnosticsDone = true
+	dm.diagnosticsRec = &record
+	return &record, nil
+}
+
+func (dm *DockerManager) diagnosticsRecord() *diagnosticsRecord {
+	if dm.remote != nil {
+		return dm.remote.diagnosticsRecord()
+	}
+	return dm.diagnosticsRec
 }
 
 // ContainerDiagnosticTail returns recent container startup diagnostics from Docker logs
@@ -340,6 +464,12 @@ func (dm *DockerManager) StartContainer(image string, cmd []string) (string, err
 		return "", err
 	}
 
+	var envVars []string
+	if v := os.Getenv(constants.EnvSptJavaOpts); v != "" {
+		envVars = append(envVars, constants.EnvSptJavaOpts+"="+v)
+	}
+	diagnosticBinds := dm.prepareDiagnosticsCapture(constants.DockerRoleNode)
+
 	// Create container
 	resp, err := dm.client.ContainerCreate(dm.ctx, &container.Config{
 		Image:        image,
@@ -347,10 +477,12 @@ func (dm *DockerManager) StartContainer(image string, cmd []string) (string, err
 		Tty:          false,
 		AttachStdout: true,
 		AttachStderr: true,
-	}, nil, nil, nil, "")
+		Env:          envVars,
+	}, &container.HostConfig{Binds: diagnosticBinds}, nil, nil, "")
 
 	if err != nil {
 		logging.LogError("docker", "failed to create container", err, "image", image)
+		dm.cleanupDiagnosticsDir()
 		return "", fmt.Errorf("failed to create container: %w", err)
 	}
 
@@ -360,6 +492,7 @@ func (dm *DockerManager) StartContainer(image string, cmd []string) (string, err
 	// Start container
 	if err := dm.client.ContainerStart(dm.ctx, resp.ID, container.StartOptions{}); err != nil {
 		logging.LogError("docker", "failed to start container", err, "container_id", resp.ID)
+		dm.cleanupDiagnosticsDir()
 		return "", fmt.Errorf("failed to start container: %w", err)
 	}
 
@@ -392,9 +525,10 @@ func (dm *DockerManager) StartContainerWithScenario(image string, scenarioPath s
 
 	// Forward SPT_JAVA_OPTS to the container so the entrypoint can append it to JAVA_OPTS
 	var envVars []string
-	if v := os.Getenv("SPT_JAVA_OPTS"); v != "" {
-		envVars = append(envVars, "SPT_JAVA_OPTS="+v)
+	if v := os.Getenv(constants.EnvSptJavaOpts); v != "" {
+		envVars = append(envVars, constants.EnvSptJavaOpts+"="+v)
 	}
+	diagnosticBinds := dm.prepareDiagnosticsCapture(constants.DockerRoleNode)
 
 	// Create container with volume mount
 	resp, err := dm.client.ContainerCreate(dm.ctx, &container.Config{
@@ -405,13 +539,14 @@ func (dm *DockerManager) StartContainerWithScenario(image string, scenarioPath s
 		AttachStderr: true,
 		Env:          envVars,
 	}, &container.HostConfig{
-		Binds: append([]string{
+		Binds: append(append([]string{
 			fmt.Sprintf("%s:/tmp/scenario.js:ro", absScenarioPath),
-		}, dm.itemFileBindSpecs()...),
+		}, diagnosticBinds...), dm.itemFileBindSpecs()...),
 	}, nil, nil, "")
 
 	if err != nil {
 		logging.LogError("docker", "failed to create container", err, "image", image)
+		dm.cleanupDiagnosticsDir()
 		return "", fmt.Errorf("failed to create container: %w", err)
 	}
 
@@ -421,6 +556,7 @@ func (dm *DockerManager) StartContainerWithScenario(image string, scenarioPath s
 	// Start container
 	if err := dm.client.ContainerStart(dm.ctx, resp.ID, container.StartOptions{}); err != nil {
 		logging.LogError("docker", "failed to start container", err, "container_id", resp.ID)
+		dm.cleanupDiagnosticsDir()
 		return "", fmt.Errorf("failed to start container: %w", err)
 	}
 
@@ -465,17 +601,18 @@ func (dm *DockerManager) StartContainerInNodeMode(image string, apiPort string, 
 	}
 
 	// Forward SPT_JAVA_OPTS to the container so the entrypoint can append it to JAVA_OPTS
-	if v := os.Getenv("SPT_JAVA_OPTS"); v != "" {
-		envVars = append(envVars, "SPT_JAVA_OPTS="+v)
+	if v := os.Getenv(constants.EnvSptJavaOpts); v != "" {
+		envVars = append(envVars, constants.EnvSptJavaOpts+"="+v)
 	}
 	logBinds, logEnv := dm.prepareNodeLogCapture()
+	diagnosticBinds := dm.prepareDiagnosticsCapture(constants.DockerRoleNode)
 	envVars = append(envVars, logEnv...)
 
 	labels := dm.baseLabels(constants.DockerRoleNode)
 
 	useHostNetwork := selectedNodeNetworkMode(networkMode) == command.NetworkModeHost
 	hostConfig := &container.HostConfig{
-		Binds: append(logBinds, dm.itemFileBindSpecs()...),
+		Binds: append(append(logBinds, diagnosticBinds...), dm.itemFileBindSpecs()...),
 	}
 	if useHostNetwork {
 		hostConfig.NetworkMode = container.NetworkMode(command.NetworkModeHost)
@@ -518,6 +655,7 @@ func (dm *DockerManager) StartContainerInNodeMode(image string, apiPort string, 
 	if err != nil {
 		logging.LogError("docker", "failed to create container in node mode", err, "image", image, "port", apiPort)
 		dm.cleanupNodeLogDir()
+		dm.cleanupDiagnosticsDir()
 		return "", fmt.Errorf("failed to create container: %w", err)
 	}
 
@@ -536,6 +674,7 @@ func (dm *DockerManager) StartContainerInNodeMode(image string, apiPort string, 
 		}
 		dm.containerID = ""
 		dm.cleanupNodeLogDir()
+		dm.cleanupDiagnosticsDir()
 
 		return "", fmt.Errorf("failed to start container: %w", err)
 	}
@@ -601,9 +740,10 @@ func (dm *DockerManager) StartWorkerNodeContainer(image string, rmiHostname stri
 		fmt.Sprintf("JAVA_TOOL_OPTIONS=-Djava.rmi.server.hostname=%s", rmiHostname),
 	}
 	// Forward SPT_JAVA_OPTS to the container so the entrypoint can append it to JAVA_OPTS
-	if v := os.Getenv("SPT_JAVA_OPTS"); v != "" {
-		workerEnv = append(workerEnv, "SPT_JAVA_OPTS="+v)
+	if v := os.Getenv(constants.EnvSptJavaOpts); v != "" {
+		workerEnv = append(workerEnv, constants.EnvSptJavaOpts+"="+v)
 	}
+	diagnosticBinds := dm.prepareDiagnosticsCapture(constants.DockerRoleWorker)
 	containerConfig := &container.Config{
 		Image:        image,
 		Cmd:          cmd,
@@ -616,7 +756,7 @@ func (dm *DockerManager) StartWorkerNodeContainer(image string, rmiHostname stri
 
 	hostConfig := &container.HostConfig{
 		PortBindings: portBindings,
-		Binds:        dm.itemFileBindSpecs(),
+		Binds:        append(diagnosticBinds, dm.itemFileBindSpecs()...),
 	}
 
 	// RDMA device passthrough when SPT_RDMA is enabled
@@ -640,6 +780,7 @@ func (dm *DockerManager) StartWorkerNodeContainer(image string, rmiHostname stri
 	resp, err := dm.client.ContainerCreate(dm.ctx, containerConfig, hostConfig, nil, nil, "")
 	if err != nil {
 		logging.LogError("docker", "failed to create worker node container", err, "image", image, "rmi_hostname", rmiHostname)
+		dm.cleanupDiagnosticsDir()
 		return "", fmt.Errorf("failed to create container: %w", err)
 	}
 
@@ -657,6 +798,7 @@ func (dm *DockerManager) StartWorkerNodeContainer(image string, rmiHostname stri
 			logging.LogContainerEvent("cleaned up after start failure", dm.containerID)
 		}
 		dm.containerID = ""
+		dm.cleanupDiagnosticsDir()
 
 		return "", fmt.Errorf("failed to start container: %w", err)
 	}
@@ -692,11 +834,17 @@ func (dm *DockerManager) StartEntryNodeContainer(image string, workerAddresses [
 
 	labels := dm.baseLabels(constants.DockerRoleEntry)
 	useHostNetwork := selectedNodeNetworkMode(networkMode) == command.NetworkModeHost
+	var envVars []string
+	if v := os.Getenv(constants.EnvSptJavaOpts); v != "" {
+		envVars = append(envVars, constants.EnvSptJavaOpts+"="+v)
+	}
+	diagnosticBinds := dm.prepareDiagnosticsCapture(constants.DockerRoleEntry)
 	containerConfig := &container.Config{
 		Image:        image,
 		Cmd:          cmd,
 		AttachStdout: true,
 		AttachStderr: true,
+		Env:          envVars,
 		Labels:       labels,
 	}
 	if !useHostNetwork {
@@ -705,7 +853,7 @@ func (dm *DockerManager) StartEntryNodeContainer(image string, workerAddresses [
 		}
 	}
 
-	hostConfig := &container.HostConfig{Binds: dm.itemFileBindSpecs()}
+	hostConfig := &container.HostConfig{Binds: append(diagnosticBinds, dm.itemFileBindSpecs()...)}
 	if useHostNetwork {
 		hostConfig.NetworkMode = container.NetworkMode(command.NetworkModeHost)
 	} else {
@@ -740,6 +888,7 @@ func (dm *DockerManager) StartEntryNodeContainer(image string, workerAddresses [
 	resp, err := dm.client.ContainerCreate(dm.ctx, containerConfig, hostConfig, nil, nil, "")
 	if err != nil {
 		logging.LogError("docker", "failed to create entry node container", err, "image", image, "workers", len(workerAddresses))
+		dm.cleanupDiagnosticsDir()
 		return "", fmt.Errorf("failed to create container: %w", err)
 	}
 
@@ -757,6 +906,7 @@ func (dm *DockerManager) StartEntryNodeContainer(image string, workerAddresses [
 			logging.LogContainerEvent("cleaned up after start failure", dm.containerID)
 		}
 		dm.containerID = ""
+		dm.cleanupDiagnosticsDir()
 
 		return "", fmt.Errorf("failed to start container: %w", err)
 	}
@@ -910,6 +1060,7 @@ func (dm *DockerManager) Cleanup() error {
 		return dm.remote.Cleanup()
 	}
 	defer dm.cleanupNodeLogDir()
+	defer dm.cleanupDiagnosticsDir()
 	if dm.containerID == "" {
 		return nil
 	}
@@ -918,6 +1069,9 @@ func (dm *DockerManager) Cleanup() error {
 
 	// Stop the container
 	timeout := 10
+	if dm.diagnosticsDir != "" {
+		timeout = dockerDiagnosticsStopTimeoutSeconds
+	}
 	err := dm.client.ContainerStop(dm.ctx, dm.containerID, container.StopOptions{
 		Timeout: &timeout,
 	})
@@ -928,17 +1082,35 @@ func (dm *DockerManager) Cleanup() error {
 
 	logging.LogContainerEvent("stopped", dm.containerID)
 
+	var cleanupErrs []error
+	var diagnosticsRecords []diagnosticsRecord
+	if dm.diagnosticsDir != "" && !dm.diagnosticsDone {
+		record, err := dm.collectDiagnostics(dm.ctx)
+		if record != nil {
+			diagnosticsRecords = append(diagnosticsRecords, *record)
+		}
+		if err != nil {
+			logging.LogWarn("docker", "diagnostics collection failed", "path", dm.diagnosticsDir, "error", err.Error())
+			cleanupErrs = append(cleanupErrs, err)
+		}
+	}
+
 	// Remove the container
 	err = dm.client.ContainerRemove(dm.ctx, dm.containerID, container.RemoveOptions{
 		Force: true,
 	})
 	if err != nil && !isNoSuchContainer(err) {
 		logging.LogError("docker", "failed to remove container", err, "container_id", dm.containerID)
-		return fmt.Errorf("failed to remove container: %w", err)
+		cleanupErrs = append(cleanupErrs, fmt.Errorf("failed to remove container: %w", err))
+		return errors.Join(cleanupErrs...)
 	}
 
 	logging.LogContainerEvent("removed", dm.containerID)
-	return nil
+	dm.containerID = ""
+	if err := writeDiagnosticsAggregateManifest(dm.diagnosticsRoot, diagnosticsRecords); err != nil {
+		cleanupErrs = append(cleanupErrs, err)
+	}
+	return errors.Join(cleanupErrs...)
 }
 
 func (dm *DockerManager) cleanupNodeLogDir() {

--- a/cli/tui/docker_client_shim_test.go
+++ b/cli/tui/docker_client_shim_test.go
@@ -30,6 +30,7 @@ type fakeDockerClient struct {
 	inspectErr            error
 	logBody               []byte
 	logOptions            container.LogsOptions
+	stopOptions           container.StopOptions
 	stopErr               error
 	removeErr             error
 	createHostConfig      *container.HostConfig
@@ -62,6 +63,7 @@ func (f *fakeDockerClient) ContainerStart(ctx context.Context, containerID strin
 }
 func (f *fakeDockerClient) ContainerStop(ctx context.Context, containerID string, options container.StopOptions) error {
 	f.stopped++
+	f.stopOptions = options
 	return f.stopErr
 }
 func (f *fakeDockerClient) ContainerRemove(ctx context.Context, containerID string, options container.RemoveOptions) error {
@@ -345,5 +347,50 @@ func TestStartContainerInNodeModeUsesConfiguredNodeLogDir(t *testing.T) {
 	}
 	if !containsString(f.createContainerConfig.Env, "SPT_LOG_DIR="+dockerNodeLogMount) {
 		t.Fatalf("env = %v, want SPT_LOG_DIR", f.createContainerConfig.Env)
+	}
+}
+
+func TestStartContainerInNodeModeUsesDiagnosticsMountWhenJavaOptsSet(t *testing.T) {
+	t.Setenv(constants.EnvSptJavaOpts, "-Xlog:gc*:file=/spt-diagnostics/spt-gc-%p.log")
+	resultsRoot := t.TempDir()
+	f := &fakeDockerClient{}
+	dm := &DockerManager{client: f, ctx: context.Background()}
+	dm.setDiagnosticsResultsRoot(resultsRoot)
+
+	if _, err := dm.StartContainerInNodeMode("test-image", "10080", constants.BridgeNetworkMode); err != nil {
+		t.Fatalf("StartContainerInNodeMode() error = %v", err)
+	}
+	wantDir := filepath.Join(resultsRoot, dockerDiagnosticsResultsDirName, "localhost", constants.DockerRoleNode)
+	wantBind := wantDir + ":" + dockerDiagnosticsMount
+	if !containsString(f.createHostConfig.Binds, wantBind) {
+		t.Fatalf("host binds = %v, want %q", f.createHostConfig.Binds, wantBind)
+	}
+	if !containsString(f.createContainerConfig.Env, constants.EnvSptJavaOpts+"=-Xlog:gc*:file=/spt-diagnostics/spt-gc-%p.log") {
+		t.Fatalf("env = %v, want SPT_JAVA_OPTS", f.createContainerConfig.Env)
+	}
+}
+
+func TestDockerManager_CleanupUsesDiagnosticsStopTimeoutAndManifest(t *testing.T) {
+	t.Setenv(constants.EnvSptJavaOpts, "-Xlog:gc*:file=/spt-diagnostics/spt-gc-%p.log")
+	resultsRoot := t.TempDir()
+	f := &fakeDockerClient{}
+	dm := &DockerManager{client: f, ctx: context.Background()}
+	dm.setDiagnosticsResultsRoot(resultsRoot)
+
+	if _, err := dm.StartContainerInNodeMode("test-image", "10080", constants.BridgeNetworkMode); err != nil {
+		t.Fatalf("StartContainerInNodeMode() error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dm.diagnosticsDir, "spt-gc-123.log"), []byte("gc"), 0o600); err != nil {
+		t.Fatalf("write diagnostics fixture: %v", err)
+	}
+	if err := dm.Cleanup(); err != nil {
+		t.Fatalf("Cleanup() error = %v", err)
+	}
+	if f.stopOptions.Timeout == nil || *f.stopOptions.Timeout != dockerDiagnosticsStopTimeoutSeconds {
+		t.Fatalf("stop timeout = %v, want %d", f.stopOptions.Timeout, dockerDiagnosticsStopTimeoutSeconds)
+	}
+	manifest := filepath.Join(resultsRoot, dockerDiagnosticsResultsDirName, "localhost", constants.DockerRoleNode, dockerDiagnosticsManifestFileName)
+	if _, err := os.Stat(manifest); err != nil {
+		t.Fatalf("expected diagnostics manifest: %v", err)
 	}
 }

--- a/cli/tui/orchestrator_multi.go
+++ b/cli/tui/orchestrator_multi.go
@@ -81,6 +81,7 @@ type MultiHostOrchestrator struct {
 	apiPort         string
 	attachWorkers   bool
 	itemFileMounts  []scenario.FileMount
+	resultsRoot     string
 
 	// RMI Configuration
 	networkMode  string
@@ -178,6 +179,13 @@ func (o *MultiHostOrchestrator) SetImage(image string) {
 	o.mu.Lock()
 	defer o.mu.Unlock()
 	o.image = image
+}
+
+// SetResultsRoot configures the run results directory used for local diagnostics collection.
+func (o *MultiHostOrchestrator) SetResultsRoot(resultsRoot string) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.resultsRoot = strings.TrimSpace(resultsRoot)
 }
 
 // SetAPIPort overrides the Spt API port used for node startup and polling.
@@ -306,6 +314,10 @@ func (o *MultiHostOrchestrator) ConnectHosts(ctx context.Context) error {
 					fmt.Errorf("host %s: %w", h.Info.Original, err))
 				return
 			}
+			o.mu.Lock()
+			resultsRoot := o.resultsRoot
+			o.mu.Unlock()
+			dm.setDiagnosticsResultsRoot(resultsRoot)
 
 			// Run preflight checks (docker availability, image presence, port readiness)
 			if o.preflight != nil {
@@ -682,6 +694,7 @@ func (o *MultiHostOrchestrator) StopAllContainers(_ context.Context) error {
 	o.notifyf("🛑 Stopping containers on %d host(s)...", len(runningHosts))
 
 	var wg sync.WaitGroup
+	recordsCh := make(chan diagnosticsRecord, len(runningHosts))
 	for _, host := range runningHosts {
 		wg.Add(1)
 		go func(h *HostConnection) {
@@ -723,6 +736,11 @@ func (o *MultiHostOrchestrator) StopAllContainers(_ context.Context) error {
 			}
 
 			err := h.DockerManager.Cleanup()
+			if collector, ok := h.DockerManager.(diagnosticsCollector); ok {
+				if record := collector.diagnosticsRecord(); record != nil {
+					recordsCh <- *record
+				}
+			}
 			if err != nil {
 				logging.LogError("docker-multi", "container stop failed",
 					fmt.Errorf("host %s container %s: %w", h.Info.Original, containerID, err),
@@ -741,7 +759,65 @@ func (o *MultiHostOrchestrator) StopAllContainers(_ context.Context) error {
 	}
 
 	wg.Wait()
+	close(recordsCh)
+	var records []diagnosticsRecord
+	for record := range recordsCh {
+		records = append(records, record)
+	}
+	if err := writeDiagnosticsAggregateManifest(o.resultsRoot, records); err != nil {
+		logging.LogWarn("docker-multi", "failed to write diagnostics manifest", "error", err.Error())
+	}
 	return nil
+}
+
+// CollectDiagnostics copies diagnostics from all managed hosts into the run results directory.
+func (o *MultiHostOrchestrator) CollectDiagnostics(ctx context.Context) error {
+	type diagnosticsResult struct {
+		host   string
+		record *diagnosticsRecord
+		err    error
+	}
+
+	var wg sync.WaitGroup
+	resultsCh := make(chan diagnosticsResult, len(o.hosts))
+	for _, host := range o.hosts {
+		if host == nil || !host.IsManaged() || host.DockerManager == nil {
+			continue
+		}
+		collector, ok := host.DockerManager.(diagnosticsCollector)
+		if !ok {
+			continue
+		}
+		wg.Add(1)
+		go func(h *HostConnection, c diagnosticsCollector) {
+			defer wg.Done()
+			hostCtx, cancel := context.WithTimeout(ctx, constants.DiagnosticsCollectionTimeout)
+			defer cancel()
+			record, err := c.collectDiagnostics(hostCtx)
+			resultsCh <- diagnosticsResult{host: h.Info.Original, record: record, err: err}
+		}(host, collector)
+	}
+
+	wg.Wait()
+	close(resultsCh)
+
+	var records []diagnosticsRecord
+	var errs []error
+	for result := range resultsCh {
+		if result.record != nil {
+			records = append(records, *result.record)
+		}
+		if result.err != nil {
+			errs = append(errs, fmt.Errorf("%s: %w", result.host, result.err))
+			logging.LogWarn("docker-multi", "diagnostics collection failed",
+				"host", result.host,
+				"error", result.err.Error())
+		}
+	}
+	if err := writeDiagnosticsAggregateManifest(o.resultsRoot, records); err != nil {
+		errs = append(errs, err)
+	}
+	return errors.Join(errs...)
 }
 
 // GetHostCount returns the total number of hosts

--- a/cli/tui/orchestrator_multi.go
+++ b/cli/tui/orchestrator_multi.go
@@ -793,6 +793,16 @@ func (o *MultiHostOrchestrator) CollectDiagnostics(ctx context.Context) error {
 			defer wg.Done()
 			hostCtx, cancel := context.WithTimeout(ctx, constants.DiagnosticsCollectionTimeout)
 			defer cancel()
+			// JFR/GC artifacts use dumponexit, which only guarantees the file
+			// exists once the JVM has exited. Stop the container first so
+			// collection isn't racing a still-running process; this is a
+			// standalone collection pass (unlike Cleanup) so nothing else in
+			// this call path stops the container for us.
+			if err := c.gracefulStopForDiagnostics(hostCtx); err != nil {
+				logging.LogWarn("docker-multi", "diagnostics graceful stop failed",
+					"host", h.Info.Original,
+					"error", err.Error())
+			}
 			record, err := c.collectDiagnostics(hostCtx)
 			resultsCh <- diagnosticsResult{host: h.Info.Original, record: record, err: err}
 		}(host, collector)

--- a/cli/tui/orchestrator_multi.go
+++ b/cli/tui/orchestrator_multi.go
@@ -98,6 +98,12 @@ type MultiHostOrchestrator struct {
 	// Optional notifier for user-facing progress messages (TUI-safe).
 	// If nil, messages are printed to stdout as before.
 	notifier func(string)
+
+	// Guards FinalizeDiagnosticsAndCleanup so it only runs once regardless of
+	// which trigger reaches it first (the auto-results pre-summary hook, or
+	// a caller-side timeout fallback) — see FinalizeDiagnosticsAndCleanup.
+	finalizeOnce sync.Once
+	finalizeErr  error
 }
 
 // RMIConfig holds RMI configuration parameters
@@ -828,6 +834,29 @@ func (o *MultiHostOrchestrator) CollectDiagnostics(ctx context.Context) error {
 		errs = append(errs, err)
 	}
 	return errors.Join(errs...)
+}
+
+// FinalizeDiagnosticsAndCleanup collects diagnostics from every managed host
+// and then fully stops/removes their containers (and cleans up remote
+// staging). It is the single, canonical end-of-run action for delegated
+// auto-results shutdown: without it, containers were only ever stopped as a
+// side effect of collecting diagnostics (never removed, staging never
+// cleaned up) on the normal-completion path, and a slow diagnostics copy
+// could otherwise race a caller-side timeout fallback trying to do the same
+// cleanup concurrently.
+//
+// Safe to call more than once, including concurrently, from different
+// triggers (e.g. once from the auto-results pre-summary hook, once from a
+// timeout fallback if the hook is still running when the wait expires): only
+// the first call does the work; every call — first or not — blocks until
+// that single execution finishes and observes the same result.
+func (o *MultiHostOrchestrator) FinalizeDiagnosticsAndCleanup(ctx context.Context) error {
+	o.finalizeOnce.Do(func() {
+		diagErr := o.CollectDiagnostics(ctx)
+		stopErr := o.StopAllContainers(ctx)
+		o.finalizeErr = errors.Join(diagErr, stopErr)
+	})
+	return o.finalizeErr
 }
 
 // GetHostCount returns the total number of hosts

--- a/cli/tui/orchestrator_multi_test.go
+++ b/cli/tui/orchestrator_multi_test.go
@@ -243,6 +243,11 @@ func (m *orderedDiagnosticsDockerManager) Cleanup() error {
 	return m.MockDockerManager.Cleanup()
 }
 
+func (m *orderedDiagnosticsDockerManager) gracefulStopForDiagnostics(context.Context) error {
+	m.appendEvent("stop")
+	return nil
+}
+
 func (m *orderedDiagnosticsDockerManager) collectDiagnostics(context.Context) (*diagnosticsRecord, error) {
 	m.appendEvent("collect")
 	return m.record, nil
@@ -290,6 +295,10 @@ type blockingDiagnosticsDockerManager struct {
 	host    string
 	started chan<- string
 	release <-chan struct{}
+}
+
+func (m *blockingDiagnosticsDockerManager) gracefulStopForDiagnostics(context.Context) error {
+	return nil
 }
 
 func (m *blockingDiagnosticsDockerManager) collectDiagnostics(ctx context.Context) (*diagnosticsRecord, error) {
@@ -359,6 +368,86 @@ func TestMultiHostOrchestrator_CollectDiagnosticsRunsHostsConcurrently(t *testin
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("CollectDiagnostics did not complete after host collectors were released")
+	}
+}
+
+type collectDiagnosticsOrderDockerManager struct {
+	*MockDockerManager
+
+	mu      sync.Mutex
+	events  []string
+	stopErr error
+}
+
+func (m *collectDiagnosticsOrderDockerManager) gracefulStopForDiagnostics(context.Context) error {
+	m.mu.Lock()
+	m.events = append(m.events, "stop")
+	m.mu.Unlock()
+	return m.stopErr
+}
+
+func (m *collectDiagnosticsOrderDockerManager) collectDiagnostics(context.Context) (*diagnosticsRecord, error) {
+	m.mu.Lock()
+	m.events = append(m.events, "collect")
+	m.mu.Unlock()
+	return &diagnosticsRecord{Host: "host1", Collected: true}, nil
+}
+
+func (m *collectDiagnosticsOrderDockerManager) diagnosticsRecord() *diagnosticsRecord {
+	return nil
+}
+
+func (m *collectDiagnosticsOrderDockerManager) eventList() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]string(nil), m.events...)
+}
+
+// TestMultiHostOrchestrator_CollectDiagnosticsStopsBeforeCollecting guards against
+// regressing to collecting JFR/GC artifacts (dumponexit) while the container
+// (and therefore the JVM) may still be running: unlike StopAllContainers/Cleanup,
+// this standalone diagnostics-only pass has nothing else in its call path that
+// stops the container first, so CollectDiagnostics must do it itself.
+func TestMultiHostOrchestrator_CollectDiagnosticsStopsBeforeCollecting(t *testing.T) {
+	hostInfos := []*hostparse.HostInfo{{Host: "host1", Original: "host1"}}
+	orchestrator := NewMultiHostOrchestrator(hostInfos, 1)
+	orchestrator.SetResultsRoot(t.TempDir())
+	fake := &collectDiagnosticsOrderDockerManager{MockDockerManager: NewMockDockerManager()}
+	orchestrator.hosts[0].SetManaged(true)
+	orchestrator.hosts[0].DockerManager = fake
+
+	if err := orchestrator.CollectDiagnostics(context.Background()); err != nil {
+		t.Fatalf("CollectDiagnostics() error = %v", err)
+	}
+
+	got := strings.Join(fake.eventList(), ",")
+	if got != "stop,collect" {
+		t.Fatalf("diagnostics order = %q, want stop,collect", got)
+	}
+}
+
+// TestMultiHostOrchestrator_CollectDiagnosticsStillCollectsWhenStopFails covers
+// the best-effort path: a stop failure (e.g. a transient SSH error) must not
+// abandon collection outright, since the remote/local diagnostics files may
+// still be readable even if we can't confirm the container fully stopped.
+func TestMultiHostOrchestrator_CollectDiagnosticsStillCollectsWhenStopFails(t *testing.T) {
+	hostInfos := []*hostparse.HostInfo{{Host: "host1", Original: "host1"}}
+	orchestrator := NewMultiHostOrchestrator(hostInfos, 1)
+	orchestrator.SetResultsRoot(t.TempDir())
+	fake := &collectDiagnosticsOrderDockerManager{
+		MockDockerManager: NewMockDockerManager(),
+		stopErr:           fmt.Errorf("ssh timeout"),
+	}
+	orchestrator.hosts[0].SetManaged(true)
+	orchestrator.hosts[0].DockerManager = fake
+
+	if err := orchestrator.CollectDiagnostics(context.Background()); err != nil {
+		t.Fatalf("CollectDiagnostics() error = %v", err)
+	}
+
+	got := strings.Join(fake.eventList(), ",")
+	if got != "stop,collect" {
+		t.Fatalf("diagnostics order = %q, want stop,collect even when stop failed (best-effort collection)", got)
 	}
 }
 

--- a/cli/tui/orchestrator_multi_test.go
+++ b/cli/tui/orchestrator_multi_test.go
@@ -451,6 +451,114 @@ func TestMultiHostOrchestrator_CollectDiagnosticsStillCollectsWhenStopFails(t *t
 	}
 }
 
+type finalizeOrderDockerManager struct {
+	*MockDockerManager
+
+	mu     sync.Mutex
+	events []string
+}
+
+func (m *finalizeOrderDockerManager) gracefulStopForDiagnostics(context.Context) error {
+	m.record("stop")
+	return nil
+}
+
+func (m *finalizeOrderDockerManager) collectDiagnostics(context.Context) (*diagnosticsRecord, error) {
+	m.record("collect")
+	return &diagnosticsRecord{Host: "host1", Collected: true}, nil
+}
+
+func (m *finalizeOrderDockerManager) diagnosticsRecord() *diagnosticsRecord {
+	return nil
+}
+
+func (m *finalizeOrderDockerManager) Cleanup() error {
+	m.record("cleanup")
+	return m.MockDockerManager.Cleanup()
+}
+
+func (m *finalizeOrderDockerManager) record(event string) {
+	m.mu.Lock()
+	m.events = append(m.events, event)
+	m.mu.Unlock()
+}
+
+func (m *finalizeOrderDockerManager) eventList() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]string(nil), m.events...)
+}
+
+func newFinalizeTestOrchestrator(t *testing.T) (*MultiHostOrchestrator, *finalizeOrderDockerManager) {
+	t.Helper()
+	hostInfos := []*hostparse.HostInfo{{Host: "host1", Original: "host1"}}
+	orchestrator := NewMultiHostOrchestrator(hostInfos, 1)
+	orchestrator.SetResultsRoot(t.TempDir())
+	h := orchestrator.hosts[0]
+	h.SetStatus(HostStatusRunning)
+	h.ContainerID = "container-1"
+	fake := &finalizeOrderDockerManager{MockDockerManager: NewMockDockerManager()}
+	h.DockerManager = fake
+	h.SetManaged(true)
+	return orchestrator, fake
+}
+
+// TestMultiHostOrchestrator_FinalizeDiagnosticsAndCleanup_CollectsBeforeStopping
+// covers the canonical end-of-run sequence: diagnostics must be collected
+// (which itself stops the container first, see gracefulStopForDiagnostics)
+// before the container is fully removed and staging cleaned up.
+func TestMultiHostOrchestrator_FinalizeDiagnosticsAndCleanup_CollectsBeforeStopping(t *testing.T) {
+	orchestrator, fake := newFinalizeTestOrchestrator(t)
+
+	if err := orchestrator.FinalizeDiagnosticsAndCleanup(context.Background()); err != nil {
+		t.Fatalf("FinalizeDiagnosticsAndCleanup() error = %v", err)
+	}
+
+	got := strings.Join(fake.eventList(), ",")
+	if got != "stop,collect,cleanup" {
+		t.Fatalf("finalize order = %q, want stop,collect,cleanup", got)
+	}
+}
+
+// TestMultiHostOrchestrator_FinalizeDiagnosticsAndCleanup_RunsOnceConcurrently
+// guards the concurrency hazard this method exists to prevent: the
+// auto-results pre-summary hook and a caller-side timeout fallback could
+// both try to finalize the same run at once (e.g. a slow diagnostics copy
+// still running when the outer wait expires). Only one of them must
+// actually do the work.
+func TestMultiHostOrchestrator_FinalizeDiagnosticsAndCleanup_RunsOnceConcurrently(t *testing.T) {
+	orchestrator, fake := newFinalizeTestOrchestrator(t)
+
+	const callers = 5
+	var wg sync.WaitGroup
+	errs := make([]error, callers)
+	for i := 0; i < callers; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			errs[idx] = orchestrator.FinalizeDiagnosticsAndCleanup(context.Background())
+		}(i)
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("call %d error = %v, want nil", i, err)
+		}
+	}
+
+	cleanupCount := 0
+	for _, event := range fake.eventList() {
+		if event == "cleanup" {
+			cleanupCount++
+		}
+	}
+	if cleanupCount != 1 {
+		t.Fatalf("cleanup ran %d times across %d concurrent callers, want exactly 1 (events: %v)",
+			cleanupCount, callers, fake.eventList())
+	}
+}
+
 func TestMultiHostOrchestrator_GetHostsInfo_CompleteInfo(t *testing.T) {
 	hostInfos := []*hostparse.HostInfo{
 		{Host: "host1", IsLocal: false, Original: "host1"},

--- a/cli/tui/orchestrator_multi_test.go
+++ b/cli/tui/orchestrator_multi_test.go
@@ -220,6 +220,148 @@ func TestMultiHostOrchestrator_StopAllContainers_ReadySnapshots(t *testing.T) {
 	}
 }
 
+type orderedDiagnosticsDockerManager struct {
+	*MockDockerManager
+
+	mu     sync.Mutex
+	events []string
+	record *diagnosticsRecord
+}
+
+func newOrderedDiagnosticsDockerManager() *orderedDiagnosticsDockerManager {
+	return &orderedDiagnosticsDockerManager{MockDockerManager: NewMockDockerManager()}
+}
+
+func (m *orderedDiagnosticsDockerManager) Cleanup() error {
+	m.appendEvent("cleanup")
+	m.record = &diagnosticsRecord{
+		Host:        "host1",
+		Role:        constants.DockerRoleWorker,
+		Collected:   true,
+		ContainerID: "container-1",
+	}
+	return m.MockDockerManager.Cleanup()
+}
+
+func (m *orderedDiagnosticsDockerManager) collectDiagnostics(context.Context) (*diagnosticsRecord, error) {
+	m.appendEvent("collect")
+	return m.record, nil
+}
+
+func (m *orderedDiagnosticsDockerManager) diagnosticsRecord() *diagnosticsRecord {
+	m.appendEvent("record")
+	return m.record
+}
+
+func (m *orderedDiagnosticsDockerManager) appendEvent(event string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.events = append(m.events, event)
+}
+
+func (m *orderedDiagnosticsDockerManager) eventList() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]string(nil), m.events...)
+}
+
+func TestMultiHostOrchestrator_StopAllContainers_DiagnosticsAfterCleanup(t *testing.T) {
+	hostInfos := []*hostparse.HostInfo{{Host: "host1", Original: "host1"}}
+	orchestrator := NewMultiHostOrchestrator(hostInfos, 1)
+	h := orchestrator.hosts[0]
+	h.SetStatus(HostStatusRunning)
+	h.ContainerID = "container-1"
+	h.DockerManager = newOrderedDiagnosticsDockerManager()
+	h.SetManaged(true)
+
+	if err := orchestrator.StopAllContainers(context.Background()); err != nil {
+		t.Fatalf("StopAllContainers() error = %v", err)
+	}
+
+	got := strings.Join(h.DockerManager.(*orderedDiagnosticsDockerManager).eventList(), ",")
+	if got != "cleanup,record" {
+		t.Fatalf("diagnostics order = %q, want cleanup,record", got)
+	}
+}
+
+type blockingDiagnosticsDockerManager struct {
+	*MockDockerManager
+
+	host    string
+	started chan<- string
+	release <-chan struct{}
+}
+
+func (m *blockingDiagnosticsDockerManager) collectDiagnostics(ctx context.Context) (*diagnosticsRecord, error) {
+	select {
+	case m.started <- m.host:
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+	select {
+	case <-m.release:
+		return &diagnosticsRecord{
+			Host:      m.host,
+			Role:      constants.DockerRoleWorker,
+			Collected: true,
+		}, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
+func (m *blockingDiagnosticsDockerManager) diagnosticsRecord() *diagnosticsRecord {
+	return nil
+}
+
+func TestMultiHostOrchestrator_CollectDiagnosticsRunsHostsConcurrently(t *testing.T) {
+	hostInfos := []*hostparse.HostInfo{
+		{Host: "host1", Original: "host1"},
+		{Host: "host2", Original: "host2"},
+	}
+	orchestrator := NewMultiHostOrchestrator(hostInfos, 2)
+	orchestrator.SetResultsRoot(t.TempDir())
+
+	started := make(chan string, len(hostInfos))
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	for _, host := range orchestrator.hosts {
+		host.SetManaged(true)
+		host.DockerManager = &blockingDiagnosticsDockerManager{
+			MockDockerManager: NewMockDockerManager(),
+			host:              host.Info.Original,
+			started:           started,
+			release:           release,
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	done := make(chan error, 1)
+	go func() {
+		done <- orchestrator.CollectDiagnostics(ctx)
+	}()
+
+	for range hostInfos {
+		select {
+		case <-started:
+		case <-time.After(500 * time.Millisecond):
+			releaseOnce.Do(func() { close(release) })
+			t.Fatal("CollectDiagnostics did not start all host collectors concurrently")
+		}
+	}
+	releaseOnce.Do(func() { close(release) })
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("CollectDiagnostics() error = %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("CollectDiagnostics did not complete after host collectors were released")
+	}
+}
+
 func TestMultiHostOrchestrator_GetHostsInfo_CompleteInfo(t *testing.T) {
 	hostInfos := []*hostparse.HostInfo{
 		{Host: "host1", IsLocal: false, Original: "host1"},

--- a/cli/tui/remote_docker.go
+++ b/cli/tui/remote_docker.go
@@ -32,18 +32,19 @@ const (
 // using the shared command layer (internal/docker/command).
 // It is used for remote hosts where the Docker SDK ssh:// transport is unavailable.
 type RemoteDockerManager struct {
-	host             *hostparse.HostInfo
-	exec             command.CommandExecutor
-	ops              command.DockerOperations
-	containerID      string
-	proberRun        func(ctx context.Context, baseURL string, pollInterval time.Duration) error
-	stagedBindMounts []string
-	stagingDir       string
-	diagnosticsRoot  string
-	diagnosticsDir   string
-	diagnosticsRole  string
-	diagnosticsDone  bool
-	diagnosticsRec   *diagnosticsRecord
+	host                *hostparse.HostInfo
+	exec                command.CommandExecutor
+	ops                 command.DockerOperations
+	containerID         string
+	proberRun           func(ctx context.Context, baseURL string, pollInterval time.Duration) error
+	stagedBindMounts    []string
+	stagingDir          string
+	diagnosticsRoot     string
+	diagnosticsDir      string
+	diagnosticsRole     string
+	diagnosticsDone     bool
+	diagnosticsRec      *diagnosticsRecord
+	diagnosticsStopDone bool
 }
 
 func sanitizeHostComponent(host string) string {
@@ -213,6 +214,7 @@ func (m *RemoteDockerManager) prepareDiagnostics(ctx context.Context, role strin
 	m.diagnosticsRole = role
 	m.diagnosticsDone = false
 	m.diagnosticsRec = nil
+	m.diagnosticsStopDone = false
 	return []string{fmt.Sprintf("%s:%s", remoteDir, dockerDiagnosticsMount)}, []string{remoteEnvFile}, nil
 }
 
@@ -225,6 +227,7 @@ func (m *RemoteDockerManager) cleanupRemoteDiagnostics(ctx context.Context) {
 	m.diagnosticsRole = ""
 	m.diagnosticsDone = false
 	m.diagnosticsRec = nil
+	m.diagnosticsStopDone = false
 }
 
 // StartContainer is not used for remote multi-host mode; return a clear error
@@ -504,6 +507,18 @@ func (m *RemoteDockerManager) collectDiagnostics(ctx context.Context) (*diagnost
 	record.Files = files
 	record.Collected = true
 
+	if !m.diagnosticsStopDone {
+		// The container was never confirmed stopped (graceful stop failed, or
+		// was never attempted), so dumponexit JFR/GC artifacts may not have
+		// been flushed yet. Preserve the remote directory for manual recovery
+		// instead of deleting a source that might still be mid-write.
+		record.Error = "graceful stop was not confirmed before collection; remote directory preserved"
+		record.PreservedRemoteDir = true
+		_ = writeDiagnosticsRecordManifest(localDir, record)
+		m.diagnosticsRec = &record
+		return &record, errors.New(record.Error)
+	}
+
 	if _, stderr, err := m.exec.ExecuteCommand(ctx, m.host, []string{"rm", remoteRemoveRecursiveFlag, m.diagnosticsDir}); err != nil {
 		record.Error = fmt.Sprintf("remove remote diagnostics directory: %v (stderr: %s)", err, stderr)
 		record.PreservedRemoteDir = true
@@ -527,6 +542,9 @@ func (m *RemoteDockerManager) diagnosticsRecord() *diagnosticsRecord {
 }
 
 func (m *RemoteDockerManager) gracefulStopForDiagnostics(ctx context.Context) error {
+	if m.diagnosticsDone || m.diagnosticsStopDone {
+		return nil
+	}
 	if m.containerID == "" || m.diagnosticsDir == "" {
 		return nil
 	}
@@ -540,6 +558,7 @@ func (m *RemoteDockerManager) gracefulStopForDiagnostics(ctx context.Context) er
 	if err != nil {
 		return fmt.Errorf("graceful docker stop for diagnostics: %w (stderr: %s)", err, stderr)
 	}
+	m.diagnosticsStopDone = true
 	return nil
 }
 

--- a/cli/tui/remote_docker.go
+++ b/cli/tui/remote_docker.go
@@ -6,8 +6,11 @@ package tui
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"os"
 	"path"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -18,6 +21,11 @@ import (
 	"github.com/dell/storage-performance-tool/cli/internal/logging"
 	"github.com/dell/storage-performance-tool/cli/internal/remoteip"
 	"github.com/dell/storage-performance-tool/cli/internal/scenario"
+)
+
+const (
+	remoteRemoveRecursiveFlag = "-rf"
+	remoteChmodCommand        = "chmod"
 )
 
 // RemoteDockerManager implements DockerInterface by executing docker CLI via SSH
@@ -31,6 +39,11 @@ type RemoteDockerManager struct {
 	proberRun        func(ctx context.Context, baseURL string, pollInterval time.Duration) error
 	stagedBindMounts []string
 	stagingDir       string
+	diagnosticsRoot  string
+	diagnosticsDir   string
+	diagnosticsRole  string
+	diagnosticsDone  bool
+	diagnosticsRec   *diagnosticsRecord
 }
 
 func sanitizeHostComponent(host string) string {
@@ -107,9 +120,25 @@ func (m *RemoteDockerManager) cleanupStaging(ctx context.Context) {
 	if m.stagingDir == "" {
 		return
 	}
-	_, _, _ = m.exec.ExecuteCommand(ctx, m.host, []string{"rm", "-rf", m.stagingDir})
+	_, _, _ = m.exec.ExecuteCommand(ctx, m.host, []string{"rm", remoteRemoveRecursiveFlag, m.stagingDir})
 	m.stagingDir = ""
 	m.stagedBindMounts = nil
+}
+
+func (m *RemoteDockerManager) ensureStagingDir(ctx context.Context) error {
+	if m.stagingDir != "" {
+		return nil
+	}
+	m.stagingDir = fmt.Sprintf("/tmp/spt-items-%d", time.Now().UnixNano())
+	if _, stderr, err := m.exec.ExecuteCommand(ctx, m.host, []string{"mkdir", "-p", m.stagingDir}); err != nil {
+		m.stagingDir = ""
+		return fmt.Errorf("create remote staging directory on %s: %w (stderr: %s)", m.host.Original, err, stderr)
+	}
+	return nil
+}
+
+func (m *RemoteDockerManager) setDiagnosticsResultsRoot(resultsRoot string) {
+	m.diagnosticsRoot = strings.TrimSpace(resultsRoot)
 }
 
 // SetFileMounts stages local item files onto the remote Docker host for bind mounting.
@@ -119,23 +148,83 @@ func (m *RemoteDockerManager) SetFileMounts(mounts []scenario.FileMount) error {
 	if len(mounts) == 0 {
 		return nil
 	}
-	m.stagingDir = fmt.Sprintf("/tmp/spt-items-%d", time.Now().UnixNano())
 	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(constants.ContainerStartTimeoutSecs)*time.Second)
 	defer cancel()
-	if _, stderr, err := m.exec.ExecuteCommand(ctx, m.host, []string{"mkdir", "-p", m.stagingDir}); err != nil {
-		return fmt.Errorf("create remote item staging directory on %s: %w (stderr: %s)", m.host.Original, err, stderr)
+	if err := m.ensureStagingDir(ctx); err != nil {
+		return err
 	}
 	for _, mount := range mounts {
 		remotePath := path.Join(m.stagingDir, path.Base(mount.ContainerPath))
 		if err := m.exec.CopyFile(ctx, m.host, mount.HostPath, remotePath); err != nil {
 			return err
 		}
-		if _, stderr, err := m.exec.ExecuteCommand(ctx, m.host, []string{"chmod", "0444", remotePath}); err != nil {
+		if _, stderr, err := m.exec.ExecuteCommand(ctx, m.host, []string{remoteChmodCommand, "0444", remotePath}); err != nil {
 			return fmt.Errorf("chmod remote item file on %s: %w (stderr: %s)", m.host.Original, err, stderr)
 		}
 		m.stagedBindMounts = append(m.stagedBindMounts, fmt.Sprintf("%s:%s:ro", remotePath, mount.ContainerPath))
 	}
 	return nil
+}
+
+func (m *RemoteDockerManager) prepareDiagnostics(ctx context.Context, role string) ([]string, []string, error) {
+	if !diagnosticsEnabled() {
+		return nil, nil, nil
+	}
+	if err := m.ensureStagingDir(ctx); err != nil {
+		return nil, nil, err
+	}
+
+	envFile, err := os.CreateTemp("", "spt-java-opts-*.env")
+	if err != nil {
+		return nil, nil, fmt.Errorf("create local env-file: %w", err)
+	}
+	envFilePath := envFile.Name()
+	defer func() { _ = os.Remove(envFilePath) }()
+	if _, err := fmt.Fprintf(envFile, "%s=%s\n", constants.EnvSptJavaOpts, os.Getenv(constants.EnvSptJavaOpts)); err != nil {
+		_ = envFile.Close()
+		return nil, nil, fmt.Errorf("write local env-file: %w", err)
+	}
+	if err := envFile.Close(); err != nil {
+		return nil, nil, fmt.Errorf("close local env-file: %w", err)
+	}
+
+	remoteEnvFile := path.Join(m.stagingDir, diagnosticsHostComponent(role)+".env")
+	if err := m.exec.CopyFile(ctx, m.host, envFilePath, remoteEnvFile); err != nil {
+		return nil, nil, fmt.Errorf("stage remote env-file on %s: %w", m.host.Original, err)
+	}
+	if _, stderr, err := m.exec.ExecuteCommand(ctx, m.host, []string{remoteChmodCommand, "0444", remoteEnvFile}); err != nil {
+		return nil, nil, fmt.Errorf("chmod remote env-file on %s: %w (stderr: %s)", m.host.Original, err, stderr)
+	}
+
+	remoteDir := path.Join(
+		remoteDiagnosticsBaseDir,
+		diagnosticsRunID(m.diagnosticsRoot),
+		diagnosticsHostComponent(m.host.Host),
+		diagnosticsHostComponent(role),
+	)
+	if _, stderr, err := m.exec.ExecuteCommand(ctx, m.host, []string{"mkdir", "-p", remoteDir}); err != nil {
+		return nil, nil, fmt.Errorf("create remote diagnostics directory on %s: %w (stderr: %s)", m.host.Original, err, stderr)
+	}
+	if _, stderr, err := m.exec.ExecuteCommand(ctx, m.host, []string{remoteChmodCommand, "0777", remoteDir}); err != nil {
+		return nil, nil, fmt.Errorf("chmod remote diagnostics directory on %s: %w (stderr: %s)", m.host.Original, err, stderr)
+	}
+
+	m.diagnosticsDir = remoteDir
+	m.diagnosticsRole = role
+	m.diagnosticsDone = false
+	m.diagnosticsRec = nil
+	return []string{fmt.Sprintf("%s:%s", remoteDir, dockerDiagnosticsMount)}, []string{remoteEnvFile}, nil
+}
+
+func (m *RemoteDockerManager) cleanupRemoteDiagnostics(ctx context.Context) {
+	if m.diagnosticsDir == "" {
+		return
+	}
+	_, _, _ = m.exec.ExecuteCommand(ctx, m.host, []string{"rm", remoteRemoveRecursiveFlag, m.diagnosticsDir})
+	m.diagnosticsDir = ""
+	m.diagnosticsRole = ""
+	m.diagnosticsDone = false
+	m.diagnosticsRec = nil
 }
 
 // StartContainer is not used for remote multi-host mode; return a clear error
@@ -155,6 +244,15 @@ func (m *RemoteDockerManager) StartContainerInNodeMode(image string, apiPort str
 		return "", fmt.Errorf("invalid api port: %q", apiPort)
 	}
 
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(constants.ContainerStartTimeoutSecs)*time.Second)
+	defer cancel()
+	diagnosticBinds, envFiles, err := m.prepareDiagnostics(ctx, constants.DockerRoleNode)
+	if err != nil {
+		m.cleanupStaging(ctx)
+		m.cleanupRemoteDiagnostics(ctx)
+		return "", err
+	}
+
 	name := generateRemoteContainerName("node", m.host.Host)
 	mode := selectedNodeNetworkMode(networkMode)
 	cfg := command.ContainerConfig{
@@ -164,18 +262,17 @@ func (m *RemoteDockerManager) StartContainerInNodeMode(image string, apiPort str
 		Detached:    true,
 		Labels:      m.baseLabels(constants.DockerRoleNode),
 		Command:     []string{dockerNodeModeArg, "--run-port=" + apiPort},
-		BindMounts:  m.stagedBindMounts,
+		BindMounts:  append(diagnosticBinds, m.stagedBindMounts...),
+		EnvFiles:    envFiles,
 	}
 	if mode != command.NetworkModeHost {
 		cfg.PortMappings = []command.PortMapping{{HostPort: port, ContainerPort: port}}
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(constants.ContainerStartTimeoutSecs)*time.Second)
-	defer cancel()
-
 	id, _, err := m.ops.StartContainer(ctx, cfg)
 	if err != nil {
 		m.cleanupStaging(ctx)
+		m.cleanupRemoteDiagnostics(ctx)
 		return "", err
 	}
 	m.containerID = strings.TrimSpace(id)
@@ -202,6 +299,15 @@ func (m *RemoteDockerManager) StartWorkerNodeContainer(image string, rmiHostname
 	}
 	logging.LogInfo("remote-docker", "using advertised IP", "host", m.host.Original, "ip", advIP)
 
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(constants.ContainerStartTimeoutSecs)*time.Second)
+	defer cancel()
+	diagnosticBinds, envFiles, err := m.prepareDiagnostics(ctx, constants.DockerRoleWorker)
+	if err != nil {
+		m.cleanupStaging(ctx)
+		m.cleanupRemoteDiagnostics(ctx)
+		return "", err
+	}
+
 	// Host networking with explicit JVM RMI hostname and explicit ports
 	name := generateRemoteContainerName("worker", m.host.Host)
 	cfg := command.ContainerConfig{
@@ -215,7 +321,8 @@ func (m *RemoteDockerManager) StartWorkerNodeContainer(image string, rmiHostname
 			constants.JavaToolOptionsEnvVar: fmt.Sprintf("%s%s", constants.JavaRMIHostnamePrefix, advIP),
 		},
 		Command:    []string{dockerNodeModeArg, "--run-port=9999", "--load-step-node-port=1099"},
-		BindMounts: m.stagedBindMounts,
+		BindMounts: append(diagnosticBinds, m.stagedBindMounts...),
+		EnvFiles:   envFiles,
 	}
 
 	// RDMA device passthrough when SPT_RDMA is enabled
@@ -228,12 +335,10 @@ func (m *RemoteDockerManager) StartWorkerNodeContainer(image string, rmiHostname
 	// Echo exact JAVA_OPTS for triage
 	logging.LogInfo("remote-docker", "JAVA_OPTS configured", "host", m.host.Original, "JAVA_OPTS", cfg.Environment[constants.JavaOptsEnvVar])
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(constants.ContainerStartTimeoutSecs)*time.Second)
-	defer cancel()
-
 	id, _, err := m.ops.StartContainer(ctx, cfg)
 	if err != nil {
 		m.cleanupStaging(ctx)
+		m.cleanupRemoteDiagnostics(ctx)
 		return "", err
 	}
 	m.containerID = strings.TrimSpace(id)
@@ -260,6 +365,15 @@ func (m *RemoteDockerManager) StartEntryNodeContainer(image string, workerAddres
 	cmd = append(cmd, dockerNodeModeArg, "--run-port="+constants.SptAPIPort)
 	cmd = append(cmd, additionalArgs...)
 
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(constants.ContainerStartTimeoutSecs)*time.Second)
+	defer cancel()
+	diagnosticBinds, envFiles, err := m.prepareDiagnostics(ctx, constants.DockerRoleEntry)
+	if err != nil {
+		m.cleanupStaging(ctx)
+		m.cleanupRemoteDiagnostics(ctx)
+		return "", err
+	}
+
 	name := generateRemoteContainerName("entry", m.host.Host)
 	cfg := command.ContainerConfig{
 		Image:       image,
@@ -268,7 +382,8 @@ func (m *RemoteDockerManager) StartEntryNodeContainer(image string, workerAddres
 		Detached:    true,
 		Labels:      m.baseLabels(constants.DockerRoleEntry),
 		Command:     cmd,
-		BindMounts:  m.stagedBindMounts,
+		BindMounts:  append(diagnosticBinds, m.stagedBindMounts...),
+		EnvFiles:    envFiles,
 	}
 
 	// RDMA device passthrough when SPT_RDMA is enabled
@@ -278,12 +393,10 @@ func (m *RemoteDockerManager) StartEntryNodeContainer(image string, workerAddres
 		cfg.Ulimits = []string{constants.RdmaUlimitMemlock}
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(constants.ContainerStartTimeoutSecs)*time.Second)
-	defer cancel()
-
 	id, _, err := m.ops.StartContainer(ctx, cfg)
 	if err != nil {
 		m.cleanupStaging(ctx)
+		m.cleanupRemoteDiagnostics(ctx)
 		return "", err
 	}
 	m.containerID = strings.TrimSpace(id)
@@ -319,18 +432,153 @@ func (m *RemoteDockerManager) StreamOutput(containerID string, stdoutCallback fu
 	)
 }
 
+func (m *RemoteDockerManager) collectDiagnostics(ctx context.Context) (*diagnosticsRecord, error) {
+	if m.diagnosticsDir == "" {
+		return nil, nil
+	}
+	if m.diagnosticsDone && m.diagnosticsRec != nil {
+		return m.diagnosticsRec, nil
+	}
+
+	localDir := ""
+	if strings.TrimSpace(m.diagnosticsRoot) != "" {
+		localDir = diagnosticsLocalDir(m.diagnosticsRoot, m.host.Host, m.diagnosticsRole)
+	}
+	record := diagnosticsRecord{
+		Host:         m.host.Original,
+		Role:         m.diagnosticsRole,
+		ContainerID:  m.containerID,
+		ContainerDir: dockerDiagnosticsMount,
+		RemoteDir:    m.diagnosticsDir,
+		LocalDir:     localDir,
+	}
+	if localDir == "" {
+		if _, stderr, err := m.exec.ExecuteCommand(ctx, m.host, []string{"rm", remoteRemoveRecursiveFlag, m.diagnosticsDir}); err != nil {
+			record.Error = fmt.Sprintf("remove remote diagnostics directory without local results root: %v (stderr: %s)", err, stderr)
+			record.PreservedRemoteDir = true
+			m.diagnosticsRec = &record
+			return &record, errors.New(record.Error)
+		}
+		record.RemoteDirRemoved = true
+		m.diagnosticsDone = true
+		m.diagnosticsRec = &record
+		return &record, nil
+	}
+	if err := os.MkdirAll(localDir, 0o750); err != nil {
+		record.Error = err.Error()
+		record.PreservedRemoteDir = true
+		m.diagnosticsRec = &record
+		return &record, fmt.Errorf("create local diagnostics directory: %w", err)
+	}
+
+	stdout, stderr, err := m.exec.ExecuteCommand(ctx, m.host, []string{"find", m.diagnosticsDir, "-maxdepth", "1", "-type", "f", "-print"})
+	if err != nil {
+		record.Error = fmt.Sprintf("list remote diagnostics: %v (stderr: %s)", err, stderr)
+		record.PreservedRemoteDir = true
+		_ = writeDiagnosticsRecordManifest(localDir, record)
+		m.diagnosticsRec = &record
+		return &record, errors.New(record.Error)
+	}
+
+	remoteFiles := strings.Fields(stdout)
+	for _, remoteFile := range remoteFiles {
+		name := path.Base(remoteFile)
+		localPath := filepath.Join(localDir, name)
+		if err := m.exec.CopyFromHost(ctx, m.host, remoteFile, localPath); err != nil {
+			record.Error = fmt.Sprintf("copy %s: %v", remoteFile, err)
+			record.PreservedRemoteDir = true
+			_ = writeDiagnosticsRecordManifest(localDir, record)
+			m.diagnosticsRec = &record
+			return &record, errors.New(record.Error)
+		}
+	}
+
+	files, err := listDiagnosticFiles(localDir)
+	if err != nil {
+		record.Error = fmt.Sprintf("list local diagnostics: %v", err)
+		record.PreservedRemoteDir = true
+		_ = writeDiagnosticsRecordManifest(localDir, record)
+		m.diagnosticsRec = &record
+		return &record, errors.New(record.Error)
+	}
+	record.Files = files
+	record.Collected = true
+
+	if _, stderr, err := m.exec.ExecuteCommand(ctx, m.host, []string{"rm", remoteRemoveRecursiveFlag, m.diagnosticsDir}); err != nil {
+		record.Error = fmt.Sprintf("remove remote diagnostics directory: %v (stderr: %s)", err, stderr)
+		record.PreservedRemoteDir = true
+		_ = writeDiagnosticsRecordManifest(localDir, record)
+		m.diagnosticsRec = &record
+		return &record, errors.New(record.Error)
+	}
+	record.RemoteDirRemoved = true
+	if err := writeDiagnosticsRecordManifest(localDir, record); err != nil {
+		m.diagnosticsRec = &record
+		return &record, fmt.Errorf("write diagnostics manifest: %w", err)
+	}
+
+	m.diagnosticsDone = true
+	m.diagnosticsRec = &record
+	return &record, nil
+}
+
+func (m *RemoteDockerManager) diagnosticsRecord() *diagnosticsRecord {
+	return m.diagnosticsRec
+}
+
+func (m *RemoteDockerManager) gracefulStopForDiagnostics(ctx context.Context) error {
+	if m.containerID == "" || m.diagnosticsDir == "" {
+		return nil
+	}
+	_, stderr, err := m.exec.ExecuteCommand(ctx, m.host, []string{
+		constants.DockerCommand,
+		constants.DockerCmdStop,
+		"-t",
+		fmt.Sprintf("%d", dockerDiagnosticsStopTimeoutSeconds),
+		m.containerID,
+	})
+	if err != nil {
+		return fmt.Errorf("graceful docker stop for diagnostics: %w (stderr: %s)", err, stderr)
+	}
+	return nil
+}
+
 // Cleanup force-removes the last started container (if any)
 func (m *RemoteDockerManager) Cleanup() error {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	timeout := 10 * time.Second
+	if m.diagnosticsDir != "" {
+		timeout = time.Duration(dockerDiagnosticsStopTimeoutSeconds+30) * time.Second
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
+	var cleanupErrs []error
+	var diagnosticsRecords []diagnosticsRecord
 	if m.containerID != "" {
+		if m.diagnosticsDir != "" && !m.diagnosticsDone {
+			if err := m.gracefulStopForDiagnostics(ctx); err != nil {
+				logging.LogWarn("remote-docker", "diagnostics graceful stop failed", "host", m.host.Original, "error", err.Error())
+				cleanupErrs = append(cleanupErrs, err)
+			}
+			record, err := m.collectDiagnostics(ctx)
+			if record != nil {
+				diagnosticsRecords = append(diagnosticsRecords, *record)
+			}
+			if err != nil {
+				logging.LogWarn("remote-docker", "diagnostics collection failed", "host", m.host.Original, "remote_dir", m.diagnosticsDir, "error", err.Error())
+				cleanupErrs = append(cleanupErrs, err)
+			}
+		}
 		if err := m.ops.StopContainer(ctx, m.containerID); err != nil {
-			return err
+			cleanupErrs = append(cleanupErrs, err)
+			return errors.Join(cleanupErrs...)
 		}
 		m.containerID = ""
 	}
 	m.cleanupStaging(ctx)
-	return nil
+	if err := writeDiagnosticsAggregateManifest(m.diagnosticsRoot, diagnosticsRecords); err != nil {
+		cleanupErrs = append(cleanupErrs, err)
+	}
+	return errors.Join(cleanupErrs...)
 }
 
 // Close is a no-op for the remote manager

--- a/cli/tui/remote_docker_test.go
+++ b/cli/tui/remote_docker_test.go
@@ -5,6 +5,7 @@ Copyright © 2025 Dell Technologies
 package tui
 
 import (
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -170,6 +171,165 @@ func TestRemoteDocker_StartWorkerNodeContainer_BuildsExpectedCommand(t *testing.
 	if !strings.Contains(cmd, "--name spt-worker-") {
 		t.Errorf("expected worker run command to include worker name prefix, got: %s", cmd)
 	}
+}
+
+func TestRemoteDocker_StartWorkerNodeContainer_DiagnosticsEnvFileAndMount(t *testing.T) {
+	javaOpts := "-Xlog:gc*,safepoint:file=/spt-diagnostics/spt-gc-%p.log:time,uptime,level,tags -XX:StartFlightRecording=dumponexit=true,maxsize=512m,filename=/spt-diagnostics/spt-%p.jfr,settings=profile"
+	t.Setenv(constants.EnvSptJavaOpts, javaOpts)
+	mgr, mock, _ := newTestRemoteManager(t)
+	resultsRoot := filepath.Join(t.TempDir(), "mt-20260705.120000.000")
+	mgr.setDiagnosticsResultsRoot(resultsRoot)
+
+	id, err := mgr.StartWorkerNodeContainer(constants.DefaultSptImage, "10.0.0.10", 40000, 3)
+	if err != nil {
+		t.Fatalf("StartWorkerNodeContainer error = %v", err)
+	}
+	if id == "" {
+		t.Fatal("container ID should not be empty")
+	}
+
+	var envCopy *command.CopiedFile
+	for i := range mock.CopiedFiles {
+		if strings.HasSuffix(mock.CopiedFiles[i].RemotePath, "/worker.env") {
+			envCopy = &mock.CopiedFiles[i]
+			break
+		}
+	}
+	if envCopy == nil {
+		t.Fatalf("expected staged worker env-file, copied files = %+v", mock.CopiedFiles)
+	}
+	wantContent := constants.EnvSptJavaOpts + "=" + javaOpts + "\n"
+	if envCopy.Content != wantContent {
+		t.Fatalf("env-file content = %q, want %q", envCopy.Content, wantContent)
+	}
+
+	executed := mock.GetExecutedCommandsMatching("docker run")
+	if len(executed) == 0 {
+		t.Fatalf("expected docker run command")
+	}
+	cmd := strings.Join(executed[len(executed)-1].Command, " ")
+	if strings.Contains(cmd, javaOpts) {
+		t.Fatalf("docker run command should not inline multi-flag SPT_JAVA_OPTS: %s", cmd)
+	}
+	mustContain := []string{
+		"--env-file " + envCopy.RemotePath,
+		"-v " + mgr.diagnosticsDir + ":" + dockerDiagnosticsMount,
+		"--network host",
+	}
+	for _, s := range mustContain {
+		if !strings.Contains(cmd, s) {
+			t.Fatalf("docker run missing %q: %s", s, cmd)
+		}
+	}
+}
+
+func TestRemoteDocker_CleanupCollectsDiagnosticsBeforeStagingCleanup(t *testing.T) {
+	t.Setenv(constants.EnvSptJavaOpts, "-Xlog:gc*:file=/spt-diagnostics/spt-gc-%p.log")
+	mgr, mock, _ := newTestRemoteManager(t)
+	resultsRoot := filepath.Join(t.TempDir(), "mt-20260705.120000.000")
+	mgr.setDiagnosticsResultsRoot(resultsRoot)
+
+	if _, err := mgr.StartWorkerNodeContainer(constants.DefaultSptImage, "10.0.0.10", 40000, 3); err != nil {
+		t.Fatalf("StartWorkerNodeContainer error = %v", err)
+	}
+	remoteDir := mgr.diagnosticsDir
+	stagingDir := mgr.stagingDir
+	mock.SetCommandSuccess(
+		"find "+remoteDir+" -maxdepth 1 -type f -print",
+		remoteDir+"/spt-gc-123.log\n"+remoteDir+"/spt-123.jfr\n",
+	)
+
+	if err := mgr.Cleanup(); err != nil {
+		t.Fatalf("Cleanup() error = %v", err)
+	}
+	if len(mock.CopiedFromFiles) != 2 {
+		t.Fatalf("copied diagnostics = %d, want 2", len(mock.CopiedFromFiles))
+	}
+	localDir := diagnosticsLocalDir(resultsRoot, mgr.host.Host, constants.DockerRoleWorker)
+	for _, name := range []string{"spt-gc-123.log", "spt-123.jfr", dockerDiagnosticsManifestFileName} {
+		if _, err := os.Stat(filepath.Join(localDir, name)); err != nil {
+			t.Fatalf("expected local diagnostics file %s: %v", name, err)
+		}
+	}
+
+	stopIdx := commandIndex(mock, "docker stop -t 60")
+	findIdx := commandIndex(mock, "find "+remoteDir)
+	diagRmIdx := commandIndex(mock, "rm -rf "+remoteDir)
+	containerRmIdx := commandIndex(mock, "docker rm -f")
+	stagingRmIdx := commandIndex(mock, "rm -rf "+stagingDir)
+	for name, idx := range map[string]int{
+		"docker stop":           stopIdx,
+		"find diagnostics":      findIdx,
+		"remove diagnostics":    diagRmIdx,
+		"remove container":      containerRmIdx,
+		"remove staging folder": stagingRmIdx,
+	} {
+		if idx < 0 {
+			t.Fatalf("missing %s command; commands = %+v", name, mock.GetExecutedCommands())
+		}
+	}
+	if !(stopIdx < findIdx && findIdx < diagRmIdx && diagRmIdx < containerRmIdx && containerRmIdx < stagingRmIdx) {
+		t.Fatalf("unexpected cleanup order: stop=%d find=%d diagRm=%d containerRm=%d stagingRm=%d", stopIdx, findIdx, diagRmIdx, containerRmIdx, stagingRmIdx)
+	}
+}
+
+func TestRemoteDocker_CleanupWithJavaOptsAndNoResultsRootRemovesRemoteDiagnostics(t *testing.T) {
+	t.Setenv(constants.EnvSptJavaOpts, "-Xmx8g")
+	mgr, mock, _ := newTestRemoteManager(t)
+
+	if _, err := mgr.StartWorkerNodeContainer(constants.DefaultSptImage, "10.0.0.10", 40000, 3); err != nil {
+		t.Fatalf("StartWorkerNodeContainer error = %v", err)
+	}
+	remoteDir := mgr.diagnosticsDir
+	stagingDir := mgr.stagingDir
+
+	if err := mgr.Cleanup(); err != nil {
+		t.Fatalf("Cleanup() error = %v", err)
+	}
+	if len(mock.CopiedFromFiles) != 0 {
+		t.Fatalf("copied diagnostics = %d, want 0 without results root", len(mock.CopiedFromFiles))
+	}
+	record := mgr.diagnosticsRecord()
+	if record == nil {
+		t.Fatal("expected diagnostics record")
+	}
+	if record.LocalDir != "" {
+		t.Fatalf("record LocalDir = %q, want empty", record.LocalDir)
+	}
+	if !record.RemoteDirRemoved || record.PreservedRemoteDir {
+		t.Fatalf("record remote cleanup = removed:%v preserved:%v, want removed only", record.RemoteDirRemoved, record.PreservedRemoteDir)
+	}
+
+	stopIdx := commandIndex(mock, "docker stop -t 60")
+	diagRmIdx := commandIndex(mock, "rm -rf "+remoteDir)
+	containerRmIdx := commandIndex(mock, "docker rm -f")
+	stagingRmIdx := commandIndex(mock, "rm -rf "+stagingDir)
+	findIdx := commandIndex(mock, "find "+remoteDir)
+	if findIdx >= 0 {
+		t.Fatalf("unexpected diagnostics copy scan without results root; commands = %+v", mock.GetExecutedCommands())
+	}
+	for name, idx := range map[string]int{
+		"docker stop":           stopIdx,
+		"remove diagnostics":    diagRmIdx,
+		"remove container":      containerRmIdx,
+		"remove staging folder": stagingRmIdx,
+	} {
+		if idx < 0 {
+			t.Fatalf("missing %s command; commands = %+v", name, mock.GetExecutedCommands())
+		}
+	}
+	if !(stopIdx < diagRmIdx && diagRmIdx < containerRmIdx && containerRmIdx < stagingRmIdx) {
+		t.Fatalf("unexpected cleanup order: stop=%d diagRm=%d containerRm=%d stagingRm=%d", stopIdx, diagRmIdx, containerRmIdx, stagingRmIdx)
+	}
+}
+
+func commandIndex(mock *command.MockCommandExecutor, contains string) int {
+	for i, executed := range mock.GetExecutedCommands() {
+		if strings.Contains(strings.Join(executed.Command, " "), contains) {
+			return i
+		}
+	}
+	return -1
 }
 
 func TestRemoteDocker_StartEntryNodeContainer_IncludesWorkerAddrsAndArgs(t *testing.T) {

--- a/cli/tui/remote_docker_test.go
+++ b/cli/tui/remote_docker_test.go
@@ -5,6 +5,7 @@ Copyright © 2025 Dell Technologies
 package tui
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -372,5 +373,113 @@ func TestRemoteDocker_StartEntryNodeContainer_IncludesWorkerAddrsAndArgs(t *test
 	}
 	if !strings.Contains(cmd, "--name spt-entry-") {
 		t.Errorf("expected entry run command to include entry name prefix, got: %s", cmd)
+	}
+}
+
+// TestRemoteDocker_CollectDiagnosticsPreservesRemoteDirWhenStopNotConfirmed guards
+// against collecting (and then deleting) JFR/GC artifacts before the container's
+// JVM has had a chance to exit and flush dumponexit files. This exercises
+// collectDiagnostics directly, bypassing gracefulStopForDiagnostics/Cleanup, the
+// same way MultiHostOrchestrator.CollectDiagnostics used to before it was fixed
+// to stop first.
+func TestRemoteDocker_CollectDiagnosticsPreservesRemoteDirWhenStopNotConfirmed(t *testing.T) {
+	t.Setenv(constants.EnvSptJavaOpts, "-Xlog:gc*:file=/spt-diagnostics/spt-gc-%p.log")
+	mgr, mock, _ := newTestRemoteManager(t)
+	resultsRoot := filepath.Join(t.TempDir(), "mt-20260705.120000.000")
+	mgr.setDiagnosticsResultsRoot(resultsRoot)
+
+	if _, err := mgr.StartWorkerNodeContainer(constants.DefaultSptImage, "10.0.0.10", 40000, 3); err != nil {
+		t.Fatalf("StartWorkerNodeContainer error = %v", err)
+	}
+	remoteDir := mgr.diagnosticsDir
+	mock.SetCommandSuccess(
+		"find "+remoteDir+" -maxdepth 1 -type f -print",
+		remoteDir+"/spt-gc-123.log\n",
+	)
+
+	record, err := mgr.collectDiagnostics(context.Background())
+	if err == nil {
+		t.Fatal("expected an error when stop was never confirmed before collection")
+	}
+	if record == nil || !record.Collected {
+		t.Fatalf("expected best-effort collection despite unconfirmed stop, record = %+v", record)
+	}
+	if !record.PreservedRemoteDir {
+		t.Fatal("expected remote dir to be preserved when stop was not confirmed")
+	}
+	if idx := commandIndex(mock, "rm -rf "+remoteDir); idx >= 0 {
+		t.Fatalf("remote diagnostics dir should not be removed when stop was not confirmed; commands = %+v", mock.GetExecutedCommands())
+	}
+}
+
+// TestRemoteDocker_CleanupCollectsEntryNodeDiagnostics covers the entry-node
+// diagnostics path specifically: prior coverage exercised worker-role Cleanup
+// only, but the plan requires diagnostics on both worker and entry containers.
+func TestRemoteDocker_CleanupCollectsEntryNodeDiagnostics(t *testing.T) {
+	t.Setenv(constants.EnvSptJavaOpts, "-Xlog:gc*:file=/spt-diagnostics/spt-gc-%p.log")
+	mgr, mock, _ := newTestRemoteManager(t)
+	resultsRoot := filepath.Join(t.TempDir(), "mt-20260705.120000.000")
+	mgr.setDiagnosticsResultsRoot(resultsRoot)
+
+	if _, err := mgr.StartEntryNodeContainer(constants.DefaultSptImage, []string{"w1:1099"}, nil, constants.DefaultNetworkMode); err != nil {
+		t.Fatalf("StartEntryNodeContainer error = %v", err)
+	}
+	remoteDir := mgr.diagnosticsDir
+	mock.SetCommandSuccess(
+		"find "+remoteDir+" -maxdepth 1 -type f -print",
+		remoteDir+"/spt-gc-123.log\n",
+	)
+
+	if err := mgr.Cleanup(); err != nil {
+		t.Fatalf("Cleanup() error = %v", err)
+	}
+
+	record := mgr.diagnosticsRecord()
+	if record == nil {
+		t.Fatal("expected diagnostics record")
+	}
+	if record.Role != constants.DockerRoleEntry {
+		t.Fatalf("record role = %q, want %q", record.Role, constants.DockerRoleEntry)
+	}
+	if !record.Collected || !record.RemoteDirRemoved {
+		t.Fatalf("expected entry diagnostics to be collected and remote dir removed, record = %+v", record)
+	}
+	localDir := diagnosticsLocalDir(resultsRoot, mgr.host.Host, constants.DockerRoleEntry)
+	if _, err := os.Stat(filepath.Join(localDir, "spt-gc-123.log")); err != nil {
+		t.Fatalf("expected local entry diagnostics file: %v", err)
+	}
+}
+
+// TestRemoteDocker_CleanupCollectsNodeModeDiagnostics covers the standalone
+// node-mode diagnostics path (StartContainerInNodeMode), the third of the
+// three container roles diagnostics must be wired for.
+func TestRemoteDocker_CleanupCollectsNodeModeDiagnostics(t *testing.T) {
+	t.Setenv(constants.EnvSptJavaOpts, "-Xlog:gc*:file=/spt-diagnostics/spt-gc-%p.log")
+	mgr, mock, _ := newTestRemoteManager(t)
+	resultsRoot := filepath.Join(t.TempDir(), "mt-20260705.120000.000")
+	mgr.setDiagnosticsResultsRoot(resultsRoot)
+
+	if _, err := mgr.StartContainerInNodeMode(constants.DefaultSptImage, "10080", constants.BridgeNetworkMode); err != nil {
+		t.Fatalf("StartContainerInNodeMode error = %v", err)
+	}
+	remoteDir := mgr.diagnosticsDir
+	mock.SetCommandSuccess(
+		"find "+remoteDir+" -maxdepth 1 -type f -print",
+		remoteDir+"/spt-gc-123.log\n",
+	)
+
+	if err := mgr.Cleanup(); err != nil {
+		t.Fatalf("Cleanup() error = %v", err)
+	}
+
+	record := mgr.diagnosticsRecord()
+	if record == nil {
+		t.Fatal("expected diagnostics record")
+	}
+	if record.Role != constants.DockerRoleNode {
+		t.Fatalf("record role = %q, want %q", record.Role, constants.DockerRoleNode)
+	}
+	if !record.Collected || !record.RemoteDirRemoved {
+		t.Fatalf("expected node-mode diagnostics to be collected and remote dir removed, record = %+v", record)
 	}
 }


### PR DESCRIPTION
## Summary

Adds client-side GC/JFR diagnostics collection for Docker-based runs (I1) and generated-defaults engine overrides (I8), plus lifecycle correctness fixes found during review of that instrumentation work:

- **Remote diagnostics collection** (`67db806`): copies GC log/JFR files out of the container's diagnostics bind mount into the run's results directory, with a manifest across all managed hosts.
- **Engine override run flag** (`be4a697`): `--engine-override` lets a run override generated-defaults engine config values.
- **Stop before collecting diagnostics** (`353f4b3`): `CollectDiagnostics` (the standalone path used after auto-results) was copying JFR/GC files and deleting the remote diagnostics directory *without* stopping the container first. JFR's `dumponexit` only guarantees the file exists once the JVM has exited, so this could race a still-running process — missing the JFR entirely or deleting a directory mid-write. Both `DockerManager` and `RemoteDockerManager` now stop (or confirm already-stopped) before collecting, on every path; if the stop can't be confirmed, collection is still attempted but the remote directory is preserved instead of deleted.
- **Diagnostics/cleanup ordering + a related race** (`39a1bcc`):
  - The visible completion summary was generated *before* diagnostics collection ran (`fetch -> shutdown -> summary -> diagnostics` instead of `... -> diagnostics -> summary`). `startAutoResults` now takes a `preSummaryHook`, run after shutdown but before the summary.
  - On successful completion with delegated auto-results shutdown, nothing ever called `StopAllContainers`/`Cleanup` — only `CollectDiagnostics` did, which stops but doesn't remove containers or clean up remote staging. A new `FinalizeDiagnosticsAndCleanup` does both, guarded by `sync.Once` so it's safe to call from both the new hook and the existing timeout fallback without duplicating work.
  - Fixes a pre-existing data race (found via `-race` while testing the above): the auto-results step-ID discovery goroutine wasn't joined before the function returned, so it could still be touching package-level test hooks after a test's deferred cleanup reassigned them.
- **Env-applied vs. explicit flags in run metadata** (`51e8256`): `pflag`'s `FlagSet.Set()` marks a flag `Changed=true` regardless of caller, so an env-default injected via `.env`/OS env was indistinguishable from something the user actually typed once recorded in `spt_run_params.json`. Env-applied flags are now tracked separately and excluded from `ChangedFlags`; a new `EnvAppliedFlags` field carries them.
