### PR TITLE
Fix DataItemFileRegion partial-write accounting

### DIFF
--- a/engine/extensions/storage-drivers/primitives/netty/src/main/java/com/dell/spt/storage/driver/coop/netty/data/DataItemFileRegion.java
+++ b/engine/extensions/storage-drivers/primitives/netty/src/main/java/com/dell/spt/storage/driver/coop/netty/data/DataItemFileRegion.java
@@ -13,18 +13,20 @@ public class DataItemFileRegion
 				implements FileRegion {
 
 	protected final DataItem dataItem;
-	protected final long baseItemSize;
+	protected final long baseItemPosition;
+	protected final long byteCount;
 	protected long doneByteCount = 0;
 
 	public DataItemFileRegion(final DataItem dataItem)
 					throws IOException {
 		this.dataItem = dataItem;
-		this.baseItemSize = dataItem.size();
+		this.baseItemPosition = dataItem.position();
+		this.byteCount = dataItem.size() - baseItemPosition;
 	}
 
 	@Override
 	public long position() {
-		return doneByteCount;
+		return baseItemPosition;
 	}
 
 	@Deprecated
@@ -40,15 +42,16 @@ public class DataItemFileRegion
 
 	@Override
 	public long count() {
-		return baseItemSize;
+		return byteCount;
 	}
 
 	@Override
 	public long transferTo(final WritableByteChannel target, final long position)
 					throws IOException {
-		dataItem.position(position);
-		doneByteCount += dataItem.writeToSocketChannel(target, baseItemSize - position);
-		return doneByteCount;
+		dataItem.position(baseItemPosition + position);
+		final long bytesWritten = dataItem.writeToSocketChannel(target, byteCount - position);
+		doneByteCount += bytesWritten;
+		return bytesWritten;
 	}
 
 	@Override

--- a/engine/extensions/storage-drivers/primitives/netty/src/test/java/com/dell/spt/storage/driver/coop/netty/data/DataItemFileRegionTest.java
+++ b/engine/extensions/storage-drivers/primitives/netty/src/test/java/com/dell/spt/storage/driver/coop/netty/data/DataItemFileRegionTest.java
@@ -1,0 +1,104 @@
+package com.dell.spt.storage.driver.coop.netty.data;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertIterableEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.dell.spt.base.data.DataInput;
+import com.dell.spt.base.item.DataItemImpl;
+import com.github.akurilov.commons.system.SizeInBytes;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.ByteBuffer;
+import java.nio.channels.WritableByteChannel;
+import java.util.ArrayList;
+import java.util.List;
+
+class DataItemFileRegionTest {
+
+	@Test
+	void partialWritesFollowFileRegionProgressContract() throws Exception {
+		try (final var dataInput = DataInput.instance(
+						null, "7a42d9c483244167", new SizeInBytes("64KB"), 1, false)) {
+			final var dataItem = new DataItemImpl("item", 0, 26);
+			dataItem.dataInput(dataInput);
+			dataItem.position(3);
+			final var region = new DataItemFileRegion(dataItem);
+			final var target = new LimitedWritableByteChannel(5);
+			final var transferResults = new ArrayList<Long>();
+			final var transferredProgress = new ArrayList<Long>();
+			final var regionPositions = new ArrayList<Long>();
+
+			try {
+				final long initialPosition = region.position();
+				while (target.totalBytesWritten() < region.count()) {
+					final long actualProgress = target.totalBytesWritten();
+					transferResults.add(region.transferTo(target, actualProgress));
+					transferredProgress.add(region.transferred());
+					regionPositions.add(region.position());
+				}
+				final long resultAfterCompletion = region.transferTo(target, target.totalBytesWritten());
+
+				assertAll(
+								() -> assertEquals(3, initialPosition),
+								() -> assertEquals(23, region.count()),
+								() -> assertEquals(region.count(), target.totalBytesWritten()),
+								() -> assertEquals(region.count(), region.transferred()),
+								() -> assertIterableEquals(target.bytesWrittenPerCall(), transferResults),
+								() -> assertIterableEquals(target.cumulativeBytesWritten(), transferredProgress),
+								() -> assertTrue(regionPositions.stream().allMatch(position -> position == initialPosition)),
+								() -> assertTrue(transferredProgress.stream().allMatch(progress -> progress <= region.count())),
+								() -> assertEquals(0, resultAfterCompletion));
+			} finally {
+				region.release();
+				target.close();
+			}
+		}
+	}
+
+	private static final class LimitedWritableByteChannel implements WritableByteChannel {
+		private final int maxBytesPerWrite;
+		private final List<Long> bytesWrittenPerCall = new ArrayList<>();
+		private final List<Long> cumulativeBytesWritten = new ArrayList<>();
+		private long totalBytesWritten;
+		private boolean open = true;
+
+		private LimitedWritableByteChannel(final int maxBytesPerWrite) {
+			this.maxBytesPerWrite = maxBytesPerWrite;
+		}
+
+		@Override
+		public int write(final ByteBuffer source) {
+			final int bytesWritten = Math.min(maxBytesPerWrite, source.remaining());
+			source.position(source.position() + bytesWritten);
+			totalBytesWritten += bytesWritten;
+			bytesWrittenPerCall.add((long) bytesWritten);
+			cumulativeBytesWritten.add(totalBytesWritten);
+			return bytesWritten;
+		}
+
+		private List<Long> bytesWrittenPerCall() {
+			return bytesWrittenPerCall;
+		}
+
+		private List<Long> cumulativeBytesWritten() {
+			return cumulativeBytesWritten;
+		}
+
+		private long totalBytesWritten() {
+			return totalBytesWritten;
+		}
+
+		@Override
+		public boolean isOpen() {
+			return open;
+		}
+
+		@Override
+		public void close() {
+			open = false;
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- keep `DataItemFileRegion.position()` fixed at the wrapped data item's starting position
- define the region count as the bytes remaining from that starting position
- return only bytes written by the current `transferTo()` invocation
- keep `transferred()` as cumulative actual progress
- add a deterministic partial-write contract test using a real `DataItemImpl` and a destination channel limited to five bytes per write

## Motivation

`DataItemFileRegion` previously returned cumulative progress from `transferTo()` and also exposed that progress through `position()`. Netty's `FileRegion` contract treats `position()` as the immutable region start, `transferred()` as cumulative progress, and the `transferTo()` return value as progress from that invocation.

The regression test records a 23-byte region transferred as `5, 5, 5, 5, 3`, verifies cumulative progress after every call, and requires a zero-byte result after completion. Against `main`, it failed on the cumulative return value, mutable position, and nonzero post-completion return before passing with this correction.

The cumulative `doneByteCount += bytesWritten` behavior intentionally matches Netty 4.1.132's `DefaultFileRegion`. Both the pinned NIO and epoll generic `FileRegion` paths pass `region.transferred()` as the next relative transfer position.

## Scope

This corrects the non-TLS write path, where SPT sends a `DataItemFileRegion`. TLS writes use `SeekableByteChannelChunkedNioStream` and are unchanged.