### PR TITLE
fix service thread startup delivery

### DIFF
--- a/cli/internal/scenario/defaults.go
+++ b/cli/internal/scenario/defaults.go
@@ -398,7 +398,8 @@ func GenerateDefaults(params Params) ([]byte, error) {
 		}
 	}
 
-	// Engine tuning: VT carrier parallelism
+	// Keep this in /run defaults for effective-config attribution even though
+	// startup argument delivery is what activates VT parallelism for the node JVM.
 	if params.ServiceThreads > 0 {
 		if config.Load == nil {
 			config.Load = &LoadConfig{}
@@ -510,4 +511,56 @@ func parseEngineOverrideValue(raw string) (any, error) {
 		return nil, err
 	}
 	return value, nil
+}
+
+const loadServiceThreadsStartupArg = "--load-service-threads="
+
+// BuildEngineStartupArgs resolves engine settings that must be present before
+// the node API starts. They cannot be activated by defaults posted later to /run.
+func BuildEngineStartupArgs(params Params) ([]string, error) {
+	if params.ServiceThreads < 0 {
+		return nil, fmt.Errorf("service threads must be non-negative, got %d", params.ServiceThreads)
+	}
+
+	effectiveThreads := params.ServiceThreads
+	overrideThreads := 0
+	overrideSeen := false
+	for _, override := range params.EngineOverrides {
+		rawPath, rawValue, hasValue := strings.Cut(override, "=")
+		parts := splitEngineOverridePath(rawPath)
+		if len(parts) != 3 || parts[0] != "load" || parts[1] != "service" || parts[2] != "threads" {
+			continue
+		}
+		if !hasValue {
+			return nil, fmt.Errorf("invalid engine override %q: expected path=value", override)
+		}
+
+		value, err := parseEngineOverrideValue(rawValue)
+		if err != nil {
+			return nil, fmt.Errorf("invalid engine override %q: %w", override, err)
+		}
+		threads, ok := value.(int)
+		if !ok {
+			return nil, fmt.Errorf("invalid engine override %q: load.service.threads must be an integer", override)
+		}
+		if threads < 0 {
+			return nil, fmt.Errorf("invalid engine override %q: load.service.threads must be non-negative", override)
+		}
+		if overrideSeen && threads != overrideThreads {
+			return nil, fmt.Errorf("conflicting load.service.threads engine overrides: %d and %d", overrideThreads, threads)
+		}
+		overrideThreads = threads
+		overrideSeen = true
+	}
+
+	if overrideSeen {
+		if effectiveThreads > 0 && effectiveThreads != overrideThreads {
+			return nil, fmt.Errorf("conflicting service thread settings: --service-threads=%d and load.service.threads=%d", effectiveThreads, overrideThreads)
+		}
+		effectiveThreads = overrideThreads
+	}
+	if effectiveThreads == 0 {
+		return nil, nil
+	}
+	return []string{fmt.Sprintf("%s%d", loadServiceThreadsStartupArg, effectiveThreads)}, nil
 }

--- a/cli/internal/scenario/defaults_test.go
+++ b/cli/internal/scenario/defaults_test.go
@@ -1,6 +1,7 @@
 package scenario
 
 import (
+	"reflect"
 	"strings"
 	"testing"
 
@@ -1342,5 +1343,103 @@ func TestGenerateDefaultsRejectsInvalidEngineOverrides(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "path=value") {
 		t.Fatalf("expected path=value error, got %v", err)
+	}
+}
+
+func TestBuildEngineStartupArgs(t *testing.T) {
+	tests := []struct {
+		name   string
+		params Params
+		want   []string
+	}{
+		{
+			name:   "service threads flag",
+			params: Params{ServiceThreads: 3},
+			want:   []string{"--load-service-threads=3"},
+		},
+		{
+			name: "dotted engine override",
+			params: Params{
+				EngineOverrides: []string{"load.service.threads=4"},
+			},
+			want: []string{"--load-service-threads=4"},
+		},
+		{
+			name: "dash separated engine override",
+			params: Params{
+				EngineOverrides: []string{"load-service-threads=6"},
+			},
+			want: []string{"--load-service-threads=6"},
+		},
+		{
+			name: "matching flag and override",
+			params: Params{
+				ServiceThreads:  4,
+				EngineOverrides: []string{"load.service.threads=4"},
+			},
+			want: []string{"--load-service-threads=4"},
+		},
+		{name: "automatic default", params: Params{}, want: nil},
+		{
+			name: "unrelated override",
+			params: Params{
+				EngineOverrides: []string{"storage.driver.threads=6"},
+			},
+			want: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := BuildEngineStartupArgs(tt.params)
+			if err != nil {
+				t.Fatalf("BuildEngineStartupArgs() error = %v", err)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("BuildEngineStartupArgs() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBuildEngineStartupArgsRejectsInvalidServiceThreads(t *testing.T) {
+	tests := []struct {
+		name   string
+		params Params
+	}{
+		{
+			name: "conflicting flag and override",
+			params: Params{
+				ServiceThreads:  3,
+				EngineOverrides: []string{"load.service.threads=4"},
+			},
+		},
+		{
+			name: "conflicting overrides",
+			params: Params{
+				EngineOverrides: []string{"load.service.threads=3", "load-service-threads=4"},
+			},
+		},
+		{
+			name: "non integer override",
+			params: Params{
+				EngineOverrides: []string{"load.service.threads=four"},
+			},
+		},
+		{
+			name: "negative override",
+			params: Params{
+				EngineOverrides: []string{"load.service.threads=-1"},
+			},
+		},
+		{name: "negative flag", params: Params{ServiceThreads: -1}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := BuildEngineStartupArgs(tt.params); err == nil {
+				t.Fatal("BuildEngineStartupArgs() error = nil, want validation error")
+			}
+		})
 	}
 }

--- a/cli/tui/api_integration_test.go
+++ b/cli/tui/api_integration_test.go
@@ -233,7 +233,7 @@ func TestAPIIntegrationFullFlow(t *testing.T) {
 	defer cancel()
 
 	// Start container
-	containerID, err := mockDM.StartContainerInNodeMode("test-image", constants.SptAPIPort, constants.DefaultNetworkMode)
+	containerID, err := mockDM.StartContainerInNodeMode("test-image", constants.SptAPIPort, constants.DefaultNetworkMode, nil)
 	if err != nil {
 		t.Fatalf("Failed to start container: %v", err)
 	}

--- a/cli/tui/docker.go
+++ b/cli/tui/docker.go
@@ -594,9 +594,9 @@ func (dm *DockerManager) StartContainerWithScenario(image string, scenarioPath s
 }
 
 // StartContainerInNodeMode starts a Spt container in API server mode.
-func (dm *DockerManager) StartContainerInNodeMode(image string, apiPort string, networkMode string) (string, error) {
+func (dm *DockerManager) StartContainerInNodeMode(image string, apiPort string, networkMode string, additionalArgs []string) (string, error) {
 	if dm.remote != nil {
-		return dm.remote.StartContainerInNodeMode(image, apiPort, networkMode)
+		return dm.remote.StartContainerInNodeMode(image, apiPort, networkMode, additionalArgs)
 	}
 
 	if err := dm.ensureImageAvailable(image); err != nil {
@@ -604,10 +604,12 @@ func (dm *DockerManager) StartContainerInNodeMode(image string, apiPort string, 
 	}
 
 	// Build command for node mode
-	cmd := []string{
+	cmd := make([]string, 0, 2+len(additionalArgs))
+	cmd = append(cmd,
 		dockerNodeModeArg,
-		"--run-port=" + apiPort,
-	}
+		"--run-port="+apiPort,
+	)
+	cmd = append(cmd, additionalArgs...)
 
 	logging.LogContainerEvent("creating", "", "image", image, "mode", "node", "port", apiPort, "cmd", cmd)
 
@@ -713,16 +715,18 @@ func (dm *DockerManager) StartContainerInNodeMode(image string, apiPort string, 
 }
 
 // StartWorkerNodeContainer starts a container in RMI worker node mode
-func (dm *DockerManager) StartWorkerNodeContainer(image string, rmiHostname string, rmiPortStart, rmiPortCount int) (string, error) {
+func (dm *DockerManager) StartWorkerNodeContainer(image string, rmiHostname string, rmiPortStart, rmiPortCount int, additionalArgs []string) (string, error) {
 	if dm.remote != nil {
-		return dm.remote.StartWorkerNodeContainer(image, rmiHostname, rmiPortStart, rmiPortCount)
+		return dm.remote.StartWorkerNodeContainer(image, rmiHostname, rmiPortStart, rmiPortCount, additionalArgs)
 	}
 
 	// Build command for worker node mode
-	cmd := []string{
+	cmd := make([]string, 0, 2+len(additionalArgs))
+	cmd = append(cmd,
 		dockerNodeModeArg,
-		"--run-port=" + constants.SptAPIPort, // REST API port
-	}
+		"--run-port="+constants.SptAPIPort, // REST API port
+	)
+	cmd = append(cmd, additionalArgs...)
 
 	logging.LogContainerEvent("creating", "", "image", image, "mode", "worker_node", "rmi_hostname", rmiHostname, "cmd", cmd)
 

--- a/cli/tui/docker_client_shim_test.go
+++ b/cli/tui/docker_client_shim_test.go
@@ -116,7 +116,7 @@ func TestStartContainerInNodeModeMountsItemFiles(t *testing.T) {
 	if err := dm.SetFileMounts(mounts); err != nil {
 		t.Fatalf("SetFileMounts() error = %v", err)
 	}
-	if _, err := dm.StartContainerInNodeMode("test-image", "10080", constants.BridgeNetworkMode); err != nil {
+	if _, err := dm.StartContainerInNodeMode("test-image", "10080", constants.BridgeNetworkMode, nil); err != nil {
 		t.Fatalf("StartContainerInNodeMode() error = %v", err)
 	}
 	if f.createHostConfig == nil {
@@ -331,7 +331,7 @@ func TestStartContainerInNodeModeUsesConfiguredNodeLogDir(t *testing.T) {
 	dm := &DockerManager{client: f, ctx: context.Background()}
 	dm.setNodeLogResultsRoot(resultsRoot)
 
-	if _, err := dm.StartContainerInNodeMode("test-image", "10080", constants.BridgeNetworkMode); err != nil {
+	if _, err := dm.StartContainerInNodeMode("test-image", "10080", constants.BridgeNetworkMode, nil); err != nil {
 		t.Fatalf("StartContainerInNodeMode() error = %v", err)
 	}
 	wantDir := filepath.Join(resultsRoot, dockerNodeLogResultsDirName)
@@ -357,7 +357,7 @@ func TestStartContainerInNodeModeUsesDiagnosticsMountWhenJavaOptsSet(t *testing.
 	dm := &DockerManager{client: f, ctx: context.Background()}
 	dm.setDiagnosticsResultsRoot(resultsRoot)
 
-	if _, err := dm.StartContainerInNodeMode("test-image", "10080", constants.BridgeNetworkMode); err != nil {
+	if _, err := dm.StartContainerInNodeMode("test-image", "10080", constants.BridgeNetworkMode, nil); err != nil {
 		t.Fatalf("StartContainerInNodeMode() error = %v", err)
 	}
 	wantDir := filepath.Join(resultsRoot, dockerDiagnosticsResultsDirName, "localhost", constants.DockerRoleNode)
@@ -377,7 +377,7 @@ func TestDockerManager_CleanupUsesDiagnosticsStopTimeoutAndManifest(t *testing.T
 	dm := &DockerManager{client: f, ctx: context.Background()}
 	dm.setDiagnosticsResultsRoot(resultsRoot)
 
-	if _, err := dm.StartContainerInNodeMode("test-image", "10080", constants.BridgeNetworkMode); err != nil {
+	if _, err := dm.StartContainerInNodeMode("test-image", "10080", constants.BridgeNetworkMode, nil); err != nil {
 		t.Fatalf("StartContainerInNodeMode() error = %v", err)
 	}
 	if err := os.WriteFile(filepath.Join(dm.diagnosticsDir, "spt-gc-123.log"), []byte("gc"), 0o600); err != nil {

--- a/cli/tui/docker_interface.go
+++ b/cli/tui/docker_interface.go
@@ -17,10 +17,10 @@ type DockerInterface interface {
 	StartContainerWithScenario(image string, scenarioPath string, additionalArgs []string) (string, error)
 
 	// StartContainerInNodeMode starts a container in API server mode.
-	StartContainerInNodeMode(image string, apiPort string, networkMode string) (string, error)
+	StartContainerInNodeMode(image string, apiPort string, networkMode string, additionalArgs []string) (string, error)
 
 	// StartWorkerNodeContainer starts a container in RMI worker node mode
-	StartWorkerNodeContainer(image string, rmiHostname string, rmiPortStart, rmiPortCount int) (string, error)
+	StartWorkerNodeContainer(image string, rmiHostname string, rmiPortStart, rmiPortCount int, additionalArgs []string) (string, error)
 
 	// StartEntryNodeContainer starts a container as RMI entry node with worker addresses
 	StartEntryNodeContainer(image string, workerAddresses []string, additionalArgs []string, networkMode string) (string, error)

--- a/cli/tui/docker_mock.go
+++ b/cli/tui/docker_mock.go
@@ -43,10 +43,11 @@ type MockDockerManager struct {
 
 	// For testing worker node starts
 	workerNodeCalls []struct {
-		Image        string
-		RMIHostname  string
-		RMIPortStart int
-		RMIPortCount int
+		Image          string
+		RMIHostname    string
+		RMIPortStart   int
+		RMIPortCount   int
+		AdditionalArgs []string
 	}
 
 	// For testing entry node starts
@@ -134,7 +135,7 @@ func (m *MockDockerManager) StartContainerWithScenario(image string, scenarioPat
 }
 
 // StartContainerInNodeMode simulates starting a container in API server mode.
-func (m *MockDockerManager) StartContainerInNodeMode(image string, apiPort string, networkMode string) (string, error) {
+func (m *MockDockerManager) StartContainerInNodeMode(image string, apiPort string, networkMode string, additionalArgs []string) (string, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -145,6 +146,7 @@ func (m *MockDockerManager) StartContainerInNodeMode(image string, apiPort strin
 	}
 
 	cmd := []string{dockerNodeModeArg, "--run-port=" + apiPort}
+	cmd = append(cmd, additionalArgs...)
 	if networkMode != "" {
 		cmd = append(cmd, "--network-mode="+networkMode)
 	}
@@ -162,7 +164,7 @@ func (m *MockDockerManager) StartContainerInNodeMode(image string, apiPort strin
 }
 
 // StartWorkerNodeContainer simulates starting a worker node container
-func (m *MockDockerManager) StartWorkerNodeContainer(image string, rmiHostname string, rmiPortStart, rmiPortCount int) (string, error) {
+func (m *MockDockerManager) StartWorkerNodeContainer(image string, rmiHostname string, rmiPortStart, rmiPortCount int, additionalArgs []string) (string, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -174,15 +176,17 @@ func (m *MockDockerManager) StartWorkerNodeContainer(image string, rmiHostname s
 
 	// Record the call for testing
 	m.workerNodeCalls = append(m.workerNodeCalls, struct {
-		Image        string
-		RMIHostname  string
-		RMIPortStart int
-		RMIPortCount int
+		Image          string
+		RMIHostname    string
+		RMIPortStart   int
+		RMIPortCount   int
+		AdditionalArgs []string
 	}{
-		Image:        image,
-		RMIHostname:  rmiHostname,
-		RMIPortStart: rmiPortStart,
-		RMIPortCount: rmiPortCount,
+		Image:          image,
+		RMIHostname:    rmiHostname,
+		RMIPortStart:   rmiPortStart,
+		RMIPortCount:   rmiPortCount,
+		AdditionalArgs: additionalArgs,
 	})
 
 	return m.containerID, nil
@@ -374,18 +378,20 @@ func (m *MockDockerManager) SetOnStreamOutput(callback func(containerID string))
 
 // GetWorkerNodeCalls returns all worker node container starts
 func (m *MockDockerManager) GetWorkerNodeCalls() []struct {
-	Image        string
-	RMIHostname  string
-	RMIPortStart int
-	RMIPortCount int
+	Image          string
+	RMIHostname    string
+	RMIPortStart   int
+	RMIPortCount   int
+	AdditionalArgs []string
 } {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	result := make([]struct {
-		Image        string
-		RMIHostname  string
-		RMIPortStart int
-		RMIPortCount int
+		Image          string
+		RMIHostname    string
+		RMIPortStart   int
+		RMIPortCount   int
+		AdditionalArgs []string
 	}, len(m.workerNodeCalls))
 	copy(result, m.workerNodeCalls)
 	return result

--- a/cli/tui/docker_rmi_test.go
+++ b/cli/tui/docker_rmi_test.go
@@ -20,6 +20,7 @@ func TestStartWorkerNodeContainer(t *testing.T) {
 		"192.168.1.100",
 		40000,
 		10,
+		nil,
 	)
 
 	if err != nil {
@@ -105,6 +106,7 @@ func TestStartWorkerNodeContainer_Failure(t *testing.T) {
 		"192.168.1.100",
 		40000,
 		10,
+		nil,
 	)
 
 	if err == nil {

--- a/cli/tui/orchestrator.go
+++ b/cli/tui/orchestrator.go
@@ -176,6 +176,10 @@ func (o *TestOrchestrator) StartTestWithContent(ctx context.Context, image strin
 	if len(scenarioContent) == 0 {
 		return fmt.Errorf("scenario content is empty")
 	}
+	startupArgs, err := scenario.BuildEngineStartupArgs(params)
+	if err != nil {
+		return fmt.Errorf("resolve engine startup settings: %w", err)
+	}
 
 	// Save scenario to file if requested
 	if params.KeepScenario {
@@ -194,7 +198,7 @@ func (o *TestOrchestrator) StartTestWithContent(ctx context.Context, image strin
 
 	// Start container in node mode
 	logging.LogInfo("orchestrator", "starting container in node mode", "image", image, "port", o.apiPort, "network_mode", o.networkMode)
-	containerID, err := o.dockerManager.StartContainerInNodeMode(image, o.apiPort, o.networkMode)
+	containerID, err := o.dockerManager.StartContainerInNodeMode(image, o.apiPort, o.networkMode, startupArgs)
 	if err != nil {
 		return fmt.Errorf("failed to start container in node mode: %w", err)
 	}

--- a/cli/tui/orchestrator_multi.go
+++ b/cli/tui/orchestrator_multi.go
@@ -502,7 +502,7 @@ func (o *MultiHostOrchestrator) configureItemFileMounts(hosts []*HostConnection,
 }
 
 // StartContainers starts Spt containers on all ready hosts
-func (o *MultiHostOrchestrator) StartContainers(_ context.Context, image string, _ string) error {
+func (o *MultiHostOrchestrator) StartContainers(_ context.Context, image string, additionalArgs []string) error {
 	o.mu.Lock()
 	o.image = image
 	o.mu.Unlock()
@@ -543,7 +543,7 @@ func (o *MultiHostOrchestrator) StartContainers(_ context.Context, image string,
 				return
 			}
 
-			containerID, err := h.DockerManager.StartContainerInNodeMode(image, o.apiPort, o.networkMode)
+			containerID, err := h.DockerManager.StartContainerInNodeMode(image, o.apiPort, o.networkMode, additionalArgs)
 			if err != nil {
 				h.SetError(fmt.Errorf("failed to start container: %w", err))
 
@@ -1466,6 +1466,10 @@ func (m *MultiHostTestOrchestrator) StartTest(ctx context.Context, image string,
 		// Behavior: run the workload only on the PRIMARY (first) host; start API-only
 		// containers on remaining hosts so they appear in the live view as idle.
 		if strings.EqualFold(params.WorkloadType, scenario.WorkloadTypeList) {
+			startupArgs, err := scenario.BuildEngineStartupArgs(params)
+			if err != nil {
+				return fmt.Errorf("resolve engine startup settings: %w", err)
+			}
 			// Status/message hooks
 			if m.onStatusUpdate != nil {
 				m.onStatusUpdate(&TestStatus{
@@ -1489,7 +1493,7 @@ func (m *MultiHostTestOrchestrator) StartTest(ctx context.Context, image string,
 					continue
 				}
 				w.SetPhase(NodePhaseContainerStarting)
-				cid, err := w.DockerManager.StartContainerInNodeMode(image, m.multiHost.apiPort, m.multiHost.networkMode)
+				cid, err := w.DockerManager.StartContainerInNodeMode(image, m.multiHost.apiPort, m.multiHost.networkMode, startupArgs)
 				if err != nil {
 					// Record but continue; non-critical for primary execution
 					w.SetError(err)
@@ -1527,6 +1531,7 @@ func (m *MultiHostTestOrchestrator) StartTest(ctx context.Context, image string,
 			if err != nil {
 				return fmt.Errorf("failed to build endpoint args: %w", err)
 			}
+			additionalArgs = append(additionalArgs, startupArgs...)
 
 			primary := readyHosts[0]
 			if primary.DockerManager == nil {
@@ -1651,6 +1656,10 @@ func (m *MultiHostTestOrchestrator) StartTestWithContent(ctx context.Context, im
 	if len(scenarioContent) == 0 {
 		return fmt.Errorf("scenario content is empty")
 	}
+	startupArgs, err := scenario.BuildEngineStartupArgs(params)
+	if err != nil {
+		return fmt.Errorf("resolve engine startup settings: %w", err)
+	}
 	m.multiHost.itemFileMounts = params.ItemFileMounts
 	if len(readyHosts) != 1 {
 		if m.onStatusUpdate != nil {
@@ -1690,7 +1699,7 @@ func (m *MultiHostTestOrchestrator) StartTestWithContent(ctx context.Context, im
 
 	m.multiHost.scenarioContent = string(scenarioContent)
 
-	if err := m.multiHost.StartContainers(ctx, image, ""); err != nil {
+	if err := m.multiHost.StartContainers(ctx, image, startupArgs); err != nil {
 		return err
 	}
 	if err := m.multiHost.WaitForAPIs(ctx, constants.APIReadinessTimeout); err != nil {
@@ -1878,7 +1887,7 @@ func (o *MultiHostOrchestrator) attachWorkerNode(host *HostConnection) error {
 }
 
 // startWorkerNode starts a worker node container with RMI configuration
-func (o *MultiHostOrchestrator) startWorkerNode(host *HostConnection) error {
+func (o *MultiHostOrchestrator) startWorkerNode(host *HostConnection, additionalArgs []string) error {
 	// Check if host has a Docker manager configured
 	if host.DockerManager == nil {
 		return fmt.Errorf("host %s has no Docker manager configured", host.Info.Original)
@@ -1904,6 +1913,7 @@ func (o *MultiHostOrchestrator) startWorkerNode(host *HostConnection) error {
 		advIP,
 		o.rmiPortStart,
 		o.rmiPortCount,
+		additionalArgs,
 	)
 	if err != nil {
 		return fmt.Errorf("failed to start worker on %s: %w", host.Info.Host, err)
@@ -1930,6 +1940,7 @@ func (o *MultiHostOrchestrator) startEntryNode(
 	primary *HostConnection,
 	workers []*HostConnection,
 	params scenario.ScenarioParams,
+	startupArgs []string,
 ) error {
 	// Build worker addresses for RMI using detected advertised IPs where available
 	workerAddresses := make([]string, 0, len(workers))
@@ -1953,6 +1964,7 @@ func (o *MultiHostOrchestrator) startEntryNode(
 	if err != nil {
 		return fmt.Errorf("failed to build endpoint args: %w", err)
 	}
+	additionalArgs = append(additionalArgs, startupArgs...)
 
 	containerID, err := primary.DockerManager.StartEntryNodeContainer(
 		o.image,
@@ -1993,12 +2005,19 @@ func (o *MultiHostOrchestrator) StartDistributedTestWithContent(_ context.Contex
 	if len(scenarioContent) == 0 {
 		return fmt.Errorf("scenario content is empty")
 	}
+	startupArgs, err := scenario.BuildEngineStartupArgs(params)
+	if err != nil {
+		return fmt.Errorf("resolve engine startup settings: %w", err)
+	}
 
 	o.mu.Lock()
 	defer o.mu.Unlock()
 
 	o.image = image
 	attachWorkers := o.attachWorkers
+	if attachWorkers && len(startupArgs) > 0 {
+		return fmt.Errorf("engine startup settings cannot be applied with attached workers; start every worker with %s", startupArgs[0])
+	}
 
 	// 1. Determine roles: first host is entry node, rest are workers
 	if len(o.hosts) == 0 {
@@ -2035,7 +2054,7 @@ func (o *MultiHostOrchestrator) StartDistributedTestWithContent(_ context.Contex
 				if attachWorkers {
 					err = o.attachWorkerNode(w)
 				} else {
-					err = o.startWorkerNode(w)
+					err = o.startWorkerNode(w, startupArgs)
 				}
 
 				if err != nil {
@@ -2094,7 +2113,7 @@ func (o *MultiHostOrchestrator) StartDistributedTestWithContent(_ context.Contex
 		}
 	}
 
-	if err := o.startEntryNode(entryNode, activeWorkers, params); err != nil {
+	if err := o.startEntryNode(entryNode, activeWorkers, params, startupArgs); err != nil {
 		return fmt.Errorf("failed to start entry node: %w", err)
 	}
 

--- a/cli/tui/orchestrator_multi_test.go
+++ b/cli/tui/orchestrator_multi_test.go
@@ -63,7 +63,7 @@ func TestMultiHostOrchestrator_StartContainers_NoDockerManager(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 
-	err := orchestrator.StartContainers(ctx, "test-image", "/test/scenario.js")
+	err := orchestrator.StartContainers(ctx, "test-image", nil)
 
 	// Should fail because hosts don't have Docker managers
 	if err == nil {
@@ -84,7 +84,7 @@ func TestMultiHostOrchestrator_StartContainers_PassesNetworkMode(t *testing.T) {
 	orchestrator.hosts[0].DockerManager = mockDocker
 	orchestrator.hosts[0].SetStatus(HostStatusReady)
 
-	if err := orchestrator.StartContainers(context.Background(), "test-image", ""); err != nil {
+	if err := orchestrator.StartContainers(context.Background(), "test-image", nil); err != nil {
 		t.Fatalf("StartContainers() error = %v", err)
 	}
 	calls := mockDocker.GetContainerCalls()
@@ -755,7 +755,7 @@ func TestStartEntryNode_UsesAdvertisedIPForWorkerAddresses(t *testing.T) {
 
 	// Call startEntryNode directly to avoid network waits
 	params := scenario.ScenarioParams{WorkloadType: "mock", Threads: 1, ObjectSize: "1MB", ObjectCount: 1}
-	if err := o.startEntryNode(primary, []*HostConnection{worker}, params); err != nil {
+	if err := o.startEntryNode(primary, []*HostConnection{worker}, params, nil); err != nil {
 		t.Fatalf("startEntryNode error: %v", err)
 	}
 
@@ -1037,7 +1037,14 @@ func TestMultiHostTestOrchestrator_StartTestWithContent_MultiHostStartsDistribut
 	replayScenario := []byte(`var step = "replay-001-max-w10kb"; Load.config({}).run();`)
 	replayDefaults := []byte("storage:\n  driver:\n    type: s3\n")
 	mounts := []scenario.FileMount{{HostPath: "/host/items.csv", ContainerPath: "/spt-input/items/read-items.csv"}}
-	params := scenario.ScenarioParams{WorkloadType: "write", Threads: 1, ItemFileMounts: mounts}
+	params := scenario.ScenarioParams{
+		WorkloadType:   "write",
+		Threads:        1,
+		ItemFileMounts: mounts,
+		EngineOverrides: []string{
+			"load.service.threads=4",
+		},
+	}
 	if err := wrapper.StartTestWithContent(ctx, "test-image", params, replayScenario, replayDefaults); err != nil {
 		t.Fatalf("StartTestWithContent() error = %v", err)
 	}
@@ -1057,10 +1064,16 @@ func TestMultiHostTestOrchestrator_StartTestWithContent_MultiHostStartsDistribut
 	if workerCalls[0].RMIHostname != "127.0.0.1" {
 		t.Fatalf("worker RMI hostname = %q, want 127.0.0.1", workerCalls[0].RMIHostname)
 	}
+	if !containsStringSimple(strings.Join(workerCalls[0].AdditionalArgs, " "), "--load-service-threads=4") {
+		t.Fatalf("worker startup args = %v, want --load-service-threads=4", workerCalls[0].AdditionalArgs)
+	}
 
 	entryCalls := entryDM.GetEntryNodeCalls()
 	if len(entryCalls) != 1 {
 		t.Fatalf("expected one entry node start, got %d", len(entryCalls))
+	}
+	if !containsStringSimple(strings.Join(entryCalls[0].AdditionalArgs, " "), "--load-service-threads=4") {
+		t.Fatalf("entry startup args = %v, want --load-service-threads=4", entryCalls[0].AdditionalArgs)
 	}
 	wantWorkerAddr := "127.0.0.1:" + constants.RMIRegistryPort
 	if len(entryCalls[0].WorkerAddresses) != 1 || entryCalls[0].WorkerAddresses[0] != wantWorkerAddr {
@@ -1349,6 +1362,31 @@ func TestMultiHostOrchestrator_StartDistributedTest_AttachWorkers(t *testing.T) 
 	}
 	if len(entryDM.GetEntryNodeCalls()) != 1 {
 		t.Fatalf("expected one entry node launch, got %d", len(entryDM.GetEntryNodeCalls()))
+	}
+}
+
+func TestMultiHostOrchestrator_StartDistributedTestRejectsStartupSettingsWithAttachedWorkers(t *testing.T) {
+	hostInfos := []*hostparse.HostInfo{
+		{Host: "entry", Original: "entry"},
+		{Host: "worker1", Original: "worker1"},
+	}
+	orchestrator := NewMultiHostOrchestrator(hostInfos, 2)
+	orchestrator.SetAttachExistingWorkers(true)
+
+	err := orchestrator.StartDistributedTestWithContent(
+		context.Background(),
+		"test-image",
+		scenario.ScenarioParams{
+			EngineOverrides: []string{"load.service.threads=4"},
+		},
+		[]byte(`Load.run({});`),
+	)
+	if err == nil {
+		t.Fatal("StartDistributedTestWithContent() error = nil, want attached-worker startup error")
+	}
+	if !strings.Contains(err.Error(), "cannot be applied with attached workers") ||
+		!strings.Contains(err.Error(), "--load-service-threads=4") {
+		t.Fatalf("StartDistributedTestWithContent() error = %v", err)
 	}
 }
 

--- a/cli/tui/orchestrator_test.go
+++ b/cli/tui/orchestrator_test.go
@@ -151,7 +151,7 @@ func TestOrchestratorStartTest(t *testing.T) {
 	// For now, let's test the components separately
 
 	// Start container
-	containerID, err := mockDM.StartContainerInNodeMode("test-image", "9999", constants.DefaultNetworkMode)
+	containerID, err := mockDM.StartContainerInNodeMode("test-image", "9999", constants.DefaultNetworkMode, nil)
 	if err != nil {
 		t.Fatalf("Failed to start container: %v", err)
 	}

--- a/cli/tui/remote_docker.go
+++ b/cli/tui/remote_docker.go
@@ -241,7 +241,7 @@ func (m *RemoteDockerManager) StartContainerWithScenario(_ string, _ string, _ [
 }
 
 // StartContainerInNodeMode starts a single Spt node exposing the provided API port.
-func (m *RemoteDockerManager) StartContainerInNodeMode(image string, apiPort string, networkMode string) (string, error) {
+func (m *RemoteDockerManager) StartContainerInNodeMode(image string, apiPort string, networkMode string, additionalArgs []string) (string, error) {
 	port := command.ParsePortFromString(apiPort)
 	if port <= 0 {
 		return "", fmt.Errorf("invalid api port: %q", apiPort)
@@ -258,13 +258,16 @@ func (m *RemoteDockerManager) StartContainerInNodeMode(image string, apiPort str
 
 	name := generateRemoteContainerName("node", m.host.Host)
 	mode := selectedNodeNetworkMode(networkMode)
+	cmd := make([]string, 0, 2+len(additionalArgs))
+	cmd = append(cmd, dockerNodeModeArg, "--run-port="+apiPort)
+	cmd = append(cmd, additionalArgs...)
 	cfg := command.ContainerConfig{
 		Image:       image,
 		Name:        name,
 		NetworkMode: mode,
 		Detached:    true,
 		Labels:      m.baseLabels(constants.DockerRoleNode),
-		Command:     []string{dockerNodeModeArg, "--run-port=" + apiPort},
+		Command:     cmd,
 		BindMounts:  append(diagnosticBinds, m.stagedBindMounts...),
 		EnvFiles:    envFiles,
 	}
@@ -290,7 +293,7 @@ func selectedNodeNetworkMode(networkMode string) command.NetworkMode {
 }
 
 // StartWorkerNodeContainer starts a worker in RMI mode on the remote host.
-func (m *RemoteDockerManager) StartWorkerNodeContainer(image string, rmiHostname string, _ int, _ int) (string, error) {
+func (m *RemoteDockerManager) StartWorkerNodeContainer(image string, rmiHostname string, _ int, _ int, additionalArgs []string) (string, error) {
 	// Detect advertised IP on the remote host if not explicitly provided
 	advIP := strings.TrimSpace(rmiHostname)
 	if advIP == "" {
@@ -313,6 +316,9 @@ func (m *RemoteDockerManager) StartWorkerNodeContainer(image string, rmiHostname
 
 	// Host networking with explicit JVM RMI hostname and explicit ports
 	name := generateRemoteContainerName("worker", m.host.Host)
+	cmd := make([]string, 0, 3+len(additionalArgs))
+	cmd = append(cmd, dockerNodeModeArg, "--run-port=9999", "--load-step-node-port=1099")
+	cmd = append(cmd, additionalArgs...)
 	cfg := command.ContainerConfig{
 		Image:       image,
 		Name:        name,
@@ -323,7 +329,7 @@ func (m *RemoteDockerManager) StartWorkerNodeContainer(image string, rmiHostname
 			constants.JavaOptsEnvVar:        fmt.Sprintf("%s%s", constants.JavaRMIHostnamePrefix, advIP),
 			constants.JavaToolOptionsEnvVar: fmt.Sprintf("%s%s", constants.JavaRMIHostnamePrefix, advIP),
 		},
-		Command:    []string{dockerNodeModeArg, "--run-port=9999", "--load-step-node-port=1099"},
+		Command:    cmd,
 		BindMounts: append(diagnosticBinds, m.stagedBindMounts...),
 		EnvFiles:   envFiles,
 	}

--- a/cli/tui/remote_docker_test.go
+++ b/cli/tui/remote_docker_test.go
@@ -33,7 +33,7 @@ func newTestRemoteManager(t *testing.T) (*RemoteDockerManager, *command.MockComm
 func TestRemoteDocker_StartContainerInNodeMode_RespectsPort(t *testing.T) {
 	mgr, mock, _ := newTestRemoteManager(t)
 
-	id, err := mgr.StartContainerInNodeMode(constants.DefaultSptImage, "10080", constants.BridgeNetworkMode)
+	id, err := mgr.StartContainerInNodeMode(constants.DefaultSptImage, "10080", constants.BridgeNetworkMode, []string{"--load-service-threads=4"})
 	if err != nil {
 		t.Fatalf("StartContainerInNodeMode error: %v", err)
 	}
@@ -54,6 +54,7 @@ func TestRemoteDocker_StartContainerInNodeMode_RespectsPort(t *testing.T) {
 		constants.DefaultSptImage,
 		"--run-node=true",
 		"--run-port=10080",
+		"--load-service-threads=4",
 		"--label spt.host=worker1.example.com",
 		"--label spt.managed=true",
 		"--label spt.role=node",
@@ -76,7 +77,7 @@ func TestRemoteDocker_StartContainerInNodeMode_StagesAndMountsItemFiles(t *testi
 		t.Fatalf("SetFileMounts() error = %v", err)
 	}
 
-	id, err := mgr.StartContainerInNodeMode(constants.DefaultSptImage, "10080", constants.BridgeNetworkMode)
+	id, err := mgr.StartContainerInNodeMode(constants.DefaultSptImage, "10080", constants.BridgeNetworkMode, nil)
 	if err != nil {
 		t.Fatalf("StartContainerInNodeMode error: %v", err)
 	}
@@ -103,7 +104,7 @@ func TestRemoteDocker_StartContainerInNodeMode_StagesAndMountsItemFiles(t *testi
 func TestRemoteDocker_StartContainerInNodeMode_HostNetwork(t *testing.T) {
 	mgr, mock, _ := newTestRemoteManager(t)
 
-	id, err := mgr.StartContainerInNodeMode(constants.DefaultSptImage, "10080", constants.HostNetworkMode)
+	id, err := mgr.StartContainerInNodeMode(constants.DefaultSptImage, "10080", constants.HostNetworkMode, nil)
 	if err != nil {
 		t.Fatalf("StartContainerInNodeMode error: %v", err)
 	}
@@ -137,7 +138,7 @@ func TestRemoteDocker_StartContainerInNodeMode_HostNetwork(t *testing.T) {
 func TestRemoteDocker_StartWorkerNodeContainer_BuildsExpectedCommand(t *testing.T) {
 	mgr, mock, _ := newTestRemoteManager(t)
 
-	id, err := mgr.StartWorkerNodeContainer(constants.DefaultSptImage, "10.0.0.10", 40000, 3)
+	id, err := mgr.StartWorkerNodeContainer(constants.DefaultSptImage, "10.0.0.10", 40000, 3, []string{"--load-service-threads=4"})
 	if err != nil {
 		t.Fatalf("StartWorkerNodeContainer error: %v", err)
 	}
@@ -160,6 +161,7 @@ func TestRemoteDocker_StartWorkerNodeContainer_BuildsExpectedCommand(t *testing.
 		"--run-node=true",
 		"--run-port=9999",
 		"--load-step-node-port=1099",
+		"--load-service-threads=4",
 		"--label spt.host=worker1.example.com",
 		"--label spt.managed=true",
 		"--label spt.role=worker",
@@ -181,7 +183,7 @@ func TestRemoteDocker_StartWorkerNodeContainer_DiagnosticsEnvFileAndMount(t *tes
 	resultsRoot := filepath.Join(t.TempDir(), "mt-20260705.120000.000")
 	mgr.setDiagnosticsResultsRoot(resultsRoot)
 
-	id, err := mgr.StartWorkerNodeContainer(constants.DefaultSptImage, "10.0.0.10", 40000, 3)
+	id, err := mgr.StartWorkerNodeContainer(constants.DefaultSptImage, "10.0.0.10", 40000, 3, nil)
 	if err != nil {
 		t.Fatalf("StartWorkerNodeContainer error = %v", err)
 	}
@@ -230,7 +232,7 @@ func TestRemoteDocker_CleanupCollectsDiagnosticsBeforeStagingCleanup(t *testing.
 	resultsRoot := filepath.Join(t.TempDir(), "mt-20260705.120000.000")
 	mgr.setDiagnosticsResultsRoot(resultsRoot)
 
-	if _, err := mgr.StartWorkerNodeContainer(constants.DefaultSptImage, "10.0.0.10", 40000, 3); err != nil {
+	if _, err := mgr.StartWorkerNodeContainer(constants.DefaultSptImage, "10.0.0.10", 40000, 3, nil); err != nil {
 		t.Fatalf("StartWorkerNodeContainer error = %v", err)
 	}
 	remoteDir := mgr.diagnosticsDir
@@ -278,7 +280,7 @@ func TestRemoteDocker_CleanupWithJavaOptsAndNoResultsRootRemovesRemoteDiagnostic
 	t.Setenv(constants.EnvSptJavaOpts, "-Xmx8g")
 	mgr, mock, _ := newTestRemoteManager(t)
 
-	if _, err := mgr.StartWorkerNodeContainer(constants.DefaultSptImage, "10.0.0.10", 40000, 3); err != nil {
+	if _, err := mgr.StartWorkerNodeContainer(constants.DefaultSptImage, "10.0.0.10", 40000, 3, nil); err != nil {
 		t.Fatalf("StartWorkerNodeContainer error = %v", err)
 	}
 	remoteDir := mgr.diagnosticsDir
@@ -388,7 +390,7 @@ func TestRemoteDocker_CollectDiagnosticsPreservesRemoteDirWhenStopNotConfirmed(t
 	resultsRoot := filepath.Join(t.TempDir(), "mt-20260705.120000.000")
 	mgr.setDiagnosticsResultsRoot(resultsRoot)
 
-	if _, err := mgr.StartWorkerNodeContainer(constants.DefaultSptImage, "10.0.0.10", 40000, 3); err != nil {
+	if _, err := mgr.StartWorkerNodeContainer(constants.DefaultSptImage, "10.0.0.10", 40000, 3, nil); err != nil {
 		t.Fatalf("StartWorkerNodeContainer error = %v", err)
 	}
 	remoteDir := mgr.diagnosticsDir
@@ -459,7 +461,7 @@ func TestRemoteDocker_CleanupCollectsNodeModeDiagnostics(t *testing.T) {
 	resultsRoot := filepath.Join(t.TempDir(), "mt-20260705.120000.000")
 	mgr.setDiagnosticsResultsRoot(resultsRoot)
 
-	if _, err := mgr.StartContainerInNodeMode(constants.DefaultSptImage, "10080", constants.BridgeNetworkMode); err != nil {
+	if _, err := mgr.StartContainerInNodeMode(constants.DefaultSptImage, "10080", constants.BridgeNetworkMode, nil); err != nil {
 		t.Fatalf("StartContainerInNodeMode error = %v", err)
 	}
 	remoteDir := mgr.diagnosticsDir

--- a/cli/tui/startup_test.go
+++ b/cli/tui/startup_test.go
@@ -355,7 +355,7 @@ func TestHybridDockerIntegration(t *testing.T) {
 
 			// Test Docker integration - in the new flow, we start container in node mode
 			// and send configuration via API, not CLI args
-			containerID, err := mockDM.StartContainerInNodeMode("spt-image", constants.SptAPIPort, constants.DefaultNetworkMode)
+			containerID, err := mockDM.StartContainerInNodeMode("spt-image", constants.SptAPIPort, constants.DefaultNetworkMode, nil)
 			if err != nil {
 				t.Errorf("Failed to start container in node mode: %v", err)
 				return


### PR DESCRIPTION
## Summary

- resolve `load.service.threads` from either `--service-threads` or the generic engine-override path before starting engine containers
- pass `--load-service-threads=N` to local, single-remote, distributed worker, distributed entry, and LIST-node JVMs
- reject conflicting values and attach-existing worker topologies where the CLI cannot configure every worker at startup

The value intentionally remains in the `/run` defaults for effective-configuration attribution. Startup argument delivery is required because `Main.applyVtParallelism()` runs before `/run` receives those defaults.