### PR TITLE
reuse operation dispatch input scratch

### DIFF
--- a/engine/extensions/storage-drivers/primitives/coop/src/main/java/com/dell/spt/storage/driver/coop/OperationDispatchTask.java
+++ b/engine/extensions/storage-drivers/primitives/coop/src/main/java/com/dell/spt/storage/driver/coop/OperationDispatchTask.java
@@ -9,6 +9,8 @@ import com.dell.spt.base.logging.LogUtil;
 import static com.dell.spt.base.Constants.KEY_CLASS_NAME;
 import static com.dell.spt.base.Constants.KEY_STEP_ID;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.BlockingQueue;
 import java.util.Queue;
 import java.util.concurrent.locks.Condition;
@@ -34,6 +36,7 @@ public final class OperationDispatchTask<I extends Item, O extends Operation<I>>
 	private final BlockingQueue<O> inOpQueue;
 	private final CoopStorageDriverBase<I, O> storageDriver;
 	private final CircularBuffer<O> buff;
+	private final List<O> tempInOps;
 	private final Lock dispatchLock;
 	private final Condition dispatchReady;
 	private final int deferredQueueCapacity;
@@ -46,6 +49,7 @@ public final class OperationDispatchTask<I extends Item, O extends Operation<I>>
 					final int batchSize, final Lock dispatchLock, final Condition dispatchReady, final int deferredQueueCapacity) {
 		super(executor);
 		this.buff = new CircularArrayBuffer<>(batchSize);
+		this.tempInOps = new ArrayList<>(batchSize);
 		this.storageDriver = storageDriver;
 		this.inOpQueue = inOpQueue;
 		this.childOpQueue = childOpQueue;
@@ -77,7 +81,6 @@ public final class OperationDispatchTask<I extends Item, O extends Operation<I>>
 			}
 
 			// Then drain incoming ops
-			final java.util.List<O> tempInOps = new java.util.ArrayList<>(batchSize);
 			if (buff.size() == 0) {
 				inOpQueue.drainTo(tempInOps, Math.max(0, Math.min(batchSize, deferredQueueCapacity - deferredMpuQueue.size())));
 				if (tempInOps.isEmpty() && deferredMpuQueue.isEmpty()) {
@@ -186,6 +189,8 @@ public final class OperationDispatchTask<I extends Item, O extends Operation<I>>
 							Level.TRACE, e,
 							"{}: failed to submit some load operations due to the illegal storage driver state ({})",
 							storageDriver.toString(), storageDriver.state());
+		} finally {
+			tempInOps.clear();
 		}
 	}
 
@@ -196,5 +201,6 @@ public final class OperationDispatchTask<I extends Item, O extends Operation<I>>
 		// completed operations, and attempting a draining flush here risks hangs if the
 		// downstream driver is in a failed or saturated state.
 		buff.clear();
+		tempInOps.clear();
 	}
 }

--- a/engine/extensions/storage-drivers/primitives/coop/src/test/java/com/dell/spt/storage/driver/coop/OperationDispatchTaskTest.java
+++ b/engine/extensions/storage-drivers/primitives/coop/src/test/java/com/dell/spt/storage/driver/coop/OperationDispatchTaskTest.java
@@ -8,6 +8,7 @@ import com.dell.spt.base.concurrent.VirtualThreadExecutor;
 import com.dell.spt.base.item.Item;
 import com.dell.spt.base.item.op.Operation;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
@@ -103,6 +104,37 @@ class OperationDispatchTaskTest {
 		task.doWork();
 
 		verify(driverMock).submit(anyList(), eq(0), eq(3));
+	}
+
+	@Test
+	void inputScratchIsReusedAndClearedAcrossIterations() throws Exception {
+		final BlockingQueue<Operation<Item>> scratchQueue = mock(BlockingQueue.class);
+		final Operation<Item> op1 = mock(Operation.class);
+		final Operation<Item> op2 = mock(Operation.class);
+		final List<Collection<Operation<Item>>> drainTargets = new ArrayList<>();
+		final AtomicInteger drainCalls = new AtomicInteger();
+		when(scratchQueue.drainTo(anyCollection(), anyInt())).thenAnswer(invocation -> {
+			final Collection<Operation<Item>> target = invocation.getArgument(0);
+			assertTrue(target.isEmpty(), "scratch must be empty before each input drain");
+			drainTargets.add(target);
+			target.add(drainCalls.getAndIncrement() == 0 ? op1 : op2);
+			return 1;
+		});
+		when(driverMock.submit(any(Operation.class))).thenReturn(true);
+		task = new OperationDispatchTask<>(
+						executor, driverMock, scratchQueue, childOpQueue, STEP_ID, BATCH_SIZE,
+						dispatchLock, dispatchReady, 16);
+
+		task.doWork();
+		task.doWork();
+
+		assertEquals(2, drainTargets.size());
+		assertSame(drainTargets.get(0), drainTargets.get(1),
+						"dispatcher should retain one task-owned input scratch collection");
+		assertTrue(drainTargets.get(0).isEmpty(),
+						"scratch should not retain operations between dispatch iterations");
+		verify(driverMock).submit(op1);
+		verify(driverMock).submit(op2);
 	}
 
 	@Test


### PR DESCRIPTION
## Summary
- reuse the operation-dispatch input batch scratch list instead of allocating one per dispatch loop
- clear retained operations after each iteration
- verify reuse and clearing across iterations