### PR TITLE
Fix release static binary check

### DIFF
--- a/.github/workflows/release-artifacts.yaml
+++ b/.github/workflows/release-artifacts.yaml
@@ -200,7 +200,8 @@ jobs:
           file cli/build/spt-linux-arm64 | tee /tmp/spt-linux-arm64.file
           grep -q 'statically linked' /tmp/spt-linux-amd64.file
           grep -q 'statically linked' /tmp/spt-linux-arm64.file
-          ldd cli/build/spt-linux-amd64 2>&1 | grep -q 'not a dynamic executable'
+          ldd cli/build/spt-linux-amd64 > /tmp/spt-linux-amd64.ldd 2>&1 || true
+          grep -q 'not a dynamic executable' /tmp/spt-linux-amd64.ldd
 
       - name: Package binaries
         run: |


### PR DESCRIPTION
## Summary
- Fix the release workflow static-binary verification so `ldd`'s expected nonzero exit code for static binaries does not fail under `pipefail`
- Keep the actual assertions that Linux release binaries are statically linked

## Context
The `v5.12.0` release run built static Linux binaries, but failed because `ldd` returned nonzero while printing `not a dynamic executable`. This workflow-only fix should merge before moving/rerunning the `v5.12.0` tag workflow.

## Verification
- `git diff --check`