### PR TITLE
Fix Netty completion and batch dispatch regressions

### DIFF
--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -70,6 +70,12 @@ var (
 	newRunTrackerFunc = func(baseURL string) autoResultsRunTracker {
 		return &runTrackerAdapter{portcheck.NewRunTracker(baseURL)}
 	}
+	// connectMultiHostOrchestratorFunc is a test seam for the command's host
+	// orchestration boundary. It keeps routing tests independent of Docker and
+	// SSH while production continues to use the concrete orchestrator.
+	connectMultiHostOrchestratorFunc = func(ctx context.Context, orchestrator *tui.MultiHostOrchestrator) error {
+		return orchestrator.ConnectHosts(ctx)
+	}
 	discoverStepIDsFunc      = results.DiscoverStepIDs
 	discoverFleetStepIDsFunc = results.DiscoverFleetStepIDs
 	newResultsFetcherFunc    = func(baseURL, outputDir string) autoResultsFetcher {
@@ -1046,7 +1052,7 @@ Available workload types:
 			orchestrator.SetForceCleanup(forceMode)
 
 			// Connect to all hosts
-			err := orchestrator.ConnectHosts(ctx)
+			err := connectMultiHostOrchestratorFunc(ctx, orchestrator)
 			if err != nil {
 				// Clean up scenario file on connection failure
 				if removeErr := os.Remove(scenarioPath); removeErr != nil {

--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -110,12 +110,24 @@ func getAPIPort(cmd *cobra.Command) string {
 	return apiPort
 }
 
+// shouldUseMultiHostOrchestrator selects the path which manages Docker on the
+// configured hosts. A lone remote host must use this path too: the single-host
+// runner owns Docker on the CLI/controller host and would otherwise ignore the
+// remote HostInfo entirely.
+func shouldUseMultiHostOrchestrator(hosts []*hostparse.HostInfo) bool {
+	if len(hosts) > 1 {
+		return true
+	}
+	return len(hosts) == 1 && hosts[0] != nil && !hosts[0].IsLocal
+}
+
 // deriveBaseURL builds the Spt API base URL for results retrieval.
 func deriveBaseURL(apiPort string, hosts []*hostparse.HostInfo) string {
-	if len(hosts) <= 1 {
+	if len(hosts) == 0 || (len(hosts) == 1 && (hosts[0] == nil || hosts[0].IsLocal)) {
 		return fmt.Sprintf("http://localhost:%s", apiPort)
 	}
-	// First host is entry node in distributed runs
+	// The first host is the entry node for both remote single-host and
+	// distributed runs.
 	entry := hosts[0]
 	return fmt.Sprintf("http://%s:%s", entry.Host, apiPort)
 }
@@ -807,17 +819,6 @@ Available workload types:
 			fmt.Println("Using AWS SDK S3 driver (s3-aws).")
 		}
 
-		// Check for port conflicts before launching Spt
-		if err := checkPortConflicts(cmd); err != nil {
-			// Clean up scenario file on conflict resolution failure
-			if removeErr := os.Remove(scenarioPath); removeErr != nil {
-				logger.Debug("Failed to clean up scenario file after port conflict",
-					"file", scenarioPath,
-					"error", removeErr.Error())
-			}
-			return err
-		}
-
 		// Parse and validate test hosts
 		testHostsStr, _ := cmd.Flags().GetString("test-hosts")
 		minHosts, _ := cmd.Flags().GetInt("min-hosts")
@@ -864,6 +865,22 @@ Available workload types:
 			"min_hosts", minHosts,
 			"hosts", testHostsStr,
 			"attach_existing", attachExisting)
+		useMultiHostOrchestrator := shouldUseMultiHostOrchestrator(hostInfos)
+
+		// The local single-host runner owns Docker on the controller, so it
+		// needs the controller port check. Remote and multi-host runs perform
+		// port preflight on each configured Docker host instead.
+		if !useMultiHostOrchestrator {
+			if err := checkPortConflicts(cmd); err != nil {
+				// Clean up scenario file on conflict resolution failure
+				if removeErr := os.Remove(scenarioPath); removeErr != nil {
+					logger.Debug("Failed to clean up scenario file after port conflict",
+						"file", scenarioPath,
+						"error", removeErr.Error())
+				}
+				return err
+			}
+		}
 
 		sptImage := constants.EffectiveSptImage()
 		networkMode, _ := cmd.Flags().GetString("network-mode")
@@ -930,13 +947,13 @@ Available workload types:
 			setSummarySink = summaryWriter.SetSink
 		}
 
-		// Construct the multi-host orchestrator now (before starting the
+		// Construct the host orchestrator now (before starting the
 		// auto-results background tracker below) so FinalizeDiagnosticsAndCleanup
 		// can run as startAutoResults' pre-summary hook. Construction itself is
 		// cheap (no I/O) — ConnectHosts and everything else that actually talks
 		// to the hosts still happens later, in its original place.
 		var multiHostOrchestrator *tui.MultiHostOrchestrator
-		if len(hostInfos) > 1 {
+		if useMultiHostOrchestrator {
 			rmiConfig := tui.RMIConfig{
 				NetworkMode: networkMode,
 				PortStart:   rmiPortStart,
@@ -998,8 +1015,10 @@ Available workload types:
 		fmt.Printf("Launching %s workload against %s...\n", workloadType, endpoint)
 		fmt.Printf("Container: %s\n", sptImage)
 
-		// Create multi-host orchestrator if we have multiple hosts
-		if len(hostInfos) > 1 {
+		// The host orchestrator also handles a single remote host. The legacy
+		// single-host runner owns local Docker and is appropriate only when the
+		// one configured host is local.
+		if useMultiHostOrchestrator {
 			// Warn if using bridge mode with multiple hosts (distributed testing)
 			if networkMode == constants.BridgeNetworkMode {
 				fmt.Println("⚠️  WARNING: Bridge networking may not work for distributed testing.")
@@ -1008,7 +1027,11 @@ Available workload types:
 				fmt.Println()
 			}
 
-			fmt.Printf("Multi-host mode: %d hosts, minimum required: %d\n", len(hostInfos), minHosts)
+			if len(hostInfos) == 1 {
+				fmt.Printf("Remote-host mode: %s\n", hostInfos[0].Original)
+			} else {
+				fmt.Printf("Multi-host mode: %d hosts, minimum required: %d\n", len(hostInfos), minHosts)
+			}
 			if attachExisting {
 				fmt.Println("Attach mode enabled: expecting worker nodes prestarted with --run-node; spt will launch the entry node.")
 			}

--- a/cli/cmd/run_test.go
+++ b/cli/cmd/run_test.go
@@ -25,3 +25,55 @@ func TestDeriveBaseURLMultiHost(t *testing.T) {
 		t.Fatalf("deriveBaseURL() = %q, want %q", got, want)
 	}
 }
+
+func TestDeriveBaseURLSingleRemoteHost(t *testing.T) {
+	hosts := []*hostparse.HostInfo{
+		{Host: "worker.example", IsLocal: false, Original: "root@worker.example"},
+	}
+	got := deriveBaseURL("9000", hosts)
+	want := "http://worker.example:9000"
+	if got != want {
+		t.Fatalf("deriveBaseURL() = %q, want %q", got, want)
+	}
+}
+
+func TestShouldUseMultiHostOrchestrator(t *testing.T) {
+	tests := []struct {
+		name  string
+		hosts []*hostparse.HostInfo
+		want  bool
+	}{
+		{
+			name: "no hosts",
+		},
+		{
+			name: "single local host",
+			hosts: []*hostparse.HostInfo{
+				{Host: "127.0.0.1", IsLocal: true, Original: "127.0.0.1"},
+			},
+		},
+		{
+			name: "single remote host",
+			hosts: []*hostparse.HostInfo{
+				{Host: "worker.example", IsLocal: false, Original: "root@worker.example"},
+			},
+			want: true,
+		},
+		{
+			name: "multiple hosts",
+			hosts: []*hostparse.HostInfo{
+				{Host: "127.0.0.1", IsLocal: true, Original: "127.0.0.1"},
+				{Host: "worker.example", IsLocal: false, Original: "root@worker.example"},
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := shouldUseMultiHostOrchestrator(tt.hosts); got != tt.want {
+				t.Fatalf("shouldUseMultiHostOrchestrator() = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}

--- a/cli/cmd/run_test.go
+++ b/cli/cmd/run_test.go
@@ -1,9 +1,14 @@
 package cmd
 
 import (
+	"context"
+	"errors"
+	"path/filepath"
 	"testing"
 
 	"github.com/dell/storage-performance-tool/cli/internal/hostparse"
+	"github.com/dell/storage-performance-tool/cli/internal/portcheck"
+	"github.com/dell/storage-performance-tool/cli/tui"
 )
 
 func TestDeriveBaseURLSingleHost(t *testing.T) {
@@ -75,5 +80,70 @@ func TestShouldUseMultiHostOrchestrator(t *testing.T) {
 				t.Fatalf("shouldUseMultiHostOrchestrator() = %t, want %t", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestRunCmdSingleRemoteHostUsesOrchestratorAndSkipsControllerPortCheck(t *testing.T) {
+	t.Chdir(t.TempDir())
+
+	setRunFlag := func(name, value string) {
+		t.Helper()
+		flag := runCmd.Flags().Lookup(name)
+		if flag == nil {
+			t.Fatalf("run flag %q not found", name)
+		}
+		previousValue := flag.Value.String()
+		previousChanged := flag.Changed
+		if err := flag.Value.Set(value); err != nil {
+			t.Fatalf("set %s=%q: %v", name, value, err)
+		}
+		flag.Changed = true
+		t.Cleanup(func() {
+			if err := flag.Value.Set(previousValue); err != nil {
+				t.Errorf("restore %s=%q: %v", name, previousValue, err)
+			}
+			flag.Changed = previousChanged
+		})
+	}
+	setRunFlag("test-hosts", "root@worker.example")
+	setRunFlag("min-hosts", "1")
+	setRunFlag("duration", "1s")
+	setRunFlag("object-size", "1K")
+	setRunFlag("threads", "1")
+	setRunFlag("headless", "true")
+	setRunFlag("auto-results", "false")
+
+	previousPortResolver := resolvePortConflictFunc
+	controllerPortChecks := 0
+	resolvePortConflictFunc = func(context.Context, string, bool) (*portcheck.ResolutionResult, error) {
+		controllerPortChecks++
+		return nil, errors.New("controller port preflight must not run for a remote host")
+	}
+	t.Cleanup(func() { resolvePortConflictFunc = previousPortResolver })
+
+	previousConnect := connectMultiHostOrchestratorFunc
+	remoteOrchestratorCalls := 0
+	errRemoteOrchestratorReached := errors.New("remote orchestrator reached")
+	connectMultiHostOrchestratorFunc = func(_ context.Context, orchestrator *tui.MultiHostOrchestrator) error {
+		if orchestrator == nil {
+			t.Fatal("remote path did not construct an orchestrator")
+		}
+		remoteOrchestratorCalls++
+		return errRemoteOrchestratorReached
+	}
+	t.Cleanup(func() { connectMultiHostOrchestratorFunc = previousConnect })
+
+	err := runCmd.RunE(runCmd, []string{WorkloadTypeMock})
+	if !errors.Is(err, errRemoteOrchestratorReached) {
+		t.Fatalf("RunE() error = %v, want remote orchestrator sentinel", err)
+	}
+	if controllerPortChecks != 0 {
+		t.Fatalf("controller port preflight calls = %d, want 0", controllerPortChecks)
+	}
+	if remoteOrchestratorCalls != 1 {
+		t.Fatalf("remote orchestrator calls = %d, want 1", remoteOrchestratorCalls)
+	}
+	if scenarioFiles, globErr := filepath.Glob("spt-scenario-*.js"); globErr != nil || len(scenarioFiles) != 0 {
+		t.Fatalf("scenario cleanup files = %v, glob error = %v", scenarioFiles, globErr)
 	}
 }

--- a/engine/extensions/storage-drivers/implementations/s3/src/main/java/com/dell/spt/storage/driver/coop/netty/http/s3/S3StorageDriver.java
+++ b/engine/extensions/storage-drivers/implementations/s3/src/main/java/com/dell/spt/storage/driver/coop/netty/http/s3/S3StorageDriver.java
@@ -1419,9 +1419,14 @@ public class S3StorageDriver<I extends Item, O extends Operation<I>>
 	@Override
 	protected int submit(final List<O> ops, final int from, final int to)
 					throws IllegalStateException {
+		final var availablePermits = concurrencyThrottle.availablePermits();
+		if (availablePermits == 0) {
+			return 0;
+		}
+		final var dispatchLimit = from + Math.min(availablePermits, to - from);
 		var submitted = 0;
 		var i = from;
-		while (i < to) {
+		while (i < dispatchLimit) {
 			final var op = ops.get(i);
 			if (isCompositeRead(op)) {
 				if (!submit(op)) {
@@ -1431,7 +1436,7 @@ public class S3StorageDriver<I extends Item, O extends Operation<I>>
 				i++;
 			} else {
 				final var segmentStart = i;
-				while (i < to && !isCompositeRead(ops.get(i))) {
+				while (i < dispatchLimit && !isCompositeRead(ops.get(i))) {
 					i++;
 				}
 				final var segmentSubmitted = super.submit(ops, segmentStart, i);

--- a/engine/extensions/storage-drivers/implementations/s3/src/test/java/com/dell/spt/storage/driver/coop/netty/http/s3/S3StorageDriverTest.java
+++ b/engine/extensions/storage-drivers/implementations/s3/src/test/java/com/dell/spt/storage/driver/coop/netty/http/s3/S3StorageDriverTest.java
@@ -56,6 +56,7 @@ import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.ArrayDeque;
+import java.util.AbstractList;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -297,6 +298,11 @@ public class S3StorageDriverTest {
 
 		int submitBatchForTest(List<Operation<Item>> ops, int from, int to) {
 			return submit(ops, from, to);
+		}
+
+		void limitAvailableDispatchPermitsForTest(int permits) {
+			concurrencyThrottle.drainPermits();
+			concurrencyThrottle.release(permits);
 		}
 
 		@Override
@@ -1449,6 +1455,36 @@ public class S3StorageDriverTest {
 		assertEquals(Operation.Status.SUCC, op.status(), "Composite READ parent should be marked SUCC");
 		var queue = childQueueOf(drv);
 		assertEquals(4, queue.size(), "Batch submit should dispatch 4 range-read sub-ops");
+	}
+
+	@Test
+	void submit_batchOrdinaryWrites_inspectionIsBoundedByAvailablePermits() throws Exception {
+		Config cfg = baseConfig(false, 4, false, null, "s3.us-east-1.amazonaws.com:443");
+		TestS3Driver drv = new TestS3Driver(cfg);
+		drv.limitAvailableDispatchPermitsForTest(4);
+
+		@SuppressWarnings("unchecked")
+		final var writeOp = (Operation<Item>) Mockito.mock(Operation.class);
+		Mockito.when(writeOp.type()).thenReturn(OpType.CREATE);
+		final var inspected = new int[1];
+		final List<Operation<Item>> ops = new AbstractList<>() {
+			@Override
+			public Operation<Item> get(final int index) {
+				inspected[0]++;
+				return writeOp;
+			}
+
+			@Override
+			public int size() {
+				return 10_000;
+			}
+		};
+
+		drv.submitBatchForTest(ops, 0, ops.size());
+
+		assertTrue(inspected[0] <= 8,
+						"Batch dispatch inspected " + inspected[0]
+										+ " operations even though only 4 permits were available");
 	}
 
 	@Test

--- a/engine/extensions/storage-drivers/primitives/netty/src/main/java/com/dell/spt/storage/driver/coop/netty/NettyStorageDriverBase.java
+++ b/engine/extensions/storage-drivers/primitives/netty/src/main/java/com/dell/spt/storage/driver/coop/netty/NettyStorageDriverBase.java
@@ -466,6 +466,12 @@ public abstract class NettyStorageDriverBase<I extends Item, O extends Operation
 				}
 				n++;
 			}
+			// shutdown may race after drainPermits() but before every leased permit
+			// becomes an in-flight request. Return only the permits that were never
+			// dispatched; completed NOOPs and asynchronous requests own their own permit.
+			if (n < permits) {
+				concurrencyThrottle.release(permits - n);
+			}
 		} catch (final ConnectException e) {
 			LogUtil.exception(Level.WARN, e, "Failed to lease the connection for the load operation");
 			nextOp.status(Operation.Status.FAIL_IO);

--- a/engine/extensions/storage-drivers/primitives/netty/src/main/java/com/dell/spt/storage/driver/coop/netty/NettyStorageDriverBase.java
+++ b/engine/extensions/storage-drivers/primitives/netty/src/main/java/com/dell/spt/storage/driver/coop/netty/NettyStorageDriverBase.java
@@ -661,6 +661,15 @@ public abstract class NettyStorageDriverBase<I extends Item, O extends Operation
 			LogUtil.exception(Level.DEBUG, e, "{}: invalid load operation state", op.toString());
 		}
 
+			// An idle channel remains in the pipeline after it is returned to the pool.
+			// Do not let a later IdleStateEvent complete this already-finished operation again.
+			if (channel != null) {
+				final var operationAttr = channel.attr(ATTR_KEY_OPERATION);
+				if (operationAttr != null) {
+					operationAttr.compareAndSet(op, null);
+				}
+			}
+
 		if (op.status() != Operation.Status.SUCC && channel != null) {
 			channel.close();
 		}

--- a/engine/extensions/storage-drivers/primitives/netty/src/main/java/com/dell/spt/storage/driver/coop/netty/NettyStorageDriverBase.java
+++ b/engine/extensions/storage-drivers/primitives/netty/src/main/java/com/dell/spt/storage/driver/coop/netty/NettyStorageDriverBase.java
@@ -661,14 +661,11 @@ public abstract class NettyStorageDriverBase<I extends Item, O extends Operation
 			LogUtil.exception(Level.DEBUG, e, "{}: invalid load operation state", op.toString());
 		}
 
-			// An idle channel remains in the pipeline after it is returned to the pool.
-			// Do not let a later IdleStateEvent complete this already-finished operation again.
-			if (channel != null) {
-				final var operationAttr = channel.attr(ATTR_KEY_OPERATION);
-				if (operationAttr != null) {
-					operationAttr.compareAndSet(op, null);
-				}
-			}
+		// An idle channel remains in the pipeline after it is returned to the pool.
+		// Do not let a later IdleStateEvent complete this already-finished operation again.
+		if (channel != null && channel.hasAttr(ATTR_KEY_OPERATION)) {
+			channel.attr(ATTR_KEY_OPERATION).compareAndSet(op, null);
+		}
 
 		if (op.status() != Operation.Status.SUCC && channel != null) {
 			channel.close();

--- a/engine/extensions/storage-drivers/primitives/netty/src/test/java/com/dell/spt/storage/driver/coop/netty/NettyCompletionPathTest.java
+++ b/engine/extensions/storage-drivers/primitives/netty/src/test/java/com/dell/spt/storage/driver/coop/netty/NettyCompletionPathTest.java
@@ -123,6 +123,26 @@ class NettyCompletionPathTest {
 	}
 
 	@Test
+	void complete_clearsOperationAttributeBeforeReleasingChannel() throws Exception {
+		final var channel = newChannelWithReleasedFlag();
+		final Operation<Item> op = mock(Operation.class);
+		when(op.status()).thenReturn(Operation.Status.SUCC);
+		when(op.result()).thenReturn(mock(Operation.class));
+		channel.attr(NettyStorageDriver.ATTR_KEY_OPERATION).set(op);
+
+		doAnswer(inv -> {
+			assertNull(channel.attr(NettyStorageDriver.ATTR_KEY_OPERATION).get(),
+							"a released channel must not retain its completed operation");
+			return null;
+		}).when(connPool).release(channel);
+
+		driver.complete(channel, op);
+
+		assertNull(channel.attr(NettyStorageDriver.ATTR_KEY_OPERATION).get());
+		channel.close();
+	}
+
+	@Test
 	void complete_releasesPermitBeforeHandleCompleted() throws Exception {
 		// Verify the ordering guarantee: permit is freed before handleCompleted runs,
 		// so child ops submitted by handleCompleted can re-acquire a permit.

--- a/engine/extensions/storage-drivers/primitives/netty/src/test/java/com/dell/spt/storage/driver/coop/netty/NettyCompletionPathTest.java
+++ b/engine/extensions/storage-drivers/primitives/netty/src/test/java/com/dell/spt/storage/driver/coop/netty/NettyCompletionPathTest.java
@@ -716,6 +716,26 @@ class NettyCompletionPathTest {
 	}
 
 	@Test
+	void batchSubmit_releasesDrainedPermitsWhenDriverIsShuttingDown() throws Exception {
+		// A shutdown can race after drainPermits() but before any operation is
+		// dispatched. Those permits represent no in-flight I/O and must be returned.
+		final var sem = new Semaphore(4, true);
+		final var semField = CoopStorageDriverBase.class.getDeclaredField("concurrencyThrottle");
+		semField.setAccessible(true);
+		semField.set(driver, sem);
+		final var limitField = StorageDriverBase.class.getDeclaredField("concurrencyLimit");
+		limitField.setAccessible(true);
+		limitField.set(driver, 4);
+		when(driver.isStarted()).thenReturn(false);
+
+		final List<Operation<Item>> ops = List.of(mock(Operation.class), mock(Operation.class));
+
+		assertEquals(0, driver.submit(ops, 0, ops.size()));
+		assertEquals(4, sem.availablePermits(),
+						"shutdown must not strand permits for operations that were never dispatched");
+	}
+
+	@Test
 	void batchSubmit_releasesPermitsOnConnectionFailure() throws Exception {
 		// When a connection lease fails mid-batch, all permits must be returned:
 		// the failed op's permit is explicitly released (conn==null path),

--- a/engine/extensions/storage-drivers/primitives/netty/src/test/java/com/dell/spt/storage/driver/coop/netty/NettyCompletionPathTest.java
+++ b/engine/extensions/storage-drivers/primitives/netty/src/test/java/com/dell/spt/storage/driver/coop/netty/NettyCompletionPathTest.java
@@ -13,9 +13,10 @@ import com.dell.spt.base.storage.driver.StorageDriverBase;
 import com.dell.spt.storage.driver.coop.CoopStorageDriverBase;
 import com.github.akurilov.commons.io.Output;
 import com.github.akurilov.netty.connection.pool.NonBlockingConnPool;
+import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.timeout.IdleStateEvent;
-import java.net.SocketTimeoutException;
+import io.netty.handler.timeout.IdleStateHandler;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ArrayBlockingQueue;
@@ -125,7 +126,8 @@ class NettyCompletionPathTest {
 	}
 
 	@Test
-	void releasedChannelIdleEventDoesNotCompleteThePriorOperationAgain() throws Exception {
+	void idleStateHandlerDoesNotCompleteThePriorOperationAfterChannelRelease() throws Exception {
+		final var idleEventCount = new AtomicInteger();
 		final var handler = new ResponseHandlerBase<Object, Item, Operation<Item>>(driver, false) {
 			@Override
 			protected void handle(
@@ -133,7 +135,18 @@ class NettyCompletionPathTest {
 				// No response body is needed for this lifecycle test.
 			}
 		};
-		final var channel = new EmbeddedChannel(handler);
+		final var channel = new EmbeddedChannel(
+						new IdleStateHandler(0, 0, 1, TimeUnit.MILLISECONDS),
+						new ChannelInboundHandlerAdapter() {
+							@Override
+							public void userEventTriggered(final io.netty.channel.ChannelHandlerContext ctx, final Object evt) {
+								if (evt instanceof IdleStateEvent) {
+									idleEventCount.incrementAndGet();
+								}
+								ctx.fireUserEventTriggered(evt);
+							}
+						},
+						handler);
 		channel.attr(NettyStorageDriver.ATTR_KEY_RELEASED).set(Boolean.FALSE);
 		final Operation<Item> op = mock(Operation.class);
 		when(op.status()).thenReturn(Operation.Status.SUCC);
@@ -142,16 +155,16 @@ class NettyCompletionPathTest {
 
 		driver.complete(channel, op);
 
-		final var handlerContext = channel.pipeline().context(handler);
-		final var timeout = assertThrows(SocketTimeoutException.class,
-						() -> handler.userEventTriggered(handlerContext, IdleStateEvent.ALL_IDLE_STATE_EVENT));
+		// Exercise the actual scheduled IdleStateHandler path, not a manually-invoked
+		// userEventTriggered proxy. Before the attribute clear, this timed-out event
+		// completed the prior operation again after its channel had been released.
+		channel.advanceTimeBy(1, TimeUnit.MILLISECONDS);
+		channel.runScheduledPendingTasks();
+		channel.runPendingTasks();
 
-		// Deliver the timeout through the response handler's real pipeline context.
-		// Before this fix, exceptionCaught found the released channel's stale operation.
-		channel.pipeline().fireExceptionCaught(timeout);
-
+		assertTrue(idleEventCount.get() > 0, "IdleStateHandler should emit an idle event");
 		verify(driver, times(1)).complete(channel, op);
-		verify(op, never()).status(Operation.Status.FAIL_IO);
+		verify(op, never()).status(any(Operation.Status.class));
 		verify(connPool, times(1)).release(channel);
 		channel.finishAndReleaseAll();
 	}

--- a/engine/extensions/storage-drivers/primitives/netty/src/test/java/com/dell/spt/storage/driver/coop/netty/NettyCompletionPathTest.java
+++ b/engine/extensions/storage-drivers/primitives/netty/src/test/java/com/dell/spt/storage/driver/coop/netty/NettyCompletionPathTest.java
@@ -14,6 +14,8 @@ import com.dell.spt.storage.driver.coop.CoopStorageDriverBase;
 import com.github.akurilov.commons.io.Output;
 import com.github.akurilov.netty.connection.pool.NonBlockingConnPool;
 import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.timeout.IdleStateEvent;
+import java.net.SocketTimeoutException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ArrayBlockingQueue;
@@ -123,23 +125,35 @@ class NettyCompletionPathTest {
 	}
 
 	@Test
-	void complete_clearsOperationAttributeBeforeReleasingChannel() throws Exception {
-		final var channel = newChannelWithReleasedFlag();
+	void releasedChannelIdleEventDoesNotCompleteThePriorOperationAgain() throws Exception {
+		final var handler = new ResponseHandlerBase<Object, Item, Operation<Item>>(driver, false) {
+			@Override
+			protected void handle(
+							final io.netty.channel.Channel channel, final Operation<Item> op, final Object msg) {
+				// No response body is needed for this lifecycle test.
+			}
+		};
+		final var channel = new EmbeddedChannel(handler);
+		channel.attr(NettyStorageDriver.ATTR_KEY_RELEASED).set(Boolean.FALSE);
 		final Operation<Item> op = mock(Operation.class);
 		when(op.status()).thenReturn(Operation.Status.SUCC);
 		when(op.result()).thenReturn(mock(Operation.class));
 		channel.attr(NettyStorageDriver.ATTR_KEY_OPERATION).set(op);
 
-		doAnswer(inv -> {
-			assertNull(channel.attr(NettyStorageDriver.ATTR_KEY_OPERATION).get(),
-							"a released channel must not retain its completed operation");
-			return null;
-		}).when(connPool).release(channel);
-
 		driver.complete(channel, op);
 
-		assertNull(channel.attr(NettyStorageDriver.ATTR_KEY_OPERATION).get());
-		channel.close();
+		final var handlerContext = channel.pipeline().context(handler);
+		final var timeout = assertThrows(SocketTimeoutException.class,
+						() -> handler.userEventTriggered(handlerContext, IdleStateEvent.ALL_IDLE_STATE_EVENT));
+
+		// Deliver the timeout through the response handler's real pipeline context.
+		// Before this fix, exceptionCaught found the released channel's stale operation.
+		channel.pipeline().fireExceptionCaught(timeout);
+
+		verify(driver, times(1)).complete(channel, op);
+		verify(op, never()).status(Operation.Status.FAIL_IO);
+		verify(connPool, times(1)).release(channel);
+		channel.finishAndReleaseAll();
 	}
 
 	@Test
@@ -356,6 +370,38 @@ class NettyCompletionPathTest {
 		// Also verify the op was re-submitted (startRequest called on the re-prepared op)
 		verify(op, atLeast(1)).startRequest();
 		channel.close();
+		resubmitChannel.close();
+	}
+
+	@Test
+	void fastRecycleClearsReleasedChannelAndRebindsOperationToResubmissionChannel() throws Exception {
+		enableFastRecycle(4);
+		final var limitField = StorageDriverBase.class.getDeclaredField("concurrencyLimit");
+		limitField.setAccessible(true);
+		limitField.set(driver, 4);
+		final var sem = new Semaphore(4, true);
+		sem.acquire(1);
+		final var semField = CoopStorageDriverBase.class.getDeclaredField("concurrencyThrottle");
+		semField.setAccessible(true);
+		semField.set(driver, sem);
+
+		final var releasedChannel = newChannelWithReleasedFlag();
+		final Operation<Item> op = mock(Operation.class);
+		when(op.status()).thenReturn(Operation.Status.SUCC);
+		when(op.result()).thenReturn(mock(Operation.class));
+		releasedChannel.attr(NettyStorageDriver.ATTR_KEY_OPERATION).set(op);
+
+		final var resubmitChannel = newResubmitChannel();
+		when(connPool.lease()).thenReturn(resubmitChannel);
+		doAnswer(inv -> {
+			assertNull(releasedChannel.attr(NettyStorageDriver.ATTR_KEY_OPERATION).get());
+			return null;
+		}).when(connPool).release(releasedChannel);
+
+		driver.complete(releasedChannel, op);
+
+		assertSame(op, resubmitChannel.attr(NettyStorageDriver.ATTR_KEY_OPERATION).get());
+		releasedChannel.close();
 		resubmitChannel.close();
 	}
 


### PR DESCRIPTION
## Summary

- clear a completed operation from its Netty channel before the channel returns to the pool, preventing a later idle event from completing and failing the old operation again
- preserve fast-recycle behavior by rebinding the operation only to its resubmission channel
- release batch permits acquired but not dispatched when shutdown races with batch submission
- bound the S3 composite-read scan to the permit-eligible batch prefix, avoiding repeated scans of the remaining ordinary-write list
- route a single remote test host through the remote orchestrator, use its API endpoint for results, and avoid controller-local port checks

## Motivation

A released Netty channel retained its prior operation attribute. If the idle handler fired before that channel was reused, the stale operation could be completed a second time and changed to `FAIL_IO`, contributing to the observed drain/socket-timeout behavior.

The composite-read batch wrapper added in `1b61163` also scanned the full remaining operation list before each permit-limited write submission. On the Proxmox source gate this reduced current throughput by about 11% and exposed the shutdown drain race. Limiting inspection to the prefix that can actually be submitted restores the bulk write path without bypassing composite reads.

Single remote-host CLI runs were additionally taking the local Docker runner path, ignoring the configured remote host. They now use the same host orchestrator boundary as distributed runs.