### PR TITLE
Bound RMI response wait and lower Netty idle timeout default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Fixed
+
+- **Unbounded distributed-coordination RMI waits** — the production JVM defaults (Docker entrypoint and `run.sh`) now set `-Dsun.rmi.transport.tcp.responseTimeout=10000`. Previously a transient network stall on the RMI connection used for entry-worker coordination (start/stop/await polling) could block a test indefinitely instead of failing fast into the existing retry/backoff path, inflating run duration and deflating measured throughput with no corresponding failure recorded.
+- **Netty idle timeout too long to ever catch a stuck operation in a short run** — `storage-net-timeoutMilliSec` default lowered from 300000ms (5 minutes) to 30000ms (matches the sibling S3-AWS driver's own `socketTimeoutMs` default). This is an idle timeout (fires only on zero read/write activity), so it does not penalize large-but-progressing transfers. A stuck S3 operation previously had to survive 5 minutes before Netty's own `IdleStateHandler` would fail it — far longer than most test runs — so it would silently vanish uncounted rather than being recorded as a failure. Workloads that legitimately need more idle headroom (e.g. LIST against large buckets, per `engine/tools/listtest.local.sh`'s existing `LIST_HTTP_TIMEOUT_MS` override) should set `--storage-net-timeoutMilliSec` explicitly.
+
 ## [5.11.2] - 2026-06-29
 
 ### Changed

--- a/engine/bundle/build.gradle
+++ b/engine/bundle/build.gradle
@@ -145,8 +145,12 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 # - UseAVX=2: avoid AVX-512 EVEX glibc code paths with known SIGBUS crashes
 # - DoJVMTIVirtualThreadTransitions: skip JVMTI mount/unmount notifications on every
 #   VirtualThread context switch; reduces per-op overhead when no debugging agent is attached
+# - sun.rmi.transport.tcp.responseTimeout: bounds how long the entry node's socket read
+#   waits for a reply to a distributed-coordination RMI call. Defaults to 0 (wait forever)
+#   in the JDK; without this, a transient network stall on the RMI connection hangs the
+#   whole run indefinitely instead of failing fast into the existing retry path.
 # Override: SPT_JAVA_OPTS="-Xmx8g" ./run.sh ...
-SPT_JAVA_OPTS="${SPT_JAVA_OPTS:--XX:+UseZGC -Xms1g -Xmx4g -XX:MaxDirectMemorySize=64g -XX:+AlwaysPreTouch -XX:+UseNUMA -Xshare:off -XX:UseAVX=2 -XX:+UnlockExperimentalVMOptions -XX:-DoJVMTIVirtualThreadTransitions}"
+SPT_JAVA_OPTS="${SPT_JAVA_OPTS:--XX:+UseZGC -Xms1g -Xmx4g -XX:MaxDirectMemorySize=64g -XX:+AlwaysPreTouch -XX:+UseNUMA -Xshare:off -XX:UseAVX=2 -XX:+UnlockExperimentalVMOptions -XX:-DoJVMTIVirtualThreadTransitions -Dsun.rmi.transport.tcp.responseTimeout=10000}"
 
 # Run Spt with all arguments passed to this script
 java $SPT_JAVA_OPTS -jar "$SCRIPT_DIR/spt.jar" "$@"

--- a/engine/bundle/docker/entrypoint.sh
+++ b/engine/bundle/docker/entrypoint.sh
@@ -26,7 +26,13 @@ set -eu
 #   VirtualThread context switch; reduces per-op overhead when no debugging agent is attached
 # - UseCompactObjectHeaders (JEP 519): 64-bit object headers instead of 128-bit;
 #   reduces heap footprint and GC pressure for high-rate short-lived objects
-DEFAULT_JAVA_OPTS="-XX:+UseZGC -Xms1g -Xmx4g -XX:MaxDirectMemorySize=64g -XX:+AlwaysPreTouch -XX:+UseNUMA -Xshare:off -XX:UseAVX=2 -XX:+UnlockExperimentalVMOptions -XX:-DoJVMTIVirtualThreadTransitions -XX:+UseCompactObjectHeaders"
+# - sun.rmi.transport.tcp.responseTimeout: bounds how long the entry node's socket read
+#   waits for a reply to a distributed-coordination RMI call (e.g. worker start/stop/await
+#   polling). Defaults to 0 (wait forever) in the JDK; a transient network stall on the RMI
+#   connection would otherwise hang the whole test/run indefinitely instead of failing fast
+#   into the existing retry/backoff path. 10s is generous relative to normal sub-10ms RMI
+#   round-trips for these small control-plane calls.
+DEFAULT_JAVA_OPTS="-XX:+UseZGC -Xms1g -Xmx4g -XX:MaxDirectMemorySize=64g -XX:+AlwaysPreTouch -XX:+UseNUMA -Xshare:off -XX:UseAVX=2 -XX:+UnlockExperimentalVMOptions -XX:-DoJVMTIVirtualThreadTransitions -XX:+UseCompactObjectHeaders -Dsun.rmi.transport.tcp.responseTimeout=10000"
 
 # Append any user-provided JAVA_OPTS (like RMI hostname) to the defaults.
 # If a user provides conflicting flags (like -Xmx8g), Java will use the last one specified.

--- a/engine/extensions/storage-drivers/primitives/netty/README.md
+++ b/engine/extensions/storage-drivers/primitives/netty/README.md
@@ -21,7 +21,7 @@ count of the open connections may be limited by `storage-driver-limit-concurrenc
 | storage-net-sndBuf                             | Fixed size >= 0 | 0 | The network connection output buffer size. Estimated automatically if 0 (default)
 | storage-net-selectInterval                     | Integer > 0 | 100 |
 | storage-net-tcpNoDelay                         | Flag | true |
-| storage-net-timeoutMilliSec                    | Integer >= 0 | 300000 | The socket/response idle timeout (milliseconds)
+| storage-net-timeoutMilliSec                    | Integer >= 0 | 30000 | The socket/response idle timeout (milliseconds). This is an idle timeout (fires only when a connection has zero read/write activity for this long), not a total-request cap, so it does not penalize large-but-progressing transfers. List-heavy workloads against large buckets may need more idle headroom (slow delimiter seeding/pagination) -- see the Connection Timeout section below.
 | storage-net-ioRatio                            | 0 < Integer < 100 | 50 | Internal [Netty's I/O ratio parameter](https://github.com/netty/netty/issues/1154#issuecomment-14870909). It's recommended to make it higher for large request/response payload (>1MB)
 | storage-net-transport                          | Enum | nio | The I/O transport to use (see the [details](http://netty.io/wiki/native-transports.html)). By default tries to use "nio" (the most compatible). For Linux try to use "epoll" or "iouring", for MacOS/BSD use "kqueue" (requires rebuilding).
 | storage-net-ssl-ciphers                        | List of strings | null | The list of ciphers to use if SSL is enabled. First cipher in the list that matches is applied. Make sure to match used ciphers and protocols. 
@@ -72,6 +72,13 @@ java -jar spt-<VERSION>.jar \
 See [`cli/docs/PQC_TLS.md`](../../../cli/docs/PQC_TLS.md) for the full guide including verification, troubleshooting, and driver coverage.
 
 ## 4. Connection Timeout
+
+Default is 30 seconds (see the Configuration Reference above). Raise it for workloads where
+a channel can legitimately go idle for a while without being stuck -- LIST against large
+buckets is the main example (slow delimiter seeding/pagination can look idle from the
+client's perspective even though the server is still working); `engine/tools/listtest.local.sh`
+already does this via its own `LIST_HTTP_TIMEOUT_MS` (defaults to 5 minutes for exactly that
+reason):
 
 ```bash
 java -jar spt-<VERSION>.jar \

--- a/engine/extensions/storage-drivers/primitives/netty/src/main/resources/config/defaults-storage-net.yaml
+++ b/engine/extensions/storage-drivers/primitives/netty/src/main/resources/config/defaults-storage-net.yaml
@@ -11,8 +11,18 @@ storage:
     rcvBuf: 0
     sndBuf: 0
     tcpNoDelay: true
-    # Default HTTP socket/idle timeout: 300 seconds (5 minutes)
-    timeoutMilliSec: 300000
+    # Default HTTP socket/idle timeout: 30 seconds. Matches the sibling S3-AWS driver's own
+    # socketTimeoutMs default (see s3-aws/README.md). This is an idle timeout (Netty
+    # IdleStateHandler: fires only when a channel has zero read/write activity for this
+    # long), not a total-request-duration cap, so it does not penalize large-but-progressing
+    # transfers. A stuck connection that never completes and is never detected within this
+    # window would otherwise silently vanish rather than being counted as a failure -- 5
+    # minutes was long enough that this could never fire within a typical short test run.
+    # List-heavy workloads against large buckets can legitimately need more idle headroom
+    # (slow delimiter seeding/pagination); override with --storage-net-timeoutMilliSec=<ms>
+    # for those cases (see engine/tools/listtest.local.sh's LIST_HTTP_TIMEOUT_MS for an
+    # existing example of exactly this override).
+    timeoutMilliSec: 30000
     ioRatio: 80
     transport: epoll
     ssl:

--- a/engine/extensions/storage-drivers/primitives/netty/src/test/java/com/dell/spt/storage/driver/coop/netty/NettyDefaultsConfigTest.java
+++ b/engine/extensions/storage-drivers/primitives/netty/src/test/java/com/dell/spt/storage/driver/coop/netty/NettyDefaultsConfigTest.java
@@ -1,0 +1,55 @@
+package com.dell.spt.storage.driver.coop.netty;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
+import java.io.InputStream;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Guards the shipped {@code storage.net.timeoutMilliSec} default against silent regression.
+ *
+ * <p>This is a real-resource integration check (loads the actual packaged
+ * {@code defaults-storage-net.yaml}, not a copy/mock of it) rather than a unit test against
+ * a hand-written config tree, so it fails if the shipped default ever drifts back toward the
+ * old 300000ms (5 minute) value -- which was long enough that a stuck S3 operation could
+ * never be caught by Netty's own {@code IdleStateHandler} within a typical short test run
+ * (see CHANGELOG.md [Unreleased]).
+ */
+@SuppressWarnings("unchecked")
+class NettyDefaultsConfigTest {
+
+	private static final String DEFAULTS_RESOURCE = "/config/defaults-storage-net.yaml";
+
+	@Test
+	void shippedDefaultTimeoutIsThirtySeconds() throws Exception {
+		final Map<String, Object> root;
+		try (final InputStream in = NettyDefaultsConfigTest.class.getResourceAsStream(DEFAULTS_RESOURCE)) {
+			assertNotNull(in, "missing packaged resource: " + DEFAULTS_RESOURCE);
+			root = new YAMLMapper().readValue(in, Map.class);
+		}
+
+		final var storage = (Map<String, Object>) root.get("storage");
+		assertNotNull(storage, "defaults YAML has no 'storage' branch");
+		final var net = (Map<String, Object>) storage.get("net");
+		assertNotNull(net, "defaults YAML has no 'storage.net' branch");
+
+		final var timeoutMilliSec = (Number) net.get("timeoutMilliSec");
+		assertNotNull(timeoutMilliSec, "storage.net.timeoutMilliSec is not set in the shipped defaults");
+		assertEquals(30_000, timeoutMilliSec.intValue(),
+						"storage.net.timeoutMilliSec default regressed from the intended 30s idle timeout "
+										+ "(matches the sibling S3-AWS driver's socketTimeoutMs default) -- "
+										+ "5 minutes was long enough that a stuck operation could never be "
+										+ "caught within a typical test run; see CHANGELOG.md [Unreleased]");
+
+		// The same value also bounds the initial connection-establish wait
+		// (NettyStorageDriverBase's ChannelOption.CONNECT_TIMEOUT_MILLIS) -- confirm it stayed
+		// comfortably generous for that purpose too rather than accidentally shrinking further.
+		assertTrue(timeoutMilliSec.intValue() >= 10_000,
+						"storage.net.timeoutMilliSec also bounds initial connection attempts; "
+										+ "keep it well above normal same-datacenter connect latency");
+	}
+}


### PR DESCRIPTION
## Summary

Two related fixes found while investigating an dev-vs-release regression check
failure on the lab environment. Both close the same class of gap: an
unbounded wait that lets a transient network stall turn into a silent multi-second
(or multi-minute) hang instead of a fast, countable failure.

- **`-Dsun.rmi.transport.tcp.responseTimeout=10000`** added to the production JVM
  defaults (`entrypoint.sh`, `run.sh` generator). The entry node polls each worker over
  RMI for distributed start/stop/await coordination
  (`LoadStepClientBase.await()` → `stepSlice.await(1, TimeUnit.MILLISECONDS)`). That
  `1ms` only bounds how long the *worker* spends internally polling before replying —
  nothing bounded how long the *entry's* socket read waited for the reply, and the JDK
  property that would cap it defaults to `0` (no timeout, wait forever). JFR captured
  this directly: a thread blocked exactly 30.007s in `jdk.SocketRead`, stack ending in
  `sun.rmi.transport.StreamRemoteCall.executeCall`, inflating the run's wall-clock
  duration and deflating measured throughput with zero corresponding failure recorded.
  Validated on the affected lab at `2000ms` (turned the silent hang into a fast
  `SocketTimeoutException`, absorbed cleanly by the existing `RemoteException`
  retry/backoff path in `LoadStepSliceUtil.await()`); shipping at `10000ms` for extra
  margin against normal sub-10ms RMI round-trip variance.

- **`storage-net-timeoutMilliSec` default lowered from `300000` (5 min) to `30000`**,
  matching the sibling S3-AWS driver's own `socketTimeoutMs` default (also `30000`) —
  the Netty driver's prior default was a 10x outlier against that existing precedent for
  conceptually the same setting. This is a Netty `IdleStateHandler`-based idle timeout
  (fires only on zero read/write activity on a channel), not a total-request-duration
  cap, so it does not penalize large-but-progressing transfers. The prior 5-minute value
  was long enough that a genuinely stuck S3 operation could never be caught by the
  engine's own idle-timeout protection within a typical short test run — the operation
  would just be silently abandoned (uncounted; `CountFail` stayed 0 throughout) once the
  test's own 30s local drain-wait budget (`LoadStepContextImpl.doStop()`) gave up and
  moved on with shutdown. Workloads that legitimately need more idle headroom (LIST
  against large buckets, slow delimiter seeding/pagination) should override explicitly —
  `engine/tools/listtest.local.sh` already does exactly this via its own
  `LIST_HTTP_TIMEOUT_MS`.

Both fixes were validated together against the reproduction environment: the E7
regression gate went from failing (ratio 0.700 vs the 0.85 threshold) to passing (0.868),
and 3/3 follow-up body runs completed cleanly with no stall, vs. 2/3 and 1/3 stalled in
earlier batches without these fixes. One caveat worth flagging: the underlying
network-level cause of the occasional RMI stall on that lab is still unidentified — these
are mitigations that make the code resilient to it, not a fix for whatever causes it.