### PR TITLE
Add historical S3 version verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 ### Fixed
 
 - **Multi-page verification discovery** — Recycled LIST discovery previously omitted intermediate pages and emitted the final page twice, so large `read-verify` prefix selections could verify only the final page. Discovery now publishes every page exactly once.
+- **Failed verification discovery** — A failed LIST page could previously publish a valid-looking partial selection. Engine publication and CLI finalization now reject discovery evidence whenever any LIST operation failed.
 
 ## [5.14.0] - 2026-08-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Added
+
+- **Historical S3 version verification** — Added `read-verify --versions=current|all`; all-version discovery preserves exact `(bucket,key,version_id)` identities across every `ListObjectVersions` page, excludes and reports delete markers, and records `excluded_delete_marker_count` in completion evidence, the console summary, and `index.json`.
+
+### Changed
+
+- **Integrity completion schema v2** — Engine-produced completion records now use schema v2 to account explicitly for excluded delete markers; strict readers continue to accept legacy v1 records where that count is necessarily zero.
+
+### Fixed
+
+- **Multi-page verification discovery** — Recycled LIST discovery previously omitted intermediate pages and emitted the final page twice, so large `read-verify` prefix selections could verify only the final page. Discovery now publishes every page exactly once.
+
 ## [5.14.0] - 2026-08-05
 
 ### Added

--- a/cli/README.md
+++ b/cli/README.md
@@ -414,6 +414,7 @@ Executes a benchmark test with the specified workload type.
 - `--items-file`: Path to a saved `items.csv` for `read`, or a canonical manifest for `read-verify` (skips seed/discovery)
 - `--allow-empty-selection`: Permit a clean empty `read-verify` selection to succeed
 - `--defer-verification`: `write-verify` only. Stop after durable, nonempty CREATE evidence and preserve `written.csv` for later `read-verify` campaigns. Incompatible with `--cleanup`. (env: `SPT_DEFER_VERIFICATION`)
+- `--versions`: `read-verify` bucket/prefix discovery only: `current` (default) or `all`. All-version discovery preserves exact version IDs, excludes and reports delete markers, requires list-version permission, and must not be combined with `--items-file`.
 - `--integrity-max-console-failures`: Maximum corruption samples printed to the console (default 20; 0 suppresses samples)
 - `--integrity-runtime-identity-tier`: Distributed verification runtime proof: `image` (default) or the stronger `payload` tier required for controlled comparisons and release evidence
 - `--shuffle`: `read` only. Shuffle items within each fetched read batch before issuing reads.

--- a/cli/cmd/constants.go
+++ b/cli/cmd/constants.go
@@ -15,6 +15,7 @@ const (
 	DefaultSptImage                  = constants.DefaultSptImage
 	flagDeferVerification            = "defer-verification"
 	flagIntegrityRuntimeIdentityTier = "integrity-runtime-identity-tier"
+	flagVersions                     = "versions"
 )
 
 // Workload type constants

--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -1913,6 +1913,7 @@ func init() {
 	runCmd.Flags().Int("seed-objects", 2500, "Number of objects to pre-create for read benchmarks (default: 2500)")
 	runCmd.Flags().Bool("cleanup", false, "A boolean flag to automatically delete all created objects after the test completes")
 	runCmd.Flags().Bool(flagDeferVerification, false, "Write-verify only: stop after durable nonempty CREATE evidence and defer readback (env: SPT_DEFER_VERIFICATION)")
+	runCmd.Flags().String(flagVersions, scenario.VersionsCurrent, "Read-verify prefix discovery: current or all object versions")
 	runCmd.Flags().Bool("create-prefix", false, "A boolean flag to ensure the target prefix (directory) is created if it doesn't exist")
 	runCmd.Flags().StringP("output-dir", "O", "", "Specifies a local directory on the host machine to save the detailed Spt report files (e.g., ./results/test-01)")
 	runCmd.Flags().Bool("generate-only", false, "Generate the scenario file without running Docker or Spt")
@@ -2119,6 +2120,7 @@ func buildScenarioParams(workloadType string, cmd *cobra.Command) (scenario.Para
 	// Get behavior flags
 	cleanup, _ := cmd.Flags().GetBool("cleanup")
 	params.Cleanup = cleanup
+	params.Versions, _ = cmd.Flags().GetString(flagVersions)
 	params.DeferVerification, _ = cmd.Flags().GetBool(flagDeferVerification)
 
 	seedObjects, _ := cmd.Flags().GetInt("seed-objects")

--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -1900,7 +1900,7 @@ func init() {
 	runCmd.Flags().StringP("object-size", "o", "", "The size of each object using human-readable units (e.g., 1MiB, 256KiB, 4GiB; legacy MB/KB/GB also accepted)")
 	runCmd.Flags().Float64("object-data-compressibility", 0.0, "Compressibility percentage of object payloads (0.0 to 100.0, default 0.0)")
 	runCmd.Flags().Bool("object-data-dedupable", true, "Allow object payloads to be deduplicated by the storage array (default true)")
-	runCmd.Flags().IntP("object-count", "n", 0, "Defines the workload by a fixed number of objects to process")
+	runCmd.Flags().IntP("object-count", "n", 0, "Fixed object count; read-verify --versions=all caps version identities")
 	runCmd.Flags().StringP("duration", "d", "", "Defines the workload by a fixed time duration (e.g., 5m, 1h)")
 	runCmd.Flags().Int(flagPrefixShards, prefixShardsAuto, "Generated-key prefix directories (-1 = auto from configured aggregate concurrency, 0 = disabled)")
 

--- a/cli/cmd/run_scenario_test.go
+++ b/cli/cmd/run_scenario_test.go
@@ -524,6 +524,21 @@ func TestBuildScenarioParams(t *testing.T) {
 	}
 }
 
+func TestBuildScenarioParamsIncludesAllVersions(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.Flags().String(flagVersions, scenario.VersionsCurrent, "")
+	if err := cmd.Flags().Set(flagVersions, scenario.VersionsAll); err != nil {
+		t.Fatal(err)
+	}
+	params, err := buildScenarioParams(WorkloadTypeReadVerify, cmd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if params.Versions != scenario.VersionsAll {
+		t.Fatalf("buildScenarioParams versions = %q, want %q", params.Versions, scenario.VersionsAll)
+	}
+}
+
 func TestBuildScenarioParamsIncludesDeferredVerification(t *testing.T) {
 	cmd := &cobra.Command{}
 	cmd.Flags().Bool(flagDeferVerification, false, "")

--- a/cli/cmd/validation.go
+++ b/cli/cmd/validation.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/dell/storage-performance-tool/cli/internal/constants"
+	"github.com/dell/storage-performance-tool/cli/internal/scenario"
 	"github.com/dell/storage-performance-tool/cli/internal/secretmask"
 	"github.com/dell/storage-performance-tool/cli/internal/sizeparse"
 	"github.com/dell/storage-performance-tool/cli/internal/workload"
@@ -190,6 +191,13 @@ func validateIntegrityWorkloadFlags(cmd *cobra.Command, workloadType string) err
 		return !appliedFromEnv
 	}
 	deferVerification, _ := cmd.Flags().GetBool(flagDeferVerification)
+	versions, _ := cmd.Flags().GetString(flagVersions)
+	if versions == "" {
+		versions = scenario.VersionsCurrent
+	}
+	if workloadType != WorkloadTypeReadVerify && changed(flagVersions) {
+		return fmt.Errorf(ErrFlagNotSupported, "--"+flagVersions, workloadType)
+	}
 	if workloadType != WorkloadTypeWriteVerify &&
 		(changed(flagDeferVerification) || deferVerification) {
 		return fmt.Errorf(ErrFlagNotSupported, "--"+flagDeferVerification, workloadType)
@@ -245,6 +253,16 @@ func validateIntegrityWorkloadFlags(cmd *cobra.Command, workloadType string) err
 	}
 	if workloadType != WorkloadTypeReadVerify {
 		return nil
+	}
+	switch versions {
+	case scenario.VersionsCurrent, scenario.VersionsAll:
+	default:
+		return fmt.Errorf("--%s must be %q or %q", flagVersions,
+			scenario.VersionsCurrent, scenario.VersionsAll)
+	}
+	itemsFile, _ := cmd.Flags().GetString("items-file")
+	if itemsFile != "" && changed(flagVersions) {
+		return errors.New("--versions is valid only for read-verify bucket/prefix discovery; omit it with --items-file")
 	}
 	unsupported := []string{
 		"duration", "part-size", "mpu-concurrent-objects", "mpu-concurrent-parts",

--- a/cli/cmd/validation_test.go
+++ b/cli/cmd/validation_test.go
@@ -504,6 +504,7 @@ func newIntegrityValidationCommand(t *testing.T) *cobra.Command {
 	cmd.Flags().String(flagIntegrityRuntimeIdentityTier, constants.IntegrityRuntimeIdentityTierImage, "")
 	cmd.Flags().String("duration", "", "")
 	cmd.Flags().String("part-size", "", "")
+	cmd.Flags().String(flagVersions, scenario.VersionsCurrent, "")
 	cmd.Flags().Int("mpu-concurrent-objects", 0, "")
 	cmd.Flags().Int("mpu-concurrent-parts", 0, "")
 	cmd.Flags().Bool("cleanup", false, "")
@@ -532,6 +533,10 @@ func TestValidateIntegrityWorkloadAcceptanceMatrix(t *testing.T) {
 		{name: "read requires auto results", workload: WorkloadTypeReadVerify, flag: "auto-results", value: "false", wantErr: true, errContains: "require --auto-results=true"},
 		{name: "write requires auto results", workload: WorkloadTypeWriteVerify, flag: "auto-results", value: "false", wantErr: true, errContains: "require --auto-results=true"},
 		{name: "read accepts items file", workload: WorkloadTypeReadVerify, flag: "items-file", value: "items.csv"},
+		{name: "read accepts all versions", workload: WorkloadTypeReadVerify, flag: flagVersions, value: scenario.VersionsAll},
+		{name: "read rejects unknown versions policy", workload: WorkloadTypeReadVerify, flag: flagVersions, value: "latest", wantErr: true, errContains: "must be"},
+		{name: "write verify rejects versions", workload: WorkloadTypeWriteVerify, flag: flagVersions, value: scenario.VersionsAll, wantErr: true, errContains: "not supported"},
+		{name: "ordinary read rejects versions", workload: WorkloadTypeRead, flag: flagVersions, value: scenario.VersionsAll, wantErr: true, errContains: "not supported"},
 		{name: "write rejects items file", workload: WorkloadTypeWriteVerify, flag: "items-file", value: "items.csv", wantErr: true, errContains: "not supported for write-verify"},
 		{name: "write accepts deferred verification", workload: WorkloadTypeWriteVerify, flag: flagDeferVerification, value: "true"},
 		{name: "read rejects deferred verification", workload: WorkloadTypeReadVerify, flag: flagDeferVerification, value: "true", wantErr: true, errContains: "not supported"},
@@ -552,6 +557,20 @@ func TestValidateIntegrityWorkloadAcceptanceMatrix(t *testing.T) {
 				t.Fatalf("validation error = %q, want containing %q", err, test.errContains)
 			}
 		})
+	}
+}
+
+func TestValidateVersionsRejectsItemsFileDiscoveryBypass(t *testing.T) {
+	cmd := newIntegrityValidationCommand(t)
+	if err := cmd.Flags().Set(flagVersions, scenario.VersionsAll); err != nil {
+		t.Fatal(err)
+	}
+	if err := cmd.Flags().Set("items-file", "items.csv"); err != nil {
+		t.Fatal(err)
+	}
+	err := validateIntegrityWorkloadFlags(cmd, WorkloadTypeReadVerify)
+	if err == nil || !strings.Contains(err.Error(), "bucket/prefix discovery") {
+		t.Fatalf("items-file all-versions validation error = %v", err)
 	}
 }
 

--- a/cli/docs/S3_INTEGRITY.md
+++ b/cli/docs/S3_INTEGRITY.md
@@ -133,8 +133,9 @@ count is reported in the completion evidence, console summary, and `index.json`.
 Suspended and unversioned behavior depends on the target's S3 compatibility.
 Some targets return no version entries for an unversioned bucket; others return
 the current object with the literal `null` version ID. SPT preserves a returned
-`null` ID and sends it on the exact-version GET. A genuinely empty result follows
-the usual `--allow-empty-selection` policy.
+`null` ID and sends it on the exact-version GET. A version entry without a
+nonempty version ID is a hard discovery failure, not an empty selection. A
+genuinely empty result follows the usual `--allow-empty-selection` policy.
 
 Version listing is not a snapshot. Use a quiescent, controlled prefix: concurrent
 version creation or deletion during pagination can change the observed set.

--- a/cli/docs/S3_INTEGRITY.md
+++ b/cli/docs/S3_INTEGRITY.md
@@ -325,22 +325,56 @@ the exact running container before scenario submission. Any required remote
 inspection failure is fatal. A local run records the available image evidence
 or its collection error in `spt_run_params.json`.
 
+## End-to-end qualification
+
+Use `cli/tools/testreadverifyversions.sh` to seed a dedicated versioned fixture,
+build independent `mc` oracles, run the candidate CLI and engine image, and
+compare every canonical identity and result artifact. The full suite covers
+current and all-version discovery, deterministic caps, historical digest and
+metadata failures, more than 1,000 data versions with interleaved delete
+markers, suspended and unversioned buckets, and both Netty and AWS drivers.
+
+Seed and run can be separated so the same fixture qualifies a commit-specific
+image:
+
+```bash
+cli/tools/testreadverifyversions.sh --phase seed --confirm-target-mutation
+
+cli/tools/testreadverifyversions.sh \
+  --phase run \
+  --evidence-dir cli/results/version-qualification-<id> \
+  --image ghcr.io/dell/storage-performance-tool:allversions-<commit> \
+  --skip-image-pull \
+  --drivers netty,aws
+
+cli/tools/testreadverifyversions.sh \
+  --phase cleanup \
+  --evidence-dir cli/results/version-qualification-<id> \
+  --confirm-target-mutation
+```
+
+A full qualification also expects credentials that can read objects but cannot
+list object versions, plus an identity-verified multi-host target. Use
+`--allow-incomplete` only for a local qualification; the summary then records
+those cases as explicit gaps. The harness refuses native RDMA because its
+hardware path must be qualified separately on RDMA-capable systems. It only
+creates or removes bucket names beginning with `spt-version-qual-`, and every
+mutating phase requires `--confirm-target-mutation`.
+
 ## Version 1 boundaries
 
 - Verification commands require the Linux CLI; Windows fails preflight before
   evidence creation because its required directory-durability primitive is unavailable.
 - SHA-256 metadata and complete-object GET only; range verification is out of scope.
 - Generated object content for writes; file-backed write payloads are out of scope.
-- Isolated, unversioned prefixes are the normal discovery contract. Automatic
-  LIST discovery selects current versions only; it does not enumerate historical
-  versions. Exact historical versions require a manifest with `version_id`
-  values, and automatic all-version discovery is deferred to a later release.
+- `--versions=current` is the default LIST discovery contract. `--versions=all`
+  enumerates historical data versions by exact identity and excludes delete markers.
+  Version listing is not a snapshot, so qualification requires a quiescent prefix.
 - Concurrent overwrite or replication change during current-version discovery
   can otherwise be mistaken for corruption.
 - Copy and update operations do not maintain the v1 metadata contract.
-- Release qualification did not include a PowerStore target or a real versioned
-  bucket. Those compatibility paths remain unvalidated; exact-version manifest
-  support is implemented but was not target-qualified in this release.
+- Local qualification covers a real versioned S3-compatible target. PowerStore and
+  distributed target compatibility remain separate qualification gates.
 - Netty and AWS S3 paths have execution qualification. The RDMA metadata path is
   implemented and software-path tested, but its hardware path was not qualified;
   do not infer RDMA hardware parity from this release.

--- a/cli/docs/S3_INTEGRITY.md
+++ b/cli/docs/S3_INTEGRITY.md
@@ -106,6 +106,38 @@ fall back to generated content or accept arbitrary objects written by older SPT
 versions and other tools. It never deletes selected objects and rejects
 `--cleanup`.
 
+To verify every historical data version under the prefix, add
+`--versions=all`:
+
+```bash
+spt run read-verify \
+  --endpoints https://s3.example.com \
+  --access-key "$S3_ACCESS_KEY" \
+  --secret-key "$S3_SECRET_KEY" \
+  --bucket qualification \
+  --prefix campaign-42/ \
+  --versions=all \
+  --threads 32 \
+  --headless
+```
+
+This mode uses S3 `ListObjectVersions` and requires the corresponding
+list-version permission. Every data version is selected by exact
+`(bucket,key,version_id)` identity; `--object-count` caps those identities rather
+than distinct keys. Delete markers are never read as object data and their
+excluded count is reported in the completion evidence, console summary, and
+`index.json`. A suspended bucket's literal `null` version ID is preserved and
+sent on the exact-version GET. An unversioned bucket normally produces an empty
+all-version selection, subject to the target's S3 compatibility behavior and
+the usual `--allow-empty-selection` policy.
+
+Version listing is not a snapshot. Use a quiescent, controlled prefix: concurrent
+version creation or deletion during pagination can change the observed set.
+Archived versions are selected normally, but a version that has not been
+restored will fail its GET and remain in `verify-remaining.csv`. Omit
+`--versions` with `--items-file` because the manifest already supplies exact
+identities.
+
 For QA-controlled selection, supply a canonical manifest instead of LIST:
 
 ```bash
@@ -200,12 +232,15 @@ using an ordinary item-file deletion scenario to reclaim preserved objects.
 Manifest completion records use a crash-durable two-file commit. SPT flushes
 and synchronizes each completed file, atomically creates its final name without
 replacing an existing name, and synchronizes the containing directory. The CSV
-is committed before its JSON marker. The marker contains exactly these v1
-members: `version`, `status`, `run_id`, `producer_kind`, `producer_id`,
-`artifact`, `source_record_count`, `unique_record_count`,
-`selected_record_count`, `manifest_bytes`, and `manifest_sha256`. Unknown
-members are rejected. A missing, staging-only, stale, or mismatched marker
-prevents a dependent engine step from starting.
+is committed before its JSON marker. Readers accept legacy v1 markers so
+manifests created by the first integrity release remain reusable. New engine
+records use v2, which retains the v1 members (`version`, `status`, `run_id`,
+`producer_kind`, `producer_id`, `artifact`, `source_record_count`,
+`unique_record_count`, `selected_record_count`, `manifest_bytes`, and
+`manifest_sha256`) and adds `excluded_delete_marker_count`. That count is zero
+outside version discovery. Unknown members and a marker field inconsistent with
+its declared schema version are rejected. A missing, staging-only, stale, or
+mismatched marker prevents a dependent engine step from starting.
 The marker must contain exactly one JSON object plus optional trailing
 whitespace. Publication never replaces an existing canonical name. A retry
 may reuse a fully validated matching pair or complete a matching manifest-only

--- a/cli/docs/S3_INTEGRITY.md
+++ b/cli/docs/S3_INTEGRITY.md
@@ -121,6 +121,12 @@ spt run read-verify \
   --headless
 ```
 
+All-version discovery intentionally uses one exact-prefix LIST stream so a
+sub-prefix containing only deleted keys cannot be omitted by a current-object
+partition probe. The discovery LIST phase is therefore serialized regardless of
+`--threads`; `--threads` still controls the concurrent exact-version GETs in the
+verification phase.
+
 This mode follows every S3 `ListObjectVersions` page and requires the target's
 list-version permission (`s3:ListBucketVersions` in AWS IAM). A denied version
 listing fails closed without publishing usable discovery completion evidence;

--- a/cli/docs/S3_INTEGRITY.md
+++ b/cli/docs/S3_INTEGRITY.md
@@ -121,14 +121,19 @@ spt run read-verify \
   --headless
 ```
 
-This mode uses S3 `ListObjectVersions` and requires the corresponding
-list-version permission. Every data version is selected by exact
-`(bucket,key,version_id)` identity; `--object-count` caps those identities rather
-than distinct keys. Delete markers are never read as object data and their
-excluded count is reported in the completion evidence, console summary, and
-`index.json`. A suspended bucket's literal `null` version ID is preserved and
-sent on the exact-version GET. An unversioned bucket normally produces an empty
-all-version selection, subject to the target's S3 compatibility behavior and
+This mode follows every S3 `ListObjectVersions` page and requires the target's
+list-version permission (`s3:ListBucketVersions` in AWS IAM). A denied version
+listing fails closed without publishing usable discovery completion evidence;
+SPT never falls back to current-version listing. Every data version is selected
+by exact `(bucket,key,version_id)` identity. `--object-count` applies after
+canonical sorting and de-duplication, so it caps version identities rather than
+distinct keys. Delete markers are never read as object data and their excluded
+count is reported in the completion evidence, console summary, and `index.json`.
+
+Suspended and unversioned behavior depends on the target's S3 compatibility.
+Some targets return no version entries for an unversioned bucket; others return
+the current object with the literal `null` version ID. SPT preserves a returned
+`null` ID and sends it on the exact-version GET. A genuinely empty result follows
 the usual `--allow-empty-selection` policy.
 
 Version listing is not a snapshot. Use a quiescent, controlled prefix: concurrent
@@ -266,6 +271,14 @@ Distributed engine sources remain under
 and node-level evidence and promotes canonical run files without deleting the
 sources.
 
+Distributed completion counts distinguish raw observations from canonical
+identities. When multiple nodes receive overlapping LIST seeds,
+`source_record_count` and `excluded_delete_marker_count` include every node's
+observations. `unique_record_count`, `selected_record_count`, and the canonical
+manifest describe the post-de-duplication set. Thus three nodes may report
+3,015 source rows for the same 1,005 unique version identities without issuing
+duplicate verification reads.
+
 ## Digest-cost reporting
 
 Metadata writes pre-hash the full final object before dispatching PUT or
@@ -291,7 +304,11 @@ Before any distributed verification I/O, the CLI proves that every participant
 resolves the selected engine image to the same immutable image ID. A matching
 mutable tag is not sufficient. It records each participant and the selected
 identity tier in `spt_run_params.json`, then checks the entry node's existing
-`/config/schema` endpoint for the four required integrity paths.
+`/config/schema` endpoint for the five required integrity paths:
+`storage.integrity.mode`, `storage.integrity.algorithm`,
+`storage.integrity.input.provenance`,
+`storage.integrity.input.expectedProducerId`, and
+`storage.integrity.selection.maxCount`.
 
 Controlled comparison and release-evidence procedures additionally require the
 strong payload tier: every participant must have an identical canonical
@@ -353,10 +370,29 @@ cli/tools/testreadverifyversions.sh \
   --confirm-target-mutation
 ```
 
-A full qualification also expects credentials that can read objects but cannot
-list object versions, plus an identity-verified multi-host target. Use
-`--allow-incomplete` only for a local qualification; the summary then records
-those cases as explicit gaps. The harness refuses native RDMA because its
+For the distributed pagination gate, preload the same commit-specific image on
+every configured host and explicitly opt the profile into the harness:
+
+```bash
+engine/tools/push-worker-image.sh \
+  --image ghcr.io/dell/storage-performance-tool:allversions-<commit>
+
+source cli/.env
+cli/tools/testreadverifyversions.sh \
+  --phase run \
+  --evidence-dir cli/results/version-qualification-<id> \
+  --image ghcr.io/dell/storage-performance-tool:allversions-<commit> \
+  --skip-image-pull \
+  --distributed-hosts "$HOSTS" \
+  --distributed-min-hosts 3
+```
+
+The harness requires the stronger payload-identity tier for distributed release
+evidence and compares the de-duplicated result with its independent oracle. A
+full qualification also expects credentials that can read objects but cannot
+list object versions. `--allow-incomplete` permits either missing external gate
+and records the exact gap in `qualification-summary.json`; it does not silently
+convert a skipped gate into a pass. The harness refuses native RDMA because its
 hardware path must be qualified separately on RDMA-capable systems. It only
 creates or removes bucket names beginning with `spt-version-qual-`, and every
 mutating phase requires `--confirm-target-mutation`.
@@ -373,9 +409,8 @@ mutating phase requires `--confirm-target-mutation`.
 - Concurrent overwrite or replication change during current-version discovery
   can otherwise be mistaken for corruption.
 - Copy and update operations do not maintain the v1 metadata contract.
-- Local qualification covers a real versioned S3-compatible target. PowerStore and
-  distributed target compatibility remain separate qualification gates.
-- Netty and AWS S3 paths have execution qualification. The RDMA metadata path is
+- Netty and AWS S3 paths have local and three-client execution qualification on
+  a real versioned S3-compatible target. The RDMA metadata path is
   implemented and software-path tested, but its hardware path was not qualified;
   do not infer RDMA hardware parity from this release.
 

--- a/cli/docs/SPT_SYNTAX.md
+++ b/cli/docs/SPT_SYNTAX.md
@@ -128,8 +128,13 @@ objects: `--object-count` caps its deterministic discovery selection and
 [S3_INTEGRITY.md](S3_INTEGRITY.md) for metadata, artifacts, resumability, empty
 selection behavior, and exit codes `0`, `1`, and `20`.
 
-All-version discovery requires list-version permission and a quiescent prefix;
-S3 version pagination is not a snapshot of concurrent mutations.
+All-version discovery requires the target's list-version permission
+(`s3:ListBucketVersions` in AWS IAM). Authorization failure is fatal and never
+falls back to current-version discovery. SPT follows version pagination,
+de-duplicates exact `(bucket,key,version_id)` identities, and excludes and
+reports delete markers. Use a quiescent prefix because version pagination is not
+a snapshot of concurrent mutations. Unversioned-bucket results are target-specific;
+see [S3_INTEGRITY.md](S3_INTEGRITY.md).
 
 **`--save-items` / `--items-file` workflow:** By default, `read` workloads seed their own objects via an internal write phase. When you need independent control over the write and read phases (different concurrency, duration, or to reuse a data set across multiple reads), use `--save-items` on a `write` run to persist the object list, then pass the resulting `items.csv` to a `read` run via `--items-file`. See [Write-Then-Read Workflow](#write-then-read-workflow) below for examples.
 

--- a/cli/docs/SPT_SYNTAX.md
+++ b/cli/docs/SPT_SYNTAX.md
@@ -99,7 +99,7 @@ Required for S3 workloads, optional/ignored for `mock`.
 | `--part-size` | | `""` | Enable multipart upload with the given part size (e.g., `5MiB`, `64MiB`, `256MiB`; legacy `MB` remains accepted as a 1024-based alias). Applies to `write`, the CREATE phase of `write-verify`, and `read` seed phases |
 | `--mpu-concurrent-objects` | | `0` | Max concurrent multipart objects in flight (`0` = unlimited). Requires `--part-size` |
 | `--mpu-concurrent-parts` | | `0` | Max concurrent parts in flight per multipart object (`0` = unlimited). Requires `--part-size` |
-| `--object-count` | `-n` | `0` | Fixed number of objects to process |
+| `--object-count` | `-n` | `0` | Fixed number of objects to process. With `read-verify --versions=all`, caps canonical version identities rather than distinct keys |
 | `--duration` | `-d` | `""` | Fixed time duration (e.g., `5m`, `1h`) |
 | `--prefix-shards` | | `-1` | Prefix directories for generated object keys. `-1` derives the count from aggregate configured concurrency, `0` disables sharding, and a positive value selects an exact count |
 | `--seed-objects` | | `2500` | Objects to pre-create for `read` benchmarks |

--- a/cli/docs/SPT_SYNTAX.md
+++ b/cli/docs/SPT_SYNTAX.md
@@ -132,8 +132,10 @@ All-version discovery requires the target's list-version permission
 (`s3:ListBucketVersions` in AWS IAM). Authorization failure is fatal and never
 falls back to current-version discovery. SPT follows version pagination,
 de-duplicates exact `(bucket,key,version_id)` identities, and excludes and
-reports delete markers. Use a quiescent prefix because version pagination is not
-a snapshot of concurrent mutations. Unversioned-bucket results are target-specific;
+reports delete markers. For completeness, this version LIST phase uses one
+serialized exact-prefix stream; `--threads` controls the later verification GETs,
+not discovery LIST concurrency. Use a quiescent prefix because version pagination
+is not a snapshot of concurrent mutations. Unversioned-bucket results are target-specific;
 see [S3_INTEGRITY.md](S3_INTEGRITY.md).
 
 **`--save-items` / `--items-file` workflow:** By default, `read` workloads seed their own objects via an internal write phase. When you need independent control over the write and read phases (different concurrency, duration, or to reuse a data set across multiple reads), use `--save-items` on a `write` run to persist the object list, then pass the resulting `items.csv` to a `read` run via `--items-file`. See [Write-Then-Read Workflow](#write-then-read-workflow) below for examples.

--- a/cli/docs/SPT_SYNTAX.md
+++ b/cli/docs/SPT_SYNTAX.md
@@ -110,6 +110,7 @@ Required for S3 workloads, optional/ignored for `mock`.
 | `--items-file` | | `""` | Path to an item manifest for `read`, or a canonical manifest for `read-verify` (skips seed/discovery) |
 | `--allow-empty-selection` | | `false` | `read-verify` only. Allow a clean empty discovery/input selection to succeed |
 | `--defer-verification` | | `false` | `write-verify` only. Stop after durable, nonempty CREATE evidence and preserve `written.csv` for later `read-verify`; incompatible with `--cleanup` (env: `SPT_DEFER_VERIFICATION`) |
+| `--versions` | | `current` | `read-verify` bucket/prefix discovery only. `current` uses ordinary object listing; `all` uses `ListObjectVersions`, preserves exact version IDs, and excludes delete markers. Omit with `--items-file` |
 | `--integrity-max-console-failures` | | `20` | Verification only. Maximum corruption samples printed to the console (`0` suppresses samples; env: `SPT_INTEGRITY_MAX_CONSOLE_FAILURES`) |
 | `--shuffle` | | `false` | `read` only. Shuffle items within each fetched read batch before issuing reads |
 | `--shuffle-batch-size` | | `0` | `read` only. Batch size override used with `--shuffle` (`0` = bounded default `512000`, max `1000000`) |
@@ -126,6 +127,9 @@ objects: `--object-count` caps its deterministic discovery selection and
 `--attach-existing`; both require automatic result collection. See
 [S3_INTEGRITY.md](S3_INTEGRITY.md) for metadata, artifacts, resumability, empty
 selection behavior, and exit codes `0`, `1`, and `20`.
+
+All-version discovery requires list-version permission and a quiescent prefix;
+S3 version pagination is not a snapshot of concurrent mutations.
 
 **`--save-items` / `--items-file` workflow:** By default, `read` workloads seed their own objects via an internal write phase. When you need independent control over the write and read phases (different concurrency, duration, or to reuse a data set across multiple reads), use `--save-items` on a `write` run to persist the object list, then pass the resulting `items.csv` to a `read` run via `--items-file`. See [Write-Then-Read Workflow](#write-then-read-workflow) below for examples.
 

--- a/cli/internal/constants/integrity.go
+++ b/cli/internal/constants/integrity.go
@@ -59,6 +59,13 @@ const (
 // external `--items-file` selection and publishes the matching completion record.
 const IntegrityCLIStagerProducerID = "spt-cli-items-stager-v1"
 
+// Integrity completion schema versions. Legacy v1 remains accepted for staged and
+// pre-all-version artifacts; engine discovery records use the current v2 schema.
+const (
+	IntegrityCompletionVersionLegacy  = 1
+	IntegrityCompletionVersionCurrent = 2
+)
+
 // Verification process exit codes are stable public automation contracts.
 const (
 	ExitCodeSuccess             = 0

--- a/cli/internal/integrity/finalizer.go
+++ b/cli/internal/integrity/finalizer.go
@@ -248,6 +248,21 @@ func FinalizeResults(options FinalizeOptions) (outcome FinalizeOutcome, finalErr
 		inputSourceCompletionPath = filepath.Join(options.ResultsRoot, producerStep+"."+inputCompletionName)
 		inputPromotionSource = fmt.Sprintf("%s from step %s", inputName, producerStep)
 	}
+	if options.Workload == workload.ReadVerify && options.StagedManifest == "" && !readNotStarted {
+		listCounts, countsErr := readOperationMetrics(options.ResultsRoot, listStep, "LIST")
+		if countsErr != nil {
+			return outcome, countsErr
+		}
+		if listCounts.failure > 0 {
+			failureLabel := "failed operations"
+			if listCounts.failure == 1 {
+				failureLabel = "failed operation"
+			}
+			return outcome, fmt.Errorf(
+				"LIST discovery recorded %d %s; refusing partial verification selection",
+				listCounts.failure, failureLabel)
+		}
+	}
 	if err = promoteCompletionPair(
 		inputSourcePath, inputSourceCompletionPath,
 		inputPath, inputCompletionPath,

--- a/cli/internal/integrity/finalizer.go
+++ b/cli/internal/integrity/finalizer.go
@@ -74,6 +74,7 @@ type FinalizeOutcome struct {
 	SelectionSourceCount       int64                               `json:"selection_source_count"`
 	SelectionUniqueCount       int64                               `json:"selection_unique_count"`
 	SelectionCount             int64                               `json:"selection_count"`
+	ExcludedDeleteMarkerCount  int64                               `json:"excluded_delete_marker_count"`
 	VerificationAttemptedCount int64                               `json:"verification_attempted_count"`
 	VerificationDeferred       bool                                `json:"verification_deferred"`
 	VerifiedCount              int64                               `json:"verified_count"`
@@ -267,6 +268,7 @@ func FinalizeResults(options FinalizeOptions) (outcome FinalizeOutcome, finalErr
 	outcome.SelectionSourceCount = int64(inputCompletion.SourceRecordCount)
 	outcome.SelectionUniqueCount = int64(inputCompletion.UniqueRecordCount)
 	outcome.SelectionCount = int64(inputCompletion.SelectedRecordCount)
+	outcome.ExcludedDeleteMarkerCount = int64(inputCompletion.ExcludedDeleteMarkerCount)
 	if options.Workload == workload.WriteVerify {
 		createCounts, countsErr := readOperationMetrics(options.ResultsRoot, createStep, "CREATE")
 		if countsErr != nil {
@@ -377,6 +379,7 @@ func integritySummary(outcome FinalizeOutcome, finalErr error) *results.Integrit
 		SelectionSourceCount:       outcome.SelectionSourceCount,
 		SelectionUniqueCount:       outcome.SelectionUniqueCount,
 		SelectionCount:             outcome.SelectionCount,
+		ExcludedDeleteMarkerCount:  outcome.ExcludedDeleteMarkerCount,
 		VerificationAttemptedCount: outcome.VerificationAttemptedCount,
 		VerificationDeferred:       outcome.VerificationDeferred,
 		VerifiedCount:              outcome.VerifiedCount,

--- a/cli/internal/integrity/finalizer_test.go
+++ b/cli/internal/integrity/finalizer_test.go
@@ -199,6 +199,10 @@ func TestFinalizeReadVerifyPreservesDiscoveryReconciliationCounts(t *testing.T) 
 		{"OpType", "CountSucc", "CountFail", "CountCorrupt"},
 		{"READ", "64", "0", "0"},
 	})
+	writeCSVFixture(t, filepath.Join(root, listStep+".metrics.total.csv"), [][]string{
+		{"OpType", "CountSucc", "CountFail", "CountCorrupt"},
+		{"LIST", "1", "0", "0"},
+	})
 
 	outcome, err := FinalizeResults(FinalizeOptions{
 		ResultsRoot: root, Workload: workload.ReadVerify, RunID: 151,
@@ -220,6 +224,41 @@ func TestFinalizeReadVerifyPreservesDiscoveryReconciliationCounts(t *testing.T) 
 		manifest.Integrity.SelectionUniqueCount != 64 ||
 		manifest.Integrity.SelectionCount != 64 {
 		t.Fatalf("index.json lost discovery reconciliation counts: %+v", manifest.Integrity)
+	}
+}
+
+func TestFinalizeReadVerifyRejectsPartialDiscoveryWhenListOperationFailed(t *testing.T) {
+	root := t.TempDir()
+	listStep := "mt-001-test-list"
+	readStep := "mt-002-test-verify"
+	writeResultsIndex(t, root, listStep, readStep)
+	writeCommittedFixture(t, root, listStep, VerifyInputName, 152, listStep, [][]string{
+		canonicalHeader,
+		{"b", "first-page-object", "1", "v1"},
+	})
+	writeCSVFixture(t, filepath.Join(root, listStep+".metrics.total.csv"), [][]string{
+		{"OpType", "CountSucc", "CountFail", "CountCorrupt"},
+		{"LIST", "1", "1", "0"},
+	})
+	writeCSVFixture(t, filepath.Join(root, readStep+".metrics.total.csv"), [][]string{
+		{"OpType", "CountSucc", "CountFail", "CountCorrupt"},
+		{"READ", "1", "0", "0"},
+	})
+
+	outcome, err := FinalizeResults(FinalizeOptions{
+		ResultsRoot: root, Workload: workload.ReadVerify, RunID: 152,
+		StepIDs: []string{listStep, readStep},
+	})
+	if err == nil || !strings.Contains(err.Error(), "LIST discovery recorded 1 failed operation") {
+		t.Fatalf("FinalizeResults() error = %v, want failed discovery rejection", err)
+	}
+	if outcome.Complete {
+		t.Fatalf("partial discovery must not finalize complete: %+v", outcome)
+	}
+	for _, name := range []string{VerifyInputName, VerifyInputCompletionName} {
+		if _, statErr := os.Stat(filepath.Join(root, name)); !os.IsNotExist(statErr) {
+			t.Fatalf("partial discovery unexpectedly promoted %s: %v", name, statErr)
+		}
 	}
 }
 

--- a/cli/internal/integrity/manifest.go
+++ b/cli/internal/integrity/manifest.go
@@ -123,7 +123,7 @@ func validateCompletionRecord(
 	producerKind, producerID, artifact string,
 	requireCanonicalManifestName bool,
 ) error {
-	if marker.Version != 1 || marker.Status != "complete" {
+	if (marker.Version != 1 && marker.Version != 2) || marker.Status != "complete" {
 		return fmt.Errorf("completion record has unsupported version/status %d/%q", marker.Version, marker.Status)
 	}
 	if runID <= 0 || marker.RunID != runID {
@@ -141,6 +141,9 @@ func validateCompletionRecord(
 	if marker.SourceRecordCount < 0 || marker.UniqueRecordCount < 0 || marker.SelectedRecordCount < 0 ||
 		marker.SourceRecordCount < marker.UniqueRecordCount || marker.UniqueRecordCount < marker.SelectedRecordCount {
 		return fmt.Errorf("completion record counts are inconsistent")
+	}
+	if marker.ExcludedDeleteMarkerCount < 0 || (marker.Version == 1 && marker.ExcludedDeleteMarkerCount != 0) {
+		return fmt.Errorf("completion record excluded delete marker count is inconsistent")
 	}
 
 	evidence, err := validateCanonicalManifestEvidence(manifestPath)

--- a/cli/internal/integrity/manifest.go
+++ b/cli/internal/integrity/manifest.go
@@ -16,6 +16,8 @@ import (
 	"strconv"
 	"strings"
 	"unicode/utf8"
+
+	"github.com/dell/storage-performance-tool/cli/internal/constants"
 )
 
 const (
@@ -123,7 +125,8 @@ func validateCompletionRecord(
 	producerKind, producerID, artifact string,
 	requireCanonicalManifestName bool,
 ) error {
-	if (marker.Version != 1 && marker.Version != 2) || marker.Status != "complete" {
+	if (marker.Version != constants.IntegrityCompletionVersionLegacy &&
+		marker.Version != constants.IntegrityCompletionVersionCurrent) || marker.Status != "complete" {
 		return fmt.Errorf("completion record has unsupported version/status %d/%q", marker.Version, marker.Status)
 	}
 	if runID <= 0 || marker.RunID != runID {
@@ -142,7 +145,7 @@ func validateCompletionRecord(
 		marker.SourceRecordCount < marker.UniqueRecordCount || marker.UniqueRecordCount < marker.SelectedRecordCount {
 		return fmt.Errorf("completion record counts are inconsistent")
 	}
-	if marker.ExcludedDeleteMarkerCount < 0 || (marker.Version == 1 && marker.ExcludedDeleteMarkerCount != 0) {
+	if marker.ExcludedDeleteMarkerCount < 0 || (marker.Version == constants.IntegrityCompletionVersionLegacy && marker.ExcludedDeleteMarkerCount != 0) {
 		return fmt.Errorf("completion record excluded delete marker count is inconsistent")
 	}
 

--- a/cli/internal/integrity/portable_test.go
+++ b/cli/internal/integrity/portable_test.go
@@ -233,11 +233,12 @@ func TestValidateCompletionPortableAcceptsOneIdentityBoundRecordAndRejectsTraili
 	}
 	digest := sha256.Sum256(manifestData)
 	marker := Completion{
-		Version: 1, Status: "complete", RunID: 17,
+		Version: 2, Status: "complete", RunID: 17,
 		ProducerKind: constants.IntegrityProvenanceEngineStep,
 		ProducerID:   "mt-001-create", Artifact: WrittenName,
 		SourceRecordCount: 1, UniqueRecordCount: 1, SelectedRecordCount: 1,
-		ManifestBytes: int64(len(manifestData)), ManifestSHA256: hex.EncodeToString(digest[:]),
+		ExcludedDeleteMarkerCount: 3, ManifestBytes: int64(len(manifestData)),
+		ManifestSHA256: hex.EncodeToString(digest[:]),
 	}
 	markerData, err := json.Marshal(marker)
 	if err != nil {
@@ -256,6 +257,9 @@ func TestValidateCompletionPortableAcceptsOneIdentityBoundRecordAndRejectsTraili
 	}
 	if validated.SelectedRecordCount != 1 {
 		t.Fatalf("selected record count = %d, want 1", validated.SelectedRecordCount)
+	}
+	if validated.ExcludedDeleteMarkerCount != 3 {
+		t.Fatalf("excluded delete-marker count = %d, want 3", validated.ExcludedDeleteMarkerCount)
 	}
 
 	if err = os.WriteFile(completionPath, append(markerData, []byte("\n{}\n")...), 0o600); err != nil {

--- a/cli/internal/integrity/stager.go
+++ b/cli/internal/integrity/stager.go
@@ -153,7 +153,7 @@ func stageInputManifestWithOperations(
 		return "", "", "", fmt.Errorf("hash staged manifest: %w", hashErr)
 	}
 	marker := Completion{
-		Version: 1, Status: "complete", RunID: runID,
+		Version: constants.IntegrityCompletionVersionLegacy, Status: "complete", RunID: runID,
 		ProducerKind: constants.IntegrityProvenanceCLIStager, ProducerID: CLIStagerProducerID,
 		Artifact: VerifyInputName, SourceRecordCount: sourceCount,
 		UniqueRecordCount: uniqueCount, SelectedRecordCount: uniqueCount,

--- a/cli/internal/integrity/stager.go
+++ b/cli/internal/integrity/stager.go
@@ -35,17 +35,18 @@ func (r ManifestRecord) identity() string { return r.bucket + "\x00" + r.key + "
 
 // Completion is the versioned commit record for one canonical manifest.
 type Completion struct {
-	Version             int    `json:"version"`
-	Status              string `json:"status"`
-	RunID               int64  `json:"run_id"`
-	ProducerKind        string `json:"producer_kind"`
-	ProducerID          string `json:"producer_id"`
-	Artifact            string `json:"artifact"`
-	SourceRecordCount   int    `json:"source_record_count"`
-	UniqueRecordCount   int    `json:"unique_record_count"`
-	SelectedRecordCount int    `json:"selected_record_count"`
-	ManifestBytes       int64  `json:"manifest_bytes"`
-	ManifestSHA256      string `json:"manifest_sha256"`
+	Version                   int    `json:"version"`
+	Status                    string `json:"status"`
+	RunID                     int64  `json:"run_id"`
+	ProducerKind              string `json:"producer_kind"`
+	ProducerID                string `json:"producer_id"`
+	Artifact                  string `json:"artifact"`
+	SourceRecordCount         int    `json:"source_record_count"`
+	UniqueRecordCount         int    `json:"unique_record_count"`
+	SelectedRecordCount       int    `json:"selected_record_count"`
+	ExcludedDeleteMarkerCount int    `json:"excluded_delete_marker_count,omitempty"`
+	ManifestBytes             int64  `json:"manifest_bytes"`
+	ManifestSHA256            string `json:"manifest_sha256"`
 }
 
 // StageInputManifest validates a complete canonical user manifest, makes a deterministic immutable

--- a/cli/internal/integrity/stager_test.go
+++ b/cli/internal/integrity/stager_test.go
@@ -228,7 +228,7 @@ func TestValidateCompletionRejectsTrustBoundaryMismatches(t *testing.T) {
 		mutate     func(*Completion)
 		wantDetail string
 	}{
-		{name: "version", mutate: func(c *Completion) { c.Version++ }, wantDetail: "unsupported version/status"},
+		{name: "version", mutate: func(c *Completion) { c.Version = 3 }, wantDetail: "unsupported version/status"},
 		{name: "status", mutate: func(c *Completion) { c.Status = "pending" }, wantDetail: "unsupported version/status"},
 		{name: "run", mutate: func(c *Completion) { c.RunID++ }, wantDetail: "completion run_id"},
 		{name: "producer kind", mutate: func(c *Completion) {

--- a/cli/internal/integrityplan/plan.go
+++ b/cli/internal/integrityplan/plan.go
@@ -39,6 +39,16 @@ const (
 	InputExternal InputProvenance = "external"
 )
 
+// DiscoveryVersions binds a read-verification plan to its LIST identity policy.
+type DiscoveryVersions string
+
+const (
+	// DiscoveryVersionsCurrent selects only current visible objects.
+	DiscoveryVersionsCurrent DiscoveryVersions = "current"
+	// DiscoveryVersionsAll selects every data version while excluding delete markers.
+	DiscoveryVersionsAll DiscoveryVersions = "all"
+)
+
 // PlanKind identifies one complete, immutable integrity scenario shape.
 type PlanKind string
 
@@ -64,15 +74,16 @@ var runtimeStepID = regexp.MustCompile(`^mt-([0-9]{3})-[0-9]{8}\.[0-9]{6}\.[0-9]
 
 // Plan is the typed verification contract generated once before launch.
 type Plan struct {
-	RunID      int64
-	Workload   string
-	Kind       PlanKind
-	Producer   *PlannedStep
-	Verifier   PlannedStep
-	Cleanup    *PlannedStep
-	Input      InputProvenance
-	Multipart  bool
-	AllowEmpty bool
+	RunID             int64
+	Workload          string
+	Kind              PlanKind
+	Producer          *PlannedStep
+	Verifier          PlannedStep
+	Cleanup           *PlannedStep
+	Input             InputProvenance
+	Multipart         bool
+	AllowEmpty        bool
+	DiscoveryVersions DiscoveryVersions
 }
 
 // Valid reports whether the complete immutable verification shape is internally consistent.
@@ -116,19 +127,27 @@ func (p Plan) Valid() bool {
 	producerIs := func(role StepRole) bool {
 		return p.Producer != nil && p.Producer.Role == role
 	}
+	versions := p.DiscoveryVersions
+	if versions == "" {
+		versions = DiscoveryVersionsCurrent
+	}
 	switch p.Kind {
 	case PlanKindWriteRead:
 		return p.Workload == workload.WriteVerify && p.Input == InputWritten &&
+			versions == DiscoveryVersionsCurrent &&
 			producerIs(StepRoleCreate) && !p.AllowEmpty &&
 			(p.Cleanup == nil || p.Cleanup.Role == StepRoleCleanup)
 	case PlanKindWriteSeed:
 		return p.Workload == workload.WriteVerify && p.Input == InputWritten &&
+			versions == DiscoveryVersionsCurrent &&
 			producerIs(StepRoleCreate) && p.Cleanup == nil && !p.AllowEmpty
 	case PlanKindReadDiscovered:
 		return p.Workload == workload.ReadVerify && p.Input == InputDiscovered &&
+			(versions == DiscoveryVersionsCurrent || versions == DiscoveryVersionsAll) &&
 			producerIs(StepRoleList) && p.Cleanup == nil
 	case PlanKindReadExternal:
 		return p.Workload == workload.ReadVerify && p.Input == InputExternal &&
+			versions == DiscoveryVersionsCurrent &&
 			p.Producer == nil && p.Cleanup == nil
 	default:
 		return false

--- a/cli/internal/integrityplan/plan_test.go
+++ b/cli/internal/integrityplan/plan_test.go
@@ -38,6 +38,17 @@ func TestPlanValidRequiresConsistentWorkloadProvenanceAndRoles(t *testing.T) {
 			want: true,
 		},
 		{
+			name: "all-version discovery read",
+			plan: Plan{RunID: 10, Workload: workload.ReadVerify, Kind: PlanKindReadDiscovered, Producer: list,
+				Verifier: verify, Input: InputDiscovered, DiscoveryVersions: DiscoveryVersionsAll},
+			want: true,
+		},
+		{
+			name: "unknown-version discovery read",
+			plan: Plan{RunID: 11, Workload: workload.ReadVerify, Kind: PlanKindReadDiscovered, Producer: list,
+				Verifier: verify, Input: InputDiscovered, DiscoveryVersions: "unknown"},
+		},
+		{
 			name: "external read",
 			plan: Plan{RunID: 3, Workload: workload.ReadVerify, Kind: PlanKindReadExternal,
 				Verifier: verify, Input: InputExternal},

--- a/cli/internal/results/fetcher.go
+++ b/cli/internal/results/fetcher.go
@@ -105,6 +105,7 @@ type IntegritySummary struct {
 	SelectionSourceCount       int64                       `json:"selection_source_count"`
 	SelectionUniqueCount       int64                       `json:"selection_unique_count"`
 	SelectionCount             int64                       `json:"selection_count"`
+	ExcludedDeleteMarkerCount  int64                       `json:"excluded_delete_marker_count"`
 	VerificationAttemptedCount int64                       `json:"verification_attempted_count"`
 	VerificationDeferred       bool                        `json:"verification_deferred"`
 	VerifiedCount              int64                       `json:"verified_count"`

--- a/cli/internal/results/summary/render.go
+++ b/cli/internal/results/summary/render.go
@@ -227,8 +227,9 @@ func (r *Renderer) renderIntegrity(b *strings.Builder, summary *RunSummary) {
 		r.writeBullet(b, "Verification", "deferred")
 	}
 	if integrity.SelectionCountsValid && hasListStep(summary) {
-		r.writeBullet(b, "Discovery", fmt.Sprintf("source %d, unique %d, selected %d",
-			integrity.SelectionSourceCount, integrity.SelectionUniqueCount, integrity.SelectionCount))
+		r.writeBullet(b, "Discovery", fmt.Sprintf("source %d, unique %d, selected %d, delete markers excluded %d",
+			integrity.SelectionSourceCount, integrity.SelectionUniqueCount, integrity.SelectionCount,
+			integrity.ExcludedDeleteMarkerCount))
 	}
 	if integrity.FinalizationError != "" {
 		r.writeBullet(b, "Finalization error", integrity.FinalizationError)

--- a/cli/internal/results/summary/render_test.go
+++ b/cli/internal/results/summary/render_test.go
@@ -266,6 +266,7 @@ func TestRendererListWorkloadDisplaysPrefix(t *testing.T) {
 		Integrity: &results.IntegritySummary{
 			Complete: true, SelectionCountsValid: true,
 			SelectionSourceCount: 384, SelectionUniqueCount: 128, SelectionCount: 128,
+			ExcludedDeleteMarkerCount: 9,
 		},
 	}
 
@@ -276,7 +277,7 @@ func TestRendererListWorkloadDisplaysPrefix(t *testing.T) {
 	mustContain(t, report, "• Prefix             daily/")
 	mustContain(t, report, "Rate Avg")
 	mustContain(t, report, "256 objects/s")
-	mustContain(t, report, "source 384, unique 128, selected 128")
+	mustContain(t, report, "source 384, unique 128, selected 128, delete markers excluded 9")
 
 	mustNotContain(t, report, "512 MiB/s")
 	table := renderer.performanceTable(summary)

--- a/cli/internal/scenario/constants.go
+++ b/cli/internal/scenario/constants.go
@@ -29,6 +29,11 @@ const (
 	// S3DriverRdma selects the RDMA-accelerated S3 driver.
 	S3DriverRdma = "rdma"
 
+	// VersionsCurrent discovers only each key's current visible object.
+	VersionsCurrent = "current"
+	// VersionsAll discovers every data version and excludes delete markers.
+	VersionsAll = "all"
+
 	// ChecksumCRC32 selects CRC-32 checksum validation.
 	ChecksumCRC32 = "crc32"
 	// ChecksumCRC32C selects CRC-32C checksum validation.

--- a/cli/internal/scenario/generator_integrity.go
+++ b/cli/internal/scenario/generator_integrity.go
@@ -82,6 +82,17 @@ func GenerateReadVerifyScenario(params Params) (string, error) {
 		return "", fmt.Errorf("read-verify object count must be non-negative")
 	}
 	ts := resolveTimestamp(params)
+	versions := params.Versions
+	if versions == "" {
+		versions = VersionsCurrent
+	}
+	if versions != VersionsCurrent && versions != VersionsAll {
+		return "", fmt.Errorf("read-verify versions must be %q or %q", VersionsCurrent, VersionsAll)
+	}
+	if params.ItemsFile != "" && versions != VersionsCurrent {
+		return "", fmt.Errorf("read-verify all-version discovery cannot be used with an items file")
+	}
+	params.Versions = versions
 	driver := resolveStorageDriverType(params.S3Driver)
 	bucketPath := "/" + strings.TrimPrefix(params.Bucket, "/")
 	readNumber := 2
@@ -112,9 +123,10 @@ func GenerateReadVerifyScenario(params Params) (string, error) {
 				Provenance: provenance, ExpectedProducerID: producerID,
 			},
 		},
-		BucketPath: bucketPath,
-		Prefix:     params.Prefix,
-		ItemsFile:  params.ItemsFile,
+		BucketPath:      bucketPath,
+		Prefix:          params.Prefix,
+		ItemsFile:       params.ItemsFile,
+		IncludeVersions: versions == VersionsAll,
 	})
 }
 

--- a/cli/internal/scenario/generator_integrity_templates.go
+++ b/cli/internal/scenario/generator_integrity_templates.go
@@ -36,14 +36,15 @@ type writeVerifyScenarioData struct {
 }
 
 type readVerifyScenarioData struct {
-	Discovery   bool
-	ListStep    string
-	ReadStep    string
-	ListStorage integrityStorageTemplateData
-	ReadStorage integrityStorageTemplateData
-	BucketPath  string
-	Prefix      string
-	ItemsFile   string
+	Discovery       bool
+	ListStep        string
+	ReadStep        string
+	ListStorage     integrityStorageTemplateData
+	ReadStorage     integrityStorageTemplateData
+	BucketPath      string
+	Prefix          string
+	ItemsFile       string
+	IncludeVersions bool
 }
 
 var integrityScenarioTemplates = template.Must(
@@ -121,7 +122,7 @@ Load.config({
   },
   "load": {
     "batch": {"size": 1000},
-    "op": {"type": "list", "list": {"delimiter": "", "fetch_metadata": true, "include_versions": false, "max_keys": 1000}, "limit": {"rate": 0}, "wait": {"finish": true}},
+    "op": {"type": "list", "list": {"delimiter": "", "fetch_metadata": true, "include_versions": {{.IncludeVersions}}, "max_keys": 1000}, "limit": {"rate": 0}, "wait": {"finish": true}},
     "step": {"id": {{jsq .ListStep}}}
   },
   {{template "summary"}}

--- a/cli/internal/scenario/generator_integrity_test.go
+++ b/cli/internal/scenario/generator_integrity_test.go
@@ -284,6 +284,29 @@ func TestGenerateReadVerifyScenarioDiscoveryAndStagedInput(t *testing.T) {
 		t.Fatalf("discovery READ producer = %#v, want %q", producer, discoveryPlan.Steps[0].ID)
 	}
 
+	if includeVersions := generatedConfigValue(t, discoveryConfigs[0], "load", "op", "list", "include_versions"); includeVersions != false {
+		t.Fatalf("default LIST include_versions = %#v, want false", includeVersions)
+	}
+
+	allVersions, err := GenerateReadVerifyScenario(Params{
+		WorkloadType: WorkloadTypeReadVerify, RunID: 11, Bucket: "b", Prefix: "p/",
+		ObjectCount: 7, Threads: 4, Versions: VersionsAll,
+		BaseTimestamp: "20260730.120000.000",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	allConfigs := parseGeneratedScenarioConfigs(t, allVersions)
+	if includeVersions := generatedConfigValue(t, allConfigs[0], "load", "op", "list", "include_versions"); includeVersions != true {
+		t.Fatalf("all-version LIST include_versions = %#v, want true", includeVersions)
+	}
+	if _, err = GenerateReadVerifyScenario(Params{
+		WorkloadType: WorkloadTypeReadVerify, RunID: 12, Bucket: "b", Threads: 1,
+		ItemsFile: "/spt-input/items/verify-input.csv", Versions: VersionsAll,
+	}); err == nil || !strings.Contains(err.Error(), "cannot be used with an items file") {
+		t.Fatalf("all-version items-file error = %v", err)
+	}
+
 	staged, err := GenerateReadVerifyScenario(Params{
 		WorkloadType: WorkloadTypeReadVerify, RunID: 10, Bucket: "b", Threads: 1,
 		ItemsFile: "/spt-input/items/verify-input.csv", BaseTimestamp: "20260730.120000.000",

--- a/cli/internal/scenario/plan.go
+++ b/cli/internal/scenario/plan.go
@@ -120,10 +120,15 @@ func BuildVerificationPlan(params Params, steps StepPlan) (integrityplan.Plan, e
 		return integrityplan.Plan{}, fmt.Errorf(
 			"verification cleanup step presence does not match requested cleanup=%t", params.Cleanup)
 	}
+	versions := params.Versions
+	if versions == "" {
+		versions = VersionsCurrent
+	}
 	plan := integrityplan.Plan{
 		RunID: params.RunID, Workload: params.WorkloadType,
 		Cleanup: cleanup, Multipart: params.PartSize != "",
-		AllowEmpty: params.AllowEmptySelection,
+		AllowEmpty:        params.AllowEmptySelection,
+		DiscoveryVersions: integrityplan.DiscoveryVersions(versions),
 	}
 	if verifier != nil {
 		plan.Verifier = *verifier

--- a/cli/internal/scenario/plan.go
+++ b/cli/internal/scenario/plan.go
@@ -19,12 +19,17 @@ type StepInfo struct {
 
 // StepPlan is an ordered list of steps discovered in a generated scenario.
 type StepPlan struct {
-	Steps []StepInfo
+	Steps                []StepInfo
+	ListIncludesVersions []bool
 }
 
-var stepIDCaptureRe = regexp.MustCompile(`"id"\s*:\s*"([A-Za-z0-9._-]+)-([0-9]{3})-([0-9]{8}\.[0-9]{6}\.[0-9]{3})-([a-z0-9_-]+)"`)
+var (
+	stepIDCaptureRe = regexp.MustCompile(`"id"\s*:\s*"([A-Za-z0-9._-]+)-([0-9]{3})-([0-9]{8}\.[0-9]{6}\.[0-9]{3})-([a-z0-9_-]+)"`)
+	listVersionsRe  = regexp.MustCompile(`"include_versions"\s*:\s*(true|false)`)
+)
 
-// BuildStepPlanFromScenario scans the scenario text and extracts step IDs in order.
+// BuildStepPlanFromScenario scans the scenario text and extracts step IDs in order,
+// along with rendered LIST version settings used by the typed-plan cross-check.
 // It does not attempt to infer relationships beyond what is encoded in the ID.
 func BuildStepPlanFromScenario(scenarioText string) (StepPlan, error) {
 	matches := stepIDCaptureRe.FindAllStringSubmatch(scenarioText, -1)
@@ -47,7 +52,11 @@ func BuildStepPlanFromScenario(scenarioText string) (StepPlan, error) {
 
 	// Preserve natural order by step number.
 	sort.SliceStable(steps, func(i, j int) bool { return steps[i].Number < steps[j].Number })
-	return StepPlan{Steps: steps}, nil
+	listIncludesVersions := make([]bool, 0, 1)
+	for _, match := range listVersionsRe.FindAllStringSubmatch(scenarioText, -1) {
+		listIncludesVersions = append(listIncludesVersions, match[1] == "true")
+	}
+	return StepPlan{Steps: steps, ListIncludesVersions: listIncludesVersions}, nil
 }
 
 // BuildVerificationPlan assigns semantic roles to one already-rendered,
@@ -167,6 +176,20 @@ func BuildVerificationPlan(params Params, steps StepPlan) (integrityplan.Plan, e
 			producer, producerErr := one(integrityplan.StepRoleList, true)
 			if producerErr != nil {
 				return integrityplan.Plan{}, producerErr
+			}
+			if len(steps.ListIncludesVersions) != 1 {
+				return integrityplan.Plan{}, fmt.Errorf(
+					"read-verify discovery scenario has %d include_versions settings, want 1",
+					len(steps.ListIncludesVersions))
+			}
+			renderedVersions := integrityplan.DiscoveryVersionsCurrent
+			if steps.ListIncludesVersions[0] {
+				renderedVersions = integrityplan.DiscoveryVersionsAll
+			}
+			if renderedVersions != plan.DiscoveryVersions {
+				return integrityplan.Plan{}, fmt.Errorf(
+					"read-verify discovery scenario versions %q do not match plan versions %q",
+					renderedVersions, plan.DiscoveryVersions)
 			}
 			plan.Kind = integrityplan.PlanKindReadDiscovered
 			plan.Producer = producer

--- a/cli/internal/scenario/types.go
+++ b/cli/internal/scenario/types.go
@@ -66,7 +66,8 @@ type Params struct {
 	MinimalTUI                  bool
 	AllowEmptySelection         bool
 	DeferVerification           bool
-	IntegrityMaxConsoleFailures int // Start TUI with graphs and messages panels collapsed
+	Versions                    string // read-verify discovery policy: current or all
+	IntegrityMaxConsoleFailures int    // Start TUI with graphs and messages panels collapsed
 
 	// S3 Tables workload
 	Tables TablesParams

--- a/cli/internal/scenario/verification_plan_test.go
+++ b/cli/internal/scenario/verification_plan_test.go
@@ -5,6 +5,7 @@ Copyright © 2026 Dell Technologies
 package scenario
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/dell/storage-performance-tool/cli/internal/integrityplan"
@@ -17,6 +18,7 @@ func TestBuildVerificationPlanGeneratedRoutes(t *testing.T) {
 		wantKind     integrityplan.PlanKind
 		wantInput    integrityplan.InputProvenance
 		wantRole     integrityplan.StepRole
+		wantVersions integrityplan.DiscoveryVersions
 		wantVerifier bool
 		wantCleanup  bool
 	}{
@@ -25,21 +27,31 @@ func TestBuildVerificationPlanGeneratedRoutes(t *testing.T) {
 			params: Params{WorkloadType: WorkloadTypeWriteVerify, RunID: 101,
 				Bucket: "b", ObjectSize: "10MiB", ObjectCount: 1, Threads: 1,
 				PartSize: "5MiB", Cleanup: true, BaseTimestamp: "20260802.120000.000"},
-			wantKind: integrityplan.PlanKindWriteRead, wantInput: integrityplan.InputWritten, wantRole: integrityplan.StepRoleCreate, wantVerifier: true,
+			wantKind: integrityplan.PlanKindWriteRead, wantInput: integrityplan.InputWritten, wantRole: integrityplan.StepRoleCreate,
+			wantVersions: integrityplan.DiscoveryVersionsCurrent, wantVerifier: true,
 			wantCleanup: true,
 		},
 		{
 			name: "read verify discovery",
 			params: Params{WorkloadType: WorkloadTypeReadVerify, RunID: 102,
+				Bucket: "b", ObjectCount: 1, Threads: 1, BaseTimestamp: "20260802.120000.000"},
+			wantKind: integrityplan.PlanKindReadDiscovered, wantInput: integrityplan.InputDiscovered, wantRole: integrityplan.StepRoleList,
+			wantVersions: integrityplan.DiscoveryVersionsCurrent, wantVerifier: true,
+		},
+		{
+			name: "read verify discovery all versions",
+			params: Params{WorkloadType: WorkloadTypeReadVerify, RunID: 105,
 				Bucket: "b", ObjectCount: 1, Threads: 1, Versions: VersionsAll, BaseTimestamp: "20260802.120000.000"},
-			wantKind: integrityplan.PlanKindReadDiscovered, wantInput: integrityplan.InputDiscovered, wantRole: integrityplan.StepRoleList, wantVerifier: true,
+			wantKind: integrityplan.PlanKindReadDiscovered, wantInput: integrityplan.InputDiscovered, wantRole: integrityplan.StepRoleList,
+			wantVersions: integrityplan.DiscoveryVersionsAll, wantVerifier: true,
 		},
 		{
 			name: "read verify external",
 			params: Params{WorkloadType: WorkloadTypeReadVerify, RunID: 103,
 				Bucket: "b", Threads: 1, ItemsFile: "/spt-input/items.csv",
 				AllowEmptySelection: true, BaseTimestamp: "20260802.120000.000"},
-			wantKind: integrityplan.PlanKindReadExternal, wantInput: integrityplan.InputExternal, wantVerifier: true,
+			wantKind: integrityplan.PlanKindReadExternal, wantInput: integrityplan.InputExternal,
+			wantVersions: integrityplan.DiscoveryVersionsCurrent, wantVerifier: true,
 		},
 		{
 			name: "deferred write verify",
@@ -47,7 +59,7 @@ func TestBuildVerificationPlanGeneratedRoutes(t *testing.T) {
 				Bucket: "b", ObjectSize: "1MiB", ObjectCount: 1, Threads: 1,
 				DeferVerification: true, BaseTimestamp: "20260802.120000.000"},
 			wantKind: integrityplan.PlanKindWriteSeed, wantInput: integrityplan.InputWritten,
-			wantRole: integrityplan.StepRoleCreate,
+			wantRole: integrityplan.StepRoleCreate, wantVersions: integrityplan.DiscoveryVersionsCurrent,
 		},
 	}
 	for _, test := range tests {
@@ -69,10 +81,10 @@ func TestBuildVerificationPlanGeneratedRoutes(t *testing.T) {
 				(plan.Cleanup != nil) != test.wantCleanup {
 				t.Fatalf("typed plan = %+v", plan)
 			}
+			if plan.DiscoveryVersions != test.wantVersions {
+				t.Fatalf("typed plan versions = %q, want %q", plan.DiscoveryVersions, test.wantVersions)
+			}
 			if test.wantRole == "" {
-				if test.params.Versions == VersionsAll && plan.DiscoveryVersions != integrityplan.DiscoveryVersionsAll {
-					t.Fatalf("typed plan versions = %q, want all", plan.DiscoveryVersions)
-				}
 				if plan.Producer != nil {
 					t.Fatalf("external plan producer = %+v, want nil", plan.Producer)
 				}
@@ -80,6 +92,27 @@ func TestBuildVerificationPlanGeneratedRoutes(t *testing.T) {
 				t.Fatalf("producer = %+v, want role %s", plan.Producer, test.wantRole)
 			}
 		})
+	}
+}
+
+func TestBuildVerificationPlanRejectsRenderedVersionDrift(t *testing.T) {
+	params := Params{WorkloadType: WorkloadTypeReadVerify, RunID: 106,
+		Bucket: "b", ObjectCount: 1, Threads: 1, Versions: VersionsAll,
+		BaseTimestamp: "20260802.120000.000"}
+	rendered, err := GenerateScenario(params)
+	if err != nil {
+		t.Fatal(err)
+	}
+	drifted := strings.Replace(rendered, `"include_versions": true`, `"include_versions": false`, 1)
+	if drifted == rendered {
+		t.Fatal("generated scenario is missing the all-version LIST setting")
+	}
+	steps, err := BuildStepPlanFromScenario(drifted)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := BuildVerificationPlan(params, steps); err == nil || !strings.Contains(err.Error(), "do not match") {
+		t.Fatalf("rendered version drift error = %v, want mismatch", err)
 	}
 }
 

--- a/cli/internal/scenario/verification_plan_test.go
+++ b/cli/internal/scenario/verification_plan_test.go
@@ -31,7 +31,7 @@ func TestBuildVerificationPlanGeneratedRoutes(t *testing.T) {
 		{
 			name: "read verify discovery",
 			params: Params{WorkloadType: WorkloadTypeReadVerify, RunID: 102,
-				Bucket: "b", ObjectCount: 1, Threads: 1, BaseTimestamp: "20260802.120000.000"},
+				Bucket: "b", ObjectCount: 1, Threads: 1, Versions: VersionsAll, BaseTimestamp: "20260802.120000.000"},
 			wantKind: integrityplan.PlanKindReadDiscovered, wantInput: integrityplan.InputDiscovered, wantRole: integrityplan.StepRoleList, wantVerifier: true,
 		},
 		{
@@ -70,6 +70,9 @@ func TestBuildVerificationPlanGeneratedRoutes(t *testing.T) {
 				t.Fatalf("typed plan = %+v", plan)
 			}
 			if test.wantRole == "" {
+				if test.params.Versions == VersionsAll && plan.DiscoveryVersions != integrityplan.DiscoveryVersionsAll {
+					t.Fatalf("typed plan versions = %q, want all", plan.DiscoveryVersions)
+				}
 				if plan.Producer != nil {
 					t.Fatalf("external plan producer = %+v, want nil", plan.Producer)
 				}

--- a/cli/tools/testreadverifyversions.sh
+++ b/cli/tools/testreadverifyversions.sh
@@ -1,0 +1,796 @@
+#!/usr/bin/env bash
+
+# End-to-end qualification for read-verify historical-version discovery.
+# Seeds controlled S3 version histories with mc, runs the candidate SPT CLI/image,
+# and compares canonical manifests with an independent version-list oracle.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+if [[ -f "$ROOT_DIR/.env" ]]; then
+	set -a
+	# shellcheck disable=SC1091
+	source "$ROOT_DIR/.env"
+	set +a
+fi
+
+SPT_BIN=${SPT_BIN:-"$ROOT_DIR/spt"}
+PHASE=all
+SUITE=full
+DRIVERS=${QUAL_DRIVERS:-"netty,aws"}
+THREADS=${THREADS:-8}
+HOSTS=${QUAL_HOSTS:-"127.0.0.1"}
+MIN_HOSTS=${MIN_HOSTS:-1}
+DISTRIBUTED_HOSTS=${QUAL_DISTRIBUTED_HOSTS:-""}
+DISTRIBUTED_MIN_HOSTS=${QUAL_DISTRIBUTED_MIN_HOSTS:-2}
+PAGE_VERSIONS=${QUAL_PAGE_VERSIONS:-1005}
+RESULTS_DIR=${RESULTS_DIR:-"$ROOT_DIR/results"}
+EVIDENCE_DIR=""
+QUAL_ID=""
+BUCKET=""
+CLEANUP_ON_SUCCESS=false
+CONFIRM_TARGET_MUTATION=false
+ALLOW_INCOMPLETE=false
+SKIP_IMAGE_PULL=${SPT_SKIP_IMAGE_PULL:-false}
+IMAGE=${SPT_IMAGE:-""}
+ENDPOINTS=${S3_ENDPOINTS:-${S3_ENDPOINT:-""}}
+ACCESS_KEY=${S3_ACCESS_KEY:-""}
+SECRET_KEY=${S3_SECRET_KEY:-""}
+RESTRICTED_ACCESS_KEY=${S3_VERSION_DENIED_ACCESS_KEY:-""}
+RESTRICTED_SECRET_KEY=${S3_VERSION_DENIED_SECRET_KEY:-""}
+MC_ALIAS=qual
+MC_CONFIG_DIR=""
+WORK_DIR=""
+RUNS_DIR=""
+ORACLE_DIR=""
+STATE_FILE=""
+SUSPENDED_BUCKET=""
+UNVERSIONED_BUCKET=""
+BAD_VERSION_ID=""
+MISSING_VERSION_ID=""
+
+die() {
+	echo "error: $*" >&2
+	exit 1
+}
+
+require_value() {
+	if (( $# < 2 )) || [[ -z "${2:-}" ]]; then
+		die "$1 requires a value"
+	fi
+}
+
+enabled() {
+	case "${1,,}" in
+		1|true|yes|on) return 0 ;;
+		*) return 1 ;;
+	esac
+}
+
+usage() {
+	cat <<EOF
+Usage: $(basename "$0") [options]
+
+Seed and qualify read-verify --versions=current|all against an S3 target.
+Target mutation is refused unless --confirm-target-mutation is supplied.
+
+Modes:
+  --phase all       Seed fixtures and run qualification (default)
+  --phase seed      Seed fixtures and write independent oracles
+  --phase run       Run against fixtures recorded in --evidence-dir
+  --phase cleanup   Remove only recorded spt-version-qual-* buckets
+
+Qualification:
+  --suite smoke|full          smoke skips pagination and special-bucket cases
+  --drivers CSV               netty,aws (default: $DRIVERS)
+  --page-versions N           Data versions in pagination fixture (default: $PAGE_VERSIONS)
+  --threads N                 SPT verification concurrency (default: $THREADS)
+  --hosts CSV                 Hosts for ordinary cases (default: $HOSTS)
+  --min-hosts N               Minimum ordinary hosts (default: $MIN_HOSTS)
+  --distributed-hosts CSV     Optional hosts for the distributed pagination gate
+  --distributed-min-hosts N   Minimum distributed hosts (default: $DISTRIBUTED_MIN_HOSTS)
+  --allow-incomplete          Permit full-suite gaps and report passed-with-gaps
+
+State and target:
+  --evidence-dir DIR          Qualification state/results directory
+  --bucket NAME               Dedicated bucket; must start spt-version-qual-
+  --results-dir DIR           Parent for new evidence (default: $RESULTS_DIR)
+  --confirm-target-mutation   Required for seed/all/cleanup
+  --cleanup-on-success        Remove all recorded versions/buckets after a passing run
+
+Candidate:
+  --spt-bin PATH              Candidate CLI (default: $SPT_BIN)
+  --image IMAGE               Commit-specific engine image
+  --skip-image-pull           Use the preloaded image
+
+Connection values are read from cli/.env and may be overridden by S3_ENDPOINTS,
+S3_ACCESS_KEY, S3_SECRET_KEY, and QUAL_HOSTS. Permission-denied cases run only when
+S3_VERSION_DENIED_ACCESS_KEY and S3_VERSION_DENIED_SECRET_KEY are configured.
+
+Examples:
+  $(basename "$0") --phase seed --confirm-target-mutation
+  $(basename "$0") --phase run --evidence-dir ./results/version-qualification-...
+  $(basename "$0") --phase all --image ghcr.io/dell/storage-performance-tool:allversions-<commit> \
+    --skip-image-pull --confirm-target-mutation
+  $(basename "$0") --phase cleanup --evidence-dir ./results/version-qualification-... \
+    --confirm-target-mutation
+EOF
+}
+
+while (( $# > 0 )); do
+	case "$1" in
+		--phase) require_value "$@"; PHASE=$2; shift 2 ;;
+		--suite) require_value "$@"; SUITE=$2; shift 2 ;;
+		--drivers) require_value "$@"; DRIVERS=$2; shift 2 ;;
+		--page-versions) require_value "$@"; PAGE_VERSIONS=$2; shift 2 ;;
+		--threads) require_value "$@"; THREADS=$2; shift 2 ;;
+		--hosts) require_value "$@"; HOSTS=$2; shift 2 ;;
+		--min-hosts) require_value "$@"; MIN_HOSTS=$2; shift 2 ;;
+		--distributed-hosts) require_value "$@"; DISTRIBUTED_HOSTS=$2; shift 2 ;;
+		--distributed-min-hosts) require_value "$@"; DISTRIBUTED_MIN_HOSTS=$2; shift 2 ;;
+		--evidence-dir) require_value "$@"; EVIDENCE_DIR=$2; shift 2 ;;
+		--bucket) require_value "$@"; BUCKET=$2; shift 2 ;;
+		--results-dir) require_value "$@"; RESULTS_DIR=$2; shift 2 ;;
+		--spt-bin) require_value "$@"; SPT_BIN=$2; shift 2 ;;
+		--image) require_value "$@"; IMAGE=$2; shift 2 ;;
+		--skip-image-pull) SKIP_IMAGE_PULL=true; shift ;;
+		--no-skip-image-pull) SKIP_IMAGE_PULL=false; shift ;;
+		--cleanup-on-success) CLEANUP_ON_SUCCESS=true; shift ;;
+		--confirm-target-mutation) CONFIRM_TARGET_MUTATION=true; shift ;;
+		--allow-incomplete) ALLOW_INCOMPLETE=true; shift ;;
+		-h|--help) usage; exit 0 ;;
+		*) die "unknown argument $1" ;;
+	esac
+done
+
+case "$PHASE" in all|seed|run|cleanup) ;; *) die "--phase must be all, seed, run, or cleanup" ;; esac
+case "$SUITE" in smoke|full) ;; *) die "--suite must be smoke or full" ;; esac
+[[ "$PAGE_VERSIONS" =~ ^[0-9]+$ ]] || die "--page-versions must be a positive integer"
+(( PAGE_VERSIONS > 0 )) || die "--page-versions must be positive"
+if [[ "$SUITE" == "full" ]]; then
+	(( PAGE_VERSIONS > 1000 )) || die "full suite requires --page-versions greater than 1000"
+fi
+[[ "$THREADS" =~ ^[0-9]+$ ]] && (( THREADS > 0 )) || die "--threads must be positive"
+[[ "$MIN_HOSTS" =~ ^[0-9]+$ ]] && (( MIN_HOSTS > 0 )) || die "--min-hosts must be positive"
+[[ "$DISTRIBUTED_MIN_HOSTS" =~ ^[0-9]+$ ]] && (( DISTRIBUTED_MIN_HOSTS > 0 )) ||
+	die "--distributed-min-hosts must be positive"
+
+IFS=',' read -r -a DRIVER_LIST <<< "$DRIVERS"
+(( ${#DRIVER_LIST[@]} > 0 )) || die "--drivers must not be empty"
+for driver in "${DRIVER_LIST[@]}"; do
+	case "$driver" in
+		netty|aws) ;;
+		rdma) die "native RDMA is explicitly unqualified without hardware; use netty,aws" ;;
+		*) die "unsupported qualification driver: $driver" ;;
+	esac
+done
+
+for tool in mc jq sha256sum stat sort diff awk find; do
+	command -v "$tool" >/dev/null || die "required tool is missing: $tool"
+done
+
+[[ -n "$ENDPOINTS" ]] || die "S3_ENDPOINTS or S3_ENDPOINT is required"
+[[ -n "$ACCESS_KEY" ]] || die "S3_ACCESS_KEY is required"
+[[ -n "$SECRET_KEY" ]] || die "S3_SECRET_KEY is required"
+
+if [[ "$PHASE" == "run" || "$PHASE" == "cleanup" ]]; then
+	[[ -n "$EVIDENCE_DIR" ]] || die "--evidence-dir is required for phase $PHASE"
+	EVIDENCE_DIR="$(cd -- "$EVIDENCE_DIR" && pwd)"
+	STATE_FILE="$EVIDENCE_DIR/state.json"
+	[[ -f "$STATE_FILE" ]] || die "state file is missing: $STATE_FILE"
+	QUAL_ID=$(jq -er '.qualification_id' "$STATE_FILE")
+	BUCKET=$(jq -er '.bucket' "$STATE_FILE")
+	SUSPENDED_BUCKET=$(jq -er '.suspended_bucket' "$STATE_FILE")
+	UNVERSIONED_BUCKET=$(jq -er '.unversioned_bucket' "$STATE_FILE")
+	BAD_VERSION_ID=$(jq -r '.bad_version_id // ""' "$STATE_FILE")
+	MISSING_VERSION_ID=$(jq -r '.missing_version_id // ""' "$STATE_FILE")
+	SUITE=$(jq -er '.suite' "$STATE_FILE")
+else
+	QUAL_ID=${QUAL_ID:-"$(date -u +%Y%m%d-%H%M%S)-$$"}
+	BUCKET=${BUCKET:-"spt-version-qual-$QUAL_ID"}
+	SUSPENDED_BUCKET="$BUCKET-suspended"
+	UNVERSIONED_BUCKET="$BUCKET-unversioned"
+	if [[ -z "$EVIDENCE_DIR" ]]; then
+		EVIDENCE_DIR="$RESULTS_DIR/version-qualification-$QUAL_ID"
+	fi
+	mkdir -p "$EVIDENCE_DIR"
+	EVIDENCE_DIR="$(cd -- "$EVIDENCE_DIR" && pwd)"
+	STATE_FILE="$EVIDENCE_DIR/state.json"
+fi
+
+RUNS_DIR="$EVIDENCE_DIR/runs"
+ORACLE_DIR="$EVIDENCE_DIR/oracles"
+mkdir -p "$RUNS_DIR" "$ORACLE_DIR"
+WORK_DIR=$(mktemp -d /tmp/spt-version-qualification.XXXXXX)
+MC_CONFIG_DIR=$(mktemp -d /tmp/spt-version-mc.XXXXXX)
+
+cleanup_local() {
+	rm -rf -- "$WORK_DIR" "$MC_CONFIG_DIR"
+}
+trap cleanup_local EXIT
+
+mcq() {
+	mc --config-dir "$MC_CONFIG_DIR" "$@"
+}
+
+qual_endpoint=${ENDPOINTS%%,*}
+mcq alias set "$MC_ALIAS" "$qual_endpoint" "$ACCESS_KEY" "$SECRET_KEY" >/dev/null
+
+validate_qualification_bucket() {
+	local bucket=$1
+	[[ "$bucket" == spt-version-qual-* ]] ||
+		die "refusing target mutation for non-qualification bucket: $bucket"
+	[[ "$bucket" != *"/"* ]] || die "bucket name must not contain slash: $bucket"
+}
+
+for target_bucket in "$BUCKET" "$SUSPENDED_BUCKET" "$UNVERSIONED_BUCKET"; do
+	validate_qualification_bucket "$target_bucket"
+done
+
+if [[ "$PHASE" == "all" || "$PHASE" == "seed" || "$PHASE" == "cleanup" ]]; then
+	enabled "$CONFIRM_TARGET_MUTATION" ||
+		die "--confirm-target-mutation is required for phase $PHASE"
+fi
+
+if enabled "$CLEANUP_ON_SUCCESS"; then
+	enabled "$CONFIRM_TARGET_MUTATION" ||
+		die "--cleanup-on-success requires --confirm-target-mutation"
+fi
+if [[ "$PHASE" == "run" || "$PHASE" == "all" ]]; then
+	[[ -n "$IMAGE" ]] || die "--image or SPT_IMAGE is required for candidate qualification"
+	if [[ "$SUITE" == "full" ]] && ! enabled "$ALLOW_INCOMPLETE"; then
+		[[ -n "$RESTRICTED_ACCESS_KEY" && -n "$RESTRICTED_SECRET_KEY" ]] ||
+			die "full suite requires restricted version-LIST credentials or --allow-incomplete"
+		[[ -n "$DISTRIBUTED_HOSTS" ]] ||
+			die "full suite requires --distributed-hosts or --allow-incomplete"
+	fi
+fi
+
+write_state() {
+	jq -n \
+		--arg qualification_id "$QUAL_ID" \
+		--arg suite "$SUITE" \
+		--arg bucket "$BUCKET" \
+		--arg suspended_bucket "$SUSPENDED_BUCKET" \
+		--arg unversioned_bucket "$UNVERSIONED_BUCKET" \
+		--arg bad_version_id "$BAD_VERSION_ID" \
+		--arg missing_version_id "$MISSING_VERSION_ID" \
+		--arg endpoint "$qual_endpoint" \
+		--argjson page_versions "$PAGE_VERSIONS" \
+		'{
+			qualification_id: $qualification_id,
+			suite: $suite,
+			bucket: $bucket,
+			suspended_bucket: $suspended_bucket,
+			unversioned_bucket: $unversioned_bucket,
+			bad_version_id: $bad_version_id,
+			missing_version_id: $missing_version_id,
+			endpoint: $endpoint,
+			page_versions: $page_versions
+		}' > "$STATE_FILE"
+}
+
+put_payload() {
+	local bucket=$1
+	local key=$2
+	local content=$3
+	local digest_override=${4:-}
+	local payload="$WORK_DIR/payload.bin"
+	local digest size attrs
+	printf '%s' "$content" > "$payload"
+	digest=$(sha256sum "$payload" | awk '{print $1}')
+	size=$(stat -c '%s' "$payload")
+	if [[ -n "$digest_override" ]]; then
+		digest=$digest_override
+	fi
+	attrs="spt-integrity-version=1;spt-integrity-algorithm=sha256;spt-integrity-digest=$digest;spt-integrity-size=$size"
+	mcq cp --quiet --attr "$attrs" "$payload" "$MC_ALIAS/$bucket/$key" >/dev/null
+}
+
+put_without_metadata() {
+	local bucket=$1
+	local key=$2
+	local content=$3
+	local payload="$WORK_DIR/payload.bin"
+	printf '%s' "$content" > "$payload"
+	mcq cp --quiet "$payload" "$MC_ALIAS/$bucket/$key" >/dev/null
+}
+
+only_data_version_id() {
+	local bucket=$1
+	local prefix=$2
+	local key=$3
+	mcq ls --recursive --versions --json "$MC_ALIAS/$bucket/$prefix" |
+		jq -er --arg key "$key" \
+			'select(.status == "success" and .key == $key and (.isDeleteMarker // false) == false) | .versionId' |
+		head -n 1
+}
+
+write_oracle() {
+	local bucket=$1
+	local prefix=$2
+	local name=$3
+	local mode=$4
+	local raw="$ORACLE_DIR/$name.raw.jsonl"
+	local data="$ORACLE_DIR/$name.data.tsv"
+	local markers="$ORACLE_DIR/$name.markers.tsv"
+	if [[ "$mode" == "all" ]]; then
+		mcq ls --recursive --versions --json "$MC_ALIAS/$bucket/$prefix" > "$raw"
+		jq -r --arg bucket "$bucket" --arg prefix "$prefix" \
+			'select(.status == "success" and (.isDeleteMarker // false) == false) |
+			 [$bucket, ($prefix + .key), (.size | tostring), .versionId] | @tsv' \
+			"$raw" | LC_ALL=C sort > "$data"
+		jq -r --arg bucket "$bucket" --arg prefix "$prefix" \
+			'select(.status == "success" and (.isDeleteMarker // false) == true) |
+			 [$bucket, ($prefix + .key), (.versionId // "")] | @tsv' \
+			"$raw" | LC_ALL=C sort > "$markers"
+	else
+		mcq ls --recursive --json "$MC_ALIAS/$bucket/$prefix" > "$raw"
+		jq -r --arg bucket "$bucket" --arg prefix "$prefix" \
+			'select(.status == "success") |
+			 [$bucket, ($prefix + .key), (.size | tostring), ""] | @tsv' \
+			"$raw" | LC_ALL=C sort > "$data"
+		: > "$markers"
+	fi
+}
+
+line_count() {
+	awk 'END {print NR + 0}' "$1"
+}
+
+seed_fixtures() {
+	echo "Creating dedicated qualification buckets"
+	write_state
+	mcq mb --with-versioning "$MC_ALIAS/$BUCKET" >/dev/null
+	mcq version info --json "$MC_ALIAS/$BUCKET" > "$EVIDENCE_DIR/main-bucket-versioning.json"
+
+	put_payload "$BUCKET" "healthy/alpha" "alpha-v1"
+	put_payload "$BUCKET" "healthy/alpha" "alpha-v2"
+	put_payload "$BUCKET" "healthy/alpha" "alpha-v3"
+	put_payload "$BUCKET" "healthy/beta" "beta-v1"
+	put_payload "$BUCKET" "healthy/beta" "beta-v2"
+	mcq rm --quiet "$MC_ALIAS/$BUCKET/healthy/beta" >/dev/null
+	put_payload "$BUCKET" "healthy/gamma" "gamma-v1"
+
+	put_payload "$BUCKET" "corrupt/object" "corrupt-old" \
+		"0000000000000000000000000000000000000000000000000000000000000000"
+	BAD_VERSION_ID=$(only_data_version_id "$BUCKET" "corrupt/" "object")
+	put_payload "$BUCKET" "corrupt/object" "corrupt-current-healthy"
+
+	put_without_metadata "$BUCKET" "missing/object" "missing-old"
+	MISSING_VERSION_ID=$(only_data_version_id "$BUCKET" "missing/" "object")
+	put_payload "$BUCKET" "missing/object" "missing-current-healthy"
+
+	if [[ "$SUITE" == "full" ]]; then
+		echo "Seeding $PAGE_VERSIONS data versions for paired-marker pagination"
+		local i
+		for ((i = 1; i <= PAGE_VERSIONS; i++)); do
+			put_payload "$BUCKET" "paged/same-key" "paged-payload"
+			if (( i == PAGE_VERSIONS / 3 || i == (PAGE_VERSIONS * 2) / 3 )); then
+				mcq rm --quiet "$MC_ALIAS/$BUCKET/paged/same-key" >/dev/null
+			fi
+			if (( i % 100 == 0 )); then
+				echo "  seeded $i/$PAGE_VERSIONS versions"
+			fi
+		done
+
+		mcq mb --with-versioning "$MC_ALIAS/$SUSPENDED_BUCKET" >/dev/null
+		put_payload "$SUSPENDED_BUCKET" "suspended/object" "opaque-version"
+		mcq version suspend "$MC_ALIAS/$SUSPENDED_BUCKET" >/dev/null
+		mcq version info --json "$MC_ALIAS/$SUSPENDED_BUCKET" > "$EVIDENCE_DIR/suspended-bucket-versioning.json"
+		put_payload "$SUSPENDED_BUCKET" "suspended/object" "literal-null-version"
+
+		mcq mb "$MC_ALIAS/$UNVERSIONED_BUCKET" >/dev/null
+		mcq version info --json "$MC_ALIAS/$UNVERSIONED_BUCKET" > "$EVIDENCE_DIR/unversioned-bucket-versioning.json"
+		put_payload "$UNVERSIONED_BUCKET" "unversioned/object" "unversioned-payload"
+	fi
+
+	write_oracle "$BUCKET" "healthy/" "healthy-current" current
+	write_oracle "$BUCKET" "healthy/" "healthy-all" all
+	write_oracle "$BUCKET" "corrupt/" "corrupt-current" current
+	write_oracle "$BUCKET" "corrupt/" "corrupt-all" all
+	write_oracle "$BUCKET" "missing/" "missing-current" current
+	write_oracle "$BUCKET" "missing/" "missing-all" all
+	if [[ "$SUITE" == "full" ]]; then
+		write_oracle "$BUCKET" "paged/" "paged-all" all
+		write_oracle "$SUSPENDED_BUCKET" "suspended/" "suspended-all" all
+		write_oracle "$UNVERSIONED_BUCKET" "unversioned/" "unversioned-all" all
+	fi
+
+	write_state
+
+	echo "Seed complete"
+	echo "  Evidence: $EVIDENCE_DIR"
+	echo "  Bucket:   $BUCKET"
+	echo "  Healthy:  $(line_count "$ORACLE_DIR/healthy-all.data.tsv") data versions, $(line_count "$ORACLE_DIR/healthy-all.markers.tsv") markers"
+	if [[ "$SUITE" == "full" ]]; then
+		echo "  Paged:    $(line_count "$ORACLE_DIR/paged-all.data.tsv") data versions, $(line_count "$ORACLE_DIR/paged-all.markers.tsv") markers"
+	fi
+}
+
+normalize_manifest() {
+	local manifest=$1
+	local output=$2
+	awk -F',' 'NR > 1 {
+		sub(/\r$/, "", $4)
+		print $1 "\t" $2 "\t" $3 "\t" $4
+	}' "$manifest" | LC_ALL=C sort > "$output"
+}
+
+expected_selection() {
+	local oracle=$1
+	local cap=$2
+	local output=$3
+	if (( cap > 0 )); then
+		head -n "$cap" "$oracle" > "$output"
+	else
+		cp "$oracle" "$output"
+	fi
+}
+
+find_result_dir() {
+	local label=$1
+	find "$RUNS_DIR" -mindepth 1 -maxdepth 1 -type d -name "$label-*" -print |
+		LC_ALL=C sort | tail -n 1
+}
+
+assert_artifacts() {
+	local result_dir=$1
+	local oracle=$2
+	local cap=$3
+	local marker_count=$4
+	local corrupt_version=${5:-}
+	local failure_reason=${6:-}
+	local index="$result_dir/index.json"
+	local input="$result_dir/verify-input.csv"
+	local completion="$result_dir/verify-input.complete.json"
+	local verified="$result_dir/verified.csv"
+	local remaining="$result_dir/verify-remaining.csv"
+	local expected="$WORK_DIR/expected.tsv"
+	local actual="$WORK_DIR/actual.tsv"
+	local expected_verified="$WORK_DIR/expected-verified.tsv"
+	local actual_verified="$WORK_DIR/actual-verified.tsv"
+	local actual_remaining="$WORK_DIR/actual-remaining.tsv"
+	local source_count selected_count corrupt_count verified_count
+	[[ -f "$index" ]] || die "missing index.json in $result_dir"
+	[[ -f "$input" && -f "$completion" && -f "$verified" && -f "$remaining" ]] ||
+		die "missing canonical integrity artifacts in $result_dir"
+
+	source_count=$(line_count "$oracle")
+	if (( cap > 0 && cap < source_count )); then
+		selected_count=$cap
+	else
+		selected_count=$source_count
+	fi
+	if [[ -n "$corrupt_version" ]]; then
+		corrupt_count=1
+	else
+		corrupt_count=0
+	fi
+	verified_count=$((selected_count - corrupt_count))
+
+	jq -e \
+		--argjson source "$source_count" \
+		--argjson selected "$selected_count" \
+		--argjson markers "$marker_count" \
+		--argjson corrupt "$corrupt_count" \
+		--argjson verified "$verified_count" \
+		'.integrity.complete == true and
+		 .integrity.selection_counts_valid == true and
+		 .integrity.selection_source_count == $source and
+		 .integrity.selection_unique_count == $source and
+		 .integrity.selection_count == $selected and
+		 .integrity.excluded_delete_marker_count == $markers and
+		 .integrity.verification_attempted_count == $selected and
+		 .integrity.verified_count == $verified and
+		 .integrity.corrupt_count == $corrupt and
+		 .integrity.remaining_count == $corrupt' "$index" >/dev/null ||
+		die "integrity count assertion failed for $result_dir"
+
+	expected_selection "$oracle" "$cap" "$expected"
+	normalize_manifest "$input" "$actual"
+	diff -u "$expected" "$actual" ||
+		die "verify-input.csv differs from the independent oracle"
+
+	if [[ -n "$corrupt_version" ]]; then
+		awk -F'\t' -v version="$corrupt_version" '$4 != version' "$expected" > "$expected_verified"
+	else
+		cp "$expected" "$expected_verified"
+	fi
+	normalize_manifest "$verified" "$actual_verified"
+	diff -u "$expected_verified" "$actual_verified" ||
+		die "verified.csv differs from expected healthy identities"
+
+	normalize_manifest "$remaining" "$actual_remaining"
+	if [[ -n "$corrupt_version" ]]; then
+		awk -F'\t' -v version="$corrupt_version" '$4 == version' "$expected" > "$WORK_DIR/expected-remaining.tsv"
+		diff -u "$WORK_DIR/expected-remaining.tsv" "$actual_remaining" ||
+			die "verify-remaining.csv does not contain the exact corrupt identity"
+		local failure_file="$result_dir/integrity.failures.csv"
+		[[ -f "$failure_file" ]] || die "missing integrity.failures.csv"
+		awk -F',' -v reason="$failure_reason" -v version="$corrupt_version" \
+			'NR > 1 && $6 == version && $9 == reason {found = 1} END {exit !found}' "$failure_file" ||
+			die "missing exact $failure_reason failure row for version $corrupt_version"
+	else
+		[[ ! -s "$actual_remaining" ]] || die "healthy run has remaining identities"
+	fi
+
+	local manifest_bytes manifest_sha
+	manifest_bytes=$(stat -c '%s' "$input")
+	manifest_sha=$(sha256sum "$input" | awk '{print $1}')
+	jq -e \
+		--argjson source "$source_count" \
+		--argjson selected "$selected_count" \
+		--argjson markers "$marker_count" \
+		--argjson bytes "$manifest_bytes" \
+		--arg sha "$manifest_sha" \
+		'.version == 2 and .status == "complete" and
+		 .source_record_count == $source and
+		 .unique_record_count == $source and
+		 .selected_record_count == $selected and
+		 .excluded_delete_marker_count == $markers and
+		 .manifest_bytes == $bytes and .manifest_sha256 == $sha' "$completion" >/dev/null ||
+		die "completion evidence assertion failed for $result_dir"
+}
+
+record_candidate_identity() {
+	local commit cli_sha image_id=""
+	commit=$(git -C "$ROOT_DIR/.." rev-parse HEAD)
+	cli_sha=$(sha256sum "$SPT_BIN" | awk '{print $1}')
+	if [[ -n "$IMAGE" ]] && command -v docker >/dev/null; then
+		image_id=$(docker image inspect "$IMAGE" --format '{{.Id}}' 2>/dev/null || true)
+	fi
+	if enabled "$SKIP_IMAGE_PULL"; then
+		[[ -n "$image_id" ]] || die "preloaded candidate image is not locally inspectable: $IMAGE"
+	fi
+	jq -n \
+		--arg commit "$commit" \
+		--arg cli "$SPT_BIN" \
+		--arg cli_sha256 "$cli_sha" \
+		--arg image "$IMAGE" \
+		--arg image_id "$image_id" \
+		'{
+			source_commit: $commit,
+			cli_path: $cli,
+			cli_sha256: $cli_sha256,
+			engine_image: $image,
+			engine_image_id: $image_id,
+			rdma: "native path unqualified: hardware unavailable"
+		}' > "$EVIDENCE_DIR/candidate-identity.json"
+}
+
+run_case() {
+	local driver=$1
+	local case_name=$2
+	local bucket=$3
+	local prefix=$4
+	local versions=$5
+	local oracle=$6
+	local cap=$7
+	local corrupt_version=$8
+	local failure_reason=$9
+	local hosts=${10}
+	local min_hosts=${11}
+	local access=${12:-$ACCESS_KEY}
+	local secret=${13:-$SECRET_KEY}
+	local expected_exit=0
+	local source_count marker_count label result_dir console_log
+	local -a cmd
+	source_count=$(line_count "$oracle")
+	marker_count=$(line_count "${oracle%.data.tsv}.markers.tsv")
+	if [[ -n "$corrupt_version" ]]; then
+		expected_exit=20
+	fi
+	label="avq-${QUAL_ID//[^A-Za-z0-9]/}-${case_name//[^A-Za-z0-9]/}-$driver"
+	label=${label:0:60}
+	console_log="$EVIDENCE_DIR/$label.console.log"
+
+	cmd=("$SPT_BIN" run read-verify
+		--headless
+		--auto-results=true
+		--shutdown-on-complete=true
+		--endpoints "$ENDPOINTS"
+		--access-key "$access"
+		--secret-key "$secret"
+		--bucket "$bucket"
+		--prefix "$prefix"
+		--versions "$versions"
+		--s3-driver "$driver"
+		--test-hosts "$hosts"
+		--min-hosts "$min_hosts"
+		--threads "$THREADS"
+		--results-dir "$RUNS_DIR"
+		--label "$label"
+		--force)
+	if (( cap > 0 )); then
+		cmd+=(--object-count "$cap")
+	fi
+	if (( source_count == 0 )); then
+		cmd+=(--allow-empty-selection)
+	fi
+
+	echo "Running $case_name with $driver ($versions, source=$source_count, markers=$marker_count)"
+	set +e
+	"${cmd[@]}" > "$console_log" 2>&1
+	local exit_code=$?
+	set -e
+	if (( exit_code != expected_exit )); then
+		tail -80 "$console_log" >&2
+		die "$case_name/$driver exit $exit_code, expected $expected_exit"
+	fi
+	result_dir=$(find_result_dir "$label")
+	[[ -n "$result_dir" ]] || die "cannot locate results for $case_name/$driver"
+	assert_artifacts "$result_dir" "$oracle" "$cap" "$marker_count" "$corrupt_version" "$failure_reason"
+	echo "  PASS: $result_dir"
+}
+
+run_permission_case() {
+	local driver=$1
+	if [[ -z "$RESTRICTED_ACCESS_KEY" || -z "$RESTRICTED_SECRET_KEY" ]]; then
+		echo "SKIP: version-LIST permission case ($driver): restricted credential is not configured"
+		return
+	fi
+	run_case "$driver" "permission-current" "$BUCKET" "healthy/" current \
+		"$ORACLE_DIR/healthy-current.data.tsv" 0 "" "" "$HOSTS" "$MIN_HOSTS" \
+		"$RESTRICTED_ACCESS_KEY" "$RESTRICTED_SECRET_KEY"
+
+	local label="avq-${QUAL_ID//[^A-Za-z0-9]/}-permissionall-$driver"
+	label=${label:0:60}
+	local console_log="$EVIDENCE_DIR/$label.console.log"
+	local -a cmd=("$SPT_BIN" run read-verify
+		--headless --auto-results=true --shutdown-on-complete=true
+		--endpoints "$ENDPOINTS"
+		--access-key "$RESTRICTED_ACCESS_KEY"
+		--secret-key "$RESTRICTED_SECRET_KEY"
+		--bucket "$BUCKET"
+		--prefix "healthy/"
+		--versions all
+		--s3-driver "$driver"
+		--test-hosts "$HOSTS"
+		--min-hosts "$MIN_HOSTS"
+		--threads "$THREADS"
+		--results-dir "$RUNS_DIR"
+		--label "$label"
+		--force)
+	echo "Running permission-all with $driver (expected authorization failure)"
+	set +e
+	"${cmd[@]}" > "$console_log" 2>&1
+	local exit_code=$?
+	set -e
+	(( exit_code == 1 )) || {
+		tail -80 "$console_log" >&2
+		die "permission-all/$driver exit $exit_code, expected 1"
+	}
+	local result_dir
+	result_dir=$(find_result_dir "$label")
+	if [[ -n "$result_dir" && -f "$result_dir/verify-input.complete.json" ]]; then
+		die "permission-all/$driver published a usable discovery completion"
+	fi
+	echo "  PASS: authorization failure was fail-closed"
+}
+
+run_qualification() {
+	[[ -x "$SPT_BIN" ]] || die "SPT binary is missing or not executable: $SPT_BIN"
+	[[ -f "$STATE_FILE" ]] || die "seed state is missing: $STATE_FILE"
+	[[ -n "$BAD_VERSION_ID" ]] || die "seed state has no corrupt historical version ID"
+	[[ -n "$MISSING_VERSION_ID" ]] || die "seed state has no missing-metadata historical version ID"
+	for oracle in healthy-current healthy-all corrupt-current corrupt-all missing-current missing-all; do
+		[[ -f "$ORACLE_DIR/$oracle.data.tsv" ]] || die "oracle is missing: $oracle"
+	done
+
+	if [[ -n "$IMAGE" ]]; then
+		export SPT_IMAGE="$IMAGE"
+	fi
+	if enabled "$SKIP_IMAGE_PULL"; then
+		export SPT_SKIP_IMAGE_PULL=true
+	else
+		unset SPT_SKIP_IMAGE_PULL
+	fi
+	record_candidate_identity
+
+	for driver in "${DRIVER_LIST[@]}"; do
+		run_case "$driver" "healthy-current" "$BUCKET" "healthy/" current \
+			"$ORACLE_DIR/healthy-current.data.tsv" 0 "" "" "$HOSTS" "$MIN_HOSTS"
+		run_case "$driver" "healthy-all" "$BUCKET" "healthy/" all \
+			"$ORACLE_DIR/healthy-all.data.tsv" 0 "" "" "$HOSTS" "$MIN_HOSTS"
+		run_case "$driver" "healthy-cap" "$BUCKET" "healthy/" all \
+			"$ORACLE_DIR/healthy-all.data.tsv" 3 "" "" "$HOSTS" "$MIN_HOSTS"
+		run_case "$driver" "corrupt-current" "$BUCKET" "corrupt/" current \
+			"$ORACLE_DIR/corrupt-current.data.tsv" 0 "" "" "$HOSTS" "$MIN_HOSTS"
+		run_case "$driver" "corrupt-all" "$BUCKET" "corrupt/" all \
+			"$ORACLE_DIR/corrupt-all.data.tsv" 0 "$BAD_VERSION_ID" "digest_mismatch" "$HOSTS" "$MIN_HOSTS"
+		run_case "$driver" "missing-current" "$BUCKET" "missing/" current \
+			"$ORACLE_DIR/missing-current.data.tsv" 0 "" "" "$HOSTS" "$MIN_HOSTS"
+		run_case "$driver" "missing-all" "$BUCKET" "missing/" all \
+			"$ORACLE_DIR/missing-all.data.tsv" 0 "$MISSING_VERSION_ID" "metadata_missing" "$HOSTS" "$MIN_HOSTS"
+
+		if [[ "$SUITE" == "full" ]]; then
+			run_case "$driver" "paged-all" "$BUCKET" "paged/" all \
+				"$ORACLE_DIR/paged-all.data.tsv" 0 "" "" "$HOSTS" "$MIN_HOSTS"
+			run_case "$driver" "suspended-all" "$SUSPENDED_BUCKET" "suspended/" all \
+				"$ORACLE_DIR/suspended-all.data.tsv" 0 "" "" "$HOSTS" "$MIN_HOSTS"
+			run_case "$driver" "unversioned-all" "$UNVERSIONED_BUCKET" "unversioned/" all \
+				"$ORACLE_DIR/unversioned-all.data.tsv" 0 "" "" "$HOSTS" "$MIN_HOSTS"
+		fi
+		run_permission_case "$driver"
+	done
+
+	if [[ "$SUITE" == "full" && -n "$DISTRIBUTED_HOSTS" ]]; then
+		for driver in "${DRIVER_LIST[@]}"; do
+			run_case "$driver" "paged-distributed" "$BUCKET" "paged/" all \
+				"$ORACLE_DIR/paged-all.data.tsv" 0 "" "" \
+				"$DISTRIBUTED_HOSTS" "$DISTRIBUTED_MIN_HOSTS"
+		done
+	elif [[ "$SUITE" == "full" ]]; then
+		echo "SKIP: distributed pagination gate: --distributed-hosts is not configured"
+	fi
+
+	local status=passed
+	local restricted_gap=""
+	local distributed_gap=""
+	if [[ -z "$RESTRICTED_ACCESS_KEY" || -z "$RESTRICTED_SECRET_KEY" ]]; then
+		restricted_gap="version-LIST permission case not run"
+	fi
+	if [[ "$SUITE" == "full" && -z "$DISTRIBUTED_HOSTS" ]]; then
+		distributed_gap="distributed pagination case not run"
+	fi
+	if [[ -n "$restricted_gap" || -n "$distributed_gap" ]]; then
+		status=passed-with-gaps
+	fi
+	jq -n \
+		--arg status "$status" \
+		--arg qualification_id "$QUAL_ID" \
+		--arg drivers "$DRIVERS" \
+		--arg distributed "${DISTRIBUTED_HOSTS:-not run}" \
+		--arg restricted_gap "$restricted_gap" \
+		--arg distributed_gap "$distributed_gap" \
+		--arg rdma "native path unqualified: hardware unavailable" \
+		'{
+			status: $status,
+			qualification_id: $qualification_id,
+			e2e_drivers: ($drivers | split(",")),
+			distributed_hosts: $distributed,
+			gaps: [$restricted_gap, $distributed_gap] | map(select(length > 0)),
+			rdma: $rdma
+		}' > "$EVIDENCE_DIR/qualification-summary.json"
+	echo "Qualification $status: $EVIDENCE_DIR"
+}
+
+cleanup_bucket() {
+	local bucket=$1
+	validate_qualification_bucket "$bucket"
+	echo "Removing all versions and bucket $bucket"
+	mcq rb --force "$MC_ALIAS/$bucket" >/dev/null
+}
+
+cleanup_target() {
+	for target_bucket in "$BUCKET" "$SUSPENDED_BUCKET" "$UNVERSIONED_BUCKET"; do
+		if mcq stat "$MC_ALIAS/$target_bucket" >/dev/null 2>&1; then
+			cleanup_bucket "$target_bucket"
+		fi
+	done
+	echo "Qualification buckets removed"
+}
+
+case "$PHASE" in
+	seed)
+		seed_fixtures
+		;;
+	run)
+		run_qualification
+		if enabled "$CLEANUP_ON_SUCCESS"; then
+			cleanup_target
+		fi
+		;;
+	all)
+		seed_fixtures
+		run_qualification
+		if enabled "$CLEANUP_ON_SUCCESS"; then
+			cleanup_target
+		fi
+		;;
+	cleanup)
+		cleanup_target
+		;;
+esac
+

--- a/cli/tools/testreadverifyversions.sh
+++ b/cli/tools/testreadverifyversions.sh
@@ -441,6 +441,7 @@ assert_artifacts() {
 	local marker_count=$4
 	local corrupt_version=${5:-}
 	local failure_reason=${6:-}
+	local source_multiplier=${7:-1}
 	local index="$result_dir/index.json"
 	local input="$result_dir/verify-input.csv"
 	local completion="$result_dir/verify-input.complete.json"
@@ -451,12 +452,15 @@ assert_artifacts() {
 	local expected_verified="$WORK_DIR/expected-verified.tsv"
 	local actual_verified="$WORK_DIR/actual-verified.tsv"
 	local actual_remaining="$WORK_DIR/actual-remaining.tsv"
-	local source_count selected_count corrupt_count verified_count
+	local source_count raw_source_count selected_count corrupt_count verified_count
 	[[ -f "$index" ]] || die "missing index.json in $result_dir"
 	[[ -f "$input" && -f "$completion" && -f "$verified" && -f "$remaining" ]] ||
 		die "missing canonical integrity artifacts in $result_dir"
 
 	source_count=$(line_count "$oracle")
+	# Every distributed node receives the LIST seed; finalization de-duplicates the overlap.
+	raw_source_count=$((source_count * source_multiplier))
+	marker_count=$((marker_count * source_multiplier))
 	if (( cap > 0 && cap < source_count )); then
 		selected_count=$cap
 	else
@@ -470,7 +474,8 @@ assert_artifacts() {
 	verified_count=$((selected_count - corrupt_count))
 
 	jq -e \
-		--argjson source "$source_count" \
+		--argjson source "$raw_source_count" \
+		--argjson unique "$source_count" \
 		--argjson selected "$selected_count" \
 		--argjson markers "$marker_count" \
 		--argjson corrupt "$corrupt_count" \
@@ -478,7 +483,7 @@ assert_artifacts() {
 		'.integrity.complete == true and
 		 .integrity.selection_counts_valid == true and
 		 .integrity.selection_source_count == $source and
-		 .integrity.selection_unique_count == $source and
+		 .integrity.selection_unique_count == $unique and
 		 .integrity.selection_count == $selected and
 		 .integrity.excluded_delete_marker_count == $markers and
 		 .integrity.verification_attempted_count == $selected and
@@ -519,18 +524,38 @@ assert_artifacts() {
 	manifest_bytes=$(stat -c '%s' "$input")
 	manifest_sha=$(sha256sum "$input" | awk '{print $1}')
 	jq -e \
-		--argjson source "$source_count" \
+		--argjson source "$raw_source_count" \
+		--argjson unique "$source_count" \
 		--argjson selected "$selected_count" \
 		--argjson markers "$marker_count" \
 		--argjson bytes "$manifest_bytes" \
 		--arg sha "$manifest_sha" \
 		'.version == 2 and .status == "complete" and
 		 .source_record_count == $source and
-		 .unique_record_count == $source and
+		 .unique_record_count == $unique and
 		 .selected_record_count == $selected and
 		 .excluded_delete_marker_count == $markers and
 		 .manifest_bytes == $bytes and .manifest_sha256 == $sha' "$completion" >/dev/null ||
 		die "completion evidence assertion failed for $result_dir"
+}
+
+assert_distributed_identity() {
+	local result_dir=$1
+	local expected_host_count=$2
+	local params="$result_dir/spt_run_params.json"
+	[[ -f "$params" ]] || die "missing distributed runtime identity evidence in $result_dir"
+	jq -e --argjson expected "$expected_host_count" '
+		. as $root |
+		.multiHost.enabled == true and
+		.multiHost.hostCount == $expected and
+		.runtimeIdentity.tier == "immutable_image_and_payload" and
+		(.runtimeIdentity.imageId | startswith("sha256:")) and
+		(.runtimeIdentity.payloadSha256 | test("^[0-9a-f]{64}$")) and
+		(.runtimeIdentity.participants | length) == $expected and
+		all(.runtimeIdentity.participants[];
+			.imageId == $root.runtimeIdentity.imageId and
+			.payloadSha256 == $root.runtimeIdentity.payloadSha256)
+	' "$params" >/dev/null || die "distributed runtime identity assertion failed for $result_dir"
 }
 
 record_candidate_identity() {
@@ -573,6 +598,7 @@ run_case() {
 	local min_hosts=${11}
 	local access=${12:-$ACCESS_KEY}
 	local secret=${13:-$SECRET_KEY}
+	local source_multiplier=${14:-1}
 	local expected_exit=0
 	local source_count marker_count label result_dir console_log
 	local -a cmd
@@ -608,6 +634,10 @@ run_case() {
 	if (( source_count == 0 )); then
 		cmd+=(--allow-empty-selection)
 	fi
+	if (( source_multiplier > 1 )); then
+		# Distributed qualification is release evidence, so require the stronger payload tier.
+		cmd+=(--integrity-runtime-identity-tier payload)
+	fi
 
 	echo "Running $case_name with $driver ($versions, source=$source_count, markers=$marker_count)"
 	set +e
@@ -620,7 +650,11 @@ run_case() {
 	fi
 	result_dir=$(find_result_dir "$label")
 	[[ -n "$result_dir" ]] || die "cannot locate results for $case_name/$driver"
-	assert_artifacts "$result_dir" "$oracle" "$cap" "$marker_count" "$corrupt_version" "$failure_reason"
+	assert_artifacts "$result_dir" "$oracle" "$cap" "$marker_count" "$corrupt_version" "$failure_reason" \
+		"$source_multiplier"
+	if (( source_multiplier > 1 )); then
+		assert_distributed_identity "$result_dir" "$source_multiplier"
+	fi
 	echo "  PASS: $result_dir"
 }
 
@@ -716,10 +750,14 @@ run_qualification() {
 	done
 
 	if [[ "$SUITE" == "full" && -n "$DISTRIBUTED_HOSTS" ]]; then
+		local -a distributed_host_list
+		IFS=',' read -r -a distributed_host_list <<< "$DISTRIBUTED_HOSTS"
+		local distributed_host_count=${#distributed_host_list[@]}
 		for driver in "${DRIVER_LIST[@]}"; do
 			run_case "$driver" "paged-distributed" "$BUCKET" "paged/" all \
 				"$ORACLE_DIR/paged-all.data.tsv" 0 "" "" \
-				"$DISTRIBUTED_HOSTS" "$DISTRIBUTED_MIN_HOSTS"
+				"$DISTRIBUTED_HOSTS" "$DISTRIBUTED_MIN_HOSTS" \
+				"$ACCESS_KEY" "$SECRET_KEY" "$distributed_host_count"
 		done
 	elif [[ "$SUITE" == "full" ]]; then
 		echo "SKIP: distributed pagination gate: --distributed-hosts is not configured"

--- a/cli/tools/testreadverifyversions.sh
+++ b/cli/tools/testreadverifyversions.sh
@@ -319,17 +319,17 @@ write_oracle() {
 		jq -r --arg bucket "$bucket" --arg prefix "$prefix" \
 			'select(.status == "success" and (.isDeleteMarker // false) == false) |
 			 [$bucket, ($prefix + .key), (.size | tostring), .versionId] | @tsv' \
-			"$raw" | LC_ALL=C sort > "$data"
+			"$raw" | LC_ALL=C sort -t$'\t' -k1,1 -k2,2 -k4,4 > "$data"
 		jq -r --arg bucket "$bucket" --arg prefix "$prefix" \
 			'select(.status == "success" and (.isDeleteMarker // false) == true) |
 			 [$bucket, ($prefix + .key), (.versionId // "")] | @tsv' \
-			"$raw" | LC_ALL=C sort > "$markers"
+			"$raw" | LC_ALL=C sort -t$'\t' -k1,1 -k2,2 -k3,3 > "$markers"
 	else
 		mcq ls --recursive --json "$MC_ALIAS/$bucket/$prefix" > "$raw"
 		jq -r --arg bucket "$bucket" --arg prefix "$prefix" \
 			'select(.status == "success") |
 			 [$bucket, ($prefix + .key), (.size | tostring), ""] | @tsv' \
-			"$raw" | LC_ALL=C sort > "$data"
+			"$raw" | LC_ALL=C sort -t$'\t' -k1,1 -k2,2 -k4,4 > "$data"
 		: > "$markers"
 	fi
 }
@@ -344,8 +344,8 @@ seed_fixtures() {
 	mcq mb --with-versioning "$MC_ALIAS/$BUCKET" >/dev/null
 	mcq version info --json "$MC_ALIAS/$BUCKET" > "$EVIDENCE_DIR/main-bucket-versioning.json"
 
-	put_payload "$BUCKET" "healthy/alpha" "alpha-v1"
-	put_payload "$BUCKET" "healthy/alpha" "alpha-v2"
+	put_payload "$BUCKET" "healthy/alpha" "a"
+	put_payload "$BUCKET" "healthy/alpha" "alpha-version-two-is-longer"
 	put_payload "$BUCKET" "healthy/alpha" "alpha-v3"
 	put_payload "$BUCKET" "healthy/beta" "beta-v1"
 	put_payload "$BUCKET" "healthy/beta" "beta-v2"
@@ -362,6 +362,15 @@ seed_fixtures() {
 	put_payload "$BUCKET" "missing/object" "missing-current-healthy"
 
 	if [[ "$SUITE" == "full" ]]; then
+		echo "Seeding version-completeness partition fixture"
+		local partition_index
+		for ((partition_index = 1; partition_index <= THREADS; partition_index++)); do
+			put_payload "$BUCKET" "partition/live-$partition_index/object" \
+				"partition-live-$partition_index"
+		done
+		put_payload "$BUCKET" "partition/deleted-only/object" "deleted-historical-data"
+		mcq rm --quiet "$MC_ALIAS/$BUCKET/partition/deleted-only/object" >/dev/null
+
 		echo "Seeding $PAGE_VERSIONS data versions for paired-marker pagination"
 		local i
 		for ((i = 1; i <= PAGE_VERSIONS; i++)); do
@@ -392,6 +401,7 @@ seed_fixtures() {
 	write_oracle "$BUCKET" "missing/" "missing-current" current
 	write_oracle "$BUCKET" "missing/" "missing-all" all
 	if [[ "$SUITE" == "full" ]]; then
+		write_oracle "$BUCKET" "partition/" "partition-all" all
 		write_oracle "$BUCKET" "paged/" "paged-all" all
 		write_oracle "$SUSPENDED_BUCKET" "suspended/" "suspended-all" all
 		write_oracle "$UNVERSIONED_BUCKET" "unversioned/" "unversioned-all" all
@@ -404,6 +414,7 @@ seed_fixtures() {
 	echo "  Bucket:   $BUCKET"
 	echo "  Healthy:  $(line_count "$ORACLE_DIR/healthy-all.data.tsv") data versions, $(line_count "$ORACLE_DIR/healthy-all.markers.tsv") markers"
 	if [[ "$SUITE" == "full" ]]; then
+		echo "  Partition: $(line_count "$ORACLE_DIR/partition-all.data.tsv") data versions, $(line_count "$ORACLE_DIR/partition-all.markers.tsv") markers"
 		echo "  Paged:    $(line_count "$ORACLE_DIR/paged-all.data.tsv") data versions, $(line_count "$ORACLE_DIR/paged-all.markers.tsv") markers"
 	fi
 }
@@ -414,7 +425,7 @@ normalize_manifest() {
 	awk -F',' 'NR > 1 {
 		sub(/\r$/, "", $4)
 		print $1 "\t" $2 "\t" $3 "\t" $4
-	}' "$manifest" | LC_ALL=C sort > "$output"
+	}' "$manifest" | LC_ALL=C sort -t$'\t' -k1,1 -k2,2 -k4,4 > "$output"
 }
 
 expected_selection() {
@@ -739,6 +750,8 @@ run_qualification() {
 			"$ORACLE_DIR/missing-all.data.tsv" 0 "$MISSING_VERSION_ID" "metadata_missing" "$HOSTS" "$MIN_HOSTS"
 
 		if [[ "$SUITE" == "full" ]]; then
+			run_case "$driver" "partition-all" "$BUCKET" "partition/" all \
+				"$ORACLE_DIR/partition-all.data.tsv" 0 "" "" "$HOSTS" "$MIN_HOSTS"
 			run_case "$driver" "paged-all" "$BUCKET" "paged/" all \
 				"$ORACLE_DIR/paged-all.data.tsv" 0 "" "" "$HOSTS" "$MIN_HOSTS"
 			run_case "$driver" "suspended-all" "$SUSPENDED_BUCKET" "suspended/" all \

--- a/engine/core/spt-base/doc/usage/input/configuration/README.md
+++ b/engine/core/spt-base/doc/usage/input/configuration/README.md
@@ -226,7 +226,7 @@ Also there's a shortcut alias for the load operation types:
 |---------------------------|---------------|---------|-------------|
 | load-op-list-delimiter    | String/null   | null    | Optional delimiter for pseudo-directory listings. When null, full object keys are returned. |
 | load-op-list-fetch_metadata | Flag        | false   | When true, aggregate size/etag metadata available in `ListObjectsV2` responses; remains lightweight when false. |
-| load-op-list-include_versions | Flag     | false   | Switches to `ListObjectVersions`, returning each version as a distinct success. Buckets without versioning return empty results and emit a warning. |
+| load-op-list-include_versions | Flag     | false   | Switches to paginated `ListObjectVersions`, returning each data version with its exact version ID and excluding delete markers while counting them separately. Unversioned-bucket results are target-specific and may be empty or contain a literal `null` version. |
 | load-op-list-max_keys     | Integer >= 0  | 0       | Overrides the per-request page size. 0 defers to S3 defaults; positive values are capped at the service limit (1000). |
 | load-op-list-sharding-mode | String       | auto      | When unset, `auto` selects `none` for single-threaded runs and `static` when concurrency > 1. Explicit values override the default: `none` runs a single LIST stream; `static` seeds multiple prefixes locally so each worker enumerates a unique prefix. |
 | load-op-list-sharding-radix | Integer >= 0 | 0      | Number of static prefixes to seed. 0 defaults to the length of `load-op-list-sharding-charset`. Profiles set this automatically but you can override it. |

--- a/engine/core/spt-base/doc/usage/item/input/README.md
+++ b/engine/core/spt-base/doc/usage/item/input/README.md
@@ -140,8 +140,10 @@ The marker is published only after its CSV and binds version/status, positive
 `run_id`, producer kind and ID, source/unique/selected counts, byte length, and
 SHA-256. `engine_step` provenance requires the exact producing step ID;
 `cli_stager` requires `spt-cli-items-stager-v1`. A missing, malformed, stale, or
-mismatched marker prevents dependent I/O. Completion v1 is a closed schema:
-unknown JSON members and trailing JSON values are rejected.
+mismatched marker prevents dependent I/O. Completion v2 adds
+`excluded_delete_marker_count`, which is zero outside all-version discovery.
+Each completion version is a closed schema: unknown JSON members and trailing
+JSON values are rejected.
 
 LIST discovery streams complete object entries into per-node sources, merges
 RFC 4180 records, canonical external-sorts them by `(bucket,key,version_id)`,
@@ -149,3 +151,9 @@ de-duplicates shard overlap, applies the configured selection maximum,
 publishes `verify-input.csv`, and only then starts READ. QA-owned `external`
 input is parsed and validated but intentionally does not require an engine
 completion marker.
+
+With `load-op-list-include_versions=true`, LIST discovery preserves every data
+version's exact ID in the canonical identity and excludes delete markers while
+recording their count in completion v2. Distributed source counts include
+overlapping per-node observations; unique and selected counts describe the
+canonical post-de-duplication manifest.

--- a/engine/core/spt-base/src/main/java/com/dell/spt/base/integrity/IntegrityManifestCompletion.java
+++ b/engine/core/spt-base/src/main/java/com/dell/spt/base/integrity/IntegrityManifestCompletion.java
@@ -11,7 +11,7 @@ import java.nio.file.Path;
 /**
  * Identity-bound completion record for a canonical integrity manifest.
  *
- * <p>Version 1 is a closed schema: unknown members and trailing JSON values are rejected.
+ * <p>Every supported version is a closed schema: unknown members and trailing JSON values are rejected.
  */
 public final class IntegrityManifestCompletion {
 
@@ -42,6 +42,9 @@ public final class IntegrityManifestCompletion {
 	@JsonProperty("selected_record_count")
 	private final long selectedRecordCount;
 
+	@JsonProperty("excluded_delete_marker_count")
+	private final long excludedDeleteMarkerCount;
+
 	@JsonProperty("manifest_bytes")
 	private final long manifestBytes;
 
@@ -59,6 +62,7 @@ public final class IntegrityManifestCompletion {
 					@JsonProperty("source_record_count") final long sourceRecordCount,
 					@JsonProperty("unique_record_count") final long uniqueRecordCount,
 					@JsonProperty("selected_record_count") final long selectedRecordCount,
+					@JsonProperty("excluded_delete_marker_count") final long excludedDeleteMarkerCount,
 					@JsonProperty("manifest_bytes") final long manifestBytes,
 					@JsonProperty("manifest_sha256") final String manifestSha256) {
 		this.version = version;
@@ -70,6 +74,7 @@ public final class IntegrityManifestCompletion {
 		this.sourceRecordCount = sourceRecordCount;
 		this.uniqueRecordCount = uniqueRecordCount;
 		this.selectedRecordCount = selectedRecordCount;
+		this.excludedDeleteMarkerCount = excludedDeleteMarkerCount;
 		this.manifestBytes = manifestBytes;
 		this.manifestSha256 = manifestSha256;
 	}
@@ -110,6 +115,10 @@ public final class IntegrityManifestCompletion {
 		return selectedRecordCount;
 	}
 
+	public long excludedDeleteMarkerCount() {
+		return excludedDeleteMarkerCount;
+	}
+
 	public long manifestBytes() {
 		return manifestBytes;
 	}
@@ -118,7 +127,8 @@ public final class IntegrityManifestCompletion {
 		return manifestSha256;
 	}
 
-	public static final int VERSION = 1;
+	public static final int LEGACY_VERSION = 1;
+	public static final int VERSION = 2;
 	public static final String STATUS_COMPLETE = "complete";
 	public static final String PRODUCER_ENGINE_STEP = "engine_step";
 	public static final String PRODUCER_CLI_STAGER = "cli_stager";
@@ -129,6 +139,10 @@ public final class IntegrityManifestCompletion {
 
 	public static Path emissionCountPath(final Path manifest) {
 		return manifest.resolveSibling(manifest.getFileName() + ".emitted.count");
+	}
+
+	public static Path deleteMarkerCountPath(final Path manifest) {
+		return manifest.resolveSibling(manifest.getFileName() + ".delete-markers.count");
 	}
 
 	public static Path completionPath(final Path manifest) {
@@ -147,8 +161,26 @@ public final class IntegrityManifestCompletion {
 					final long uniqueCount,
 					final long selectedCount)
 					throws IOException {
+		return create(
+						manifest, runId, producerKind, producerId,
+						sourceCount, uniqueCount, selectedCount, 0);
+	}
+
+	public static IntegrityManifestCompletion create(
+					final Path manifest,
+					final long runId,
+					final String producerKind,
+					final String producerId,
+					final long sourceCount,
+					final long uniqueCount,
+					final long selectedCount,
+					final long excludedDeleteMarkerCount)
+					throws IOException {
 		requirePositiveRunId(runId);
 		validateCounts(sourceCount, uniqueCount, selectedCount);
+		if (excludedDeleteMarkerCount < 0) {
+			throw new IOException("excluded delete marker count must be nonnegative");
+		}
 		final IntegrityManifestValidator.Evidence evidence = IntegrityManifestValidator.validate(manifest);
 		if (evidence.rows() != selectedCount) {
 			throw new IOException(
@@ -165,6 +197,7 @@ public final class IntegrityManifestCompletion {
 						sourceCount,
 						uniqueCount,
 						selectedCount,
+						excludedDeleteMarkerCount,
 						evidence.bytes(),
 						evidence.sha256());
 	}
@@ -227,13 +260,15 @@ public final class IntegrityManifestCompletion {
 		case CLI_STAGER -> PRODUCER_CLI_STAGER;
 		default -> throw new IOException("completion records are not valid for provenance " + provenance);
 		};
-		if (record.version != VERSION
+		if ((record.version != VERSION && record.version != LEGACY_VERSION)
 						|| !STATUS_COMPLETE.equals(record.status)
 						|| record.runId != expectedRunId
 						|| !expectedKind.equals(record.producerKind)
 						|| !requireText(expectedProducerId, "expected producer id").equals(record.producerId)
 						|| !manifest.getFileName().toString().equals(record.artifact)
-						|| record.manifestBytes < 0) {
+						|| record.manifestBytes < 0
+						|| record.excludedDeleteMarkerCount < 0
+						|| (record.version == LEGACY_VERSION && record.excludedDeleteMarkerCount != 0)) {
 			throw new IOException("integrity input completion record does not match manifest identity");
 		}
 		final IntegrityManifestValidator.Evidence evidence = IntegrityManifestValidator.validate(manifest);

--- a/engine/core/spt-base/src/main/java/com/dell/spt/base/integrity/IntegrityManifestCompletion.java
+++ b/engine/core/spt-base/src/main/java/com/dell/spt/base/integrity/IntegrityManifestCompletion.java
@@ -152,6 +152,10 @@ public final class IntegrityManifestCompletion {
 		return manifest.resolveSibling(base + ".complete.json");
 	}
 
+	/**
+	 * Creates completion evidence for non-LIST artifacts, which cannot contain delete markers.
+	 * Discovery callers must use the count-aware overload and report excluded delete markers.
+	 */
 	public static IntegrityManifestCompletion create(
 					final Path manifest,
 					final long runId,

--- a/engine/core/spt-base/src/main/java/com/dell/spt/base/item/io/IntegrityOperationManifestOutput.java
+++ b/engine/core/spt-base/src/main/java/com/dell/spt/base/item/io/IntegrityOperationManifestOutput.java
@@ -30,6 +30,7 @@ public final class IntegrityOperationManifestOutput<O extends Operation<? extend
 	private final OpType opType;
 	private final CSVPrinter printer;
 	private long emittedRecordCount;
+	private long excludedDeleteMarkerCount;
 	private boolean closed;
 
 	public IntegrityOperationManifestOutput(
@@ -61,9 +62,11 @@ public final class IntegrityOperationManifestOutput<O extends Operation<? extend
 		try {
 			if (result instanceof ListOperation<?> listOperation) {
 				for (final var listedObject : listOperation.listedObjects()) {
-					printer.printRecord(configuredBucket, listedObject.key(), listedObject.size(), "");
+					printer.printRecord(configuredBucket, listedObject.key(), listedObject.size(),
+									listedObject.versionId() == null ? "" : listedObject.versionId());
 					emittedRecordCount++;
 				}
+				excludedDeleteMarkerCount = Math.addExact(excludedDeleteMarkerCount, listOperation.deleteMarkersListed());
 				return true;
 			}
 			final Item item = result.item();
@@ -119,17 +122,19 @@ public final class IntegrityOperationManifestOutput<O extends Operation<? extend
 			printer.close(true);
 			CrashDurableFilePublisher.syncExisting(manifestPath);
 			if (OpType.LIST.equals(opType)) {
-				publishEmissionCount();
+				publishCount(IntegrityManifestCompletion.emissionCountPath(manifestPath),
+								emittedRecordCount, "emission");
+				publishCount(IntegrityManifestCompletion.deleteMarkerCountPath(manifestPath),
+								excludedDeleteMarkerCount, "delete-marker");
 			}
 		} catch (final IOException e) {
 			throwUnchecked(e);
 		}
 	}
 
-	private void publishEmissionCount() throws IOException {
-		final Path countPath = IntegrityManifestCompletion.emissionCountPath(manifestPath);
+	private void publishCount(final Path countPath, final long count, final String description) throws IOException {
 		if (Files.exists(countPath)) {
-			throw new IOException("refusing to replace existing emission count " + countPath);
+			throw new IOException("refusing to replace existing " + description + " count " + countPath);
 		}
 		final Path parent = countPath.toAbsolutePath().getParent();
 		final Path staging = Files.createTempFile(parent, "." + countPath.getFileName(), ".staging");
@@ -137,7 +142,7 @@ public final class IntegrityOperationManifestOutput<O extends Operation<? extend
 		try {
 			Files.writeString(
 							staging,
-							Long.toString(emittedRecordCount) + "\n",
+							Long.toString(count) + "\n",
 							StandardCharsets.US_ASCII,
 							StandardOpenOption.TRUNCATE_EXISTING);
 			IntegrityManifestCompletion.atomicMove(staging, countPath);

--- a/engine/core/spt-base/src/main/java/com/dell/spt/base/item/op/list/ListOperation.java
+++ b/engine/core/spt-base/src/main/java/com/dell/spt/base/item/op/list/ListOperation.java
@@ -24,6 +24,14 @@ public interface ListOperation<I extends PathItem> extends PathOperation<I> {
 	/** Replaces the concrete object records returned by this page. */
 	default void listedObjects(final List<ListedObject> objects) {}
 
+	/** Returns the number of delete markers excluded from this page's data-version results. */
+	default int deleteMarkersListed() {
+		return 0;
+	}
+
+	/** Records the number of delete markers excluded from this page's data-version results. */
+	default void deleteMarkersListed(final int n) {}
+
 	/** Returns aggregated bytes across listed objects (0 when metadata absent). */
 	long bytesListed();
 

--- a/engine/core/spt-base/src/main/java/com/dell/spt/base/item/op/list/ListOperationImpl.java
+++ b/engine/core/spt-base/src/main/java/com/dell/spt/base/item/op/list/ListOperationImpl.java
@@ -14,6 +14,7 @@ public class ListOperationImpl<I extends PathItem> extends PathOperationImpl<I>
 
 	private int objectsListed;
 	private List<ListedObject> listedObjects = List.of();
+	private int deleteMarkersListed;
 	private long bytesListed;
 	private String continuationToken;
 	private boolean truncated;
@@ -35,6 +36,7 @@ public class ListOperationImpl<I extends PathItem> extends PathOperationImpl<I>
 		super(other);
 		this.objectsListed = other.objectsListed;
 		this.listedObjects = other.listedObjects;
+		this.deleteMarkersListed = other.deleteMarkersListed;
 		this.bytesListed = other.bytesListed;
 		this.continuationToken = other.continuationToken;
 		this.truncated = other.truncated;
@@ -56,6 +58,16 @@ public class ListOperationImpl<I extends PathItem> extends PathOperationImpl<I>
 	@Override
 	public void objectsListed(final int n) {
 		this.objectsListed = n;
+	}
+
+	@Override
+	public int deleteMarkersListed() {
+		return deleteMarkersListed;
+	}
+
+	@Override
+	public void deleteMarkersListed(final int n) {
+		deleteMarkersListed = n;
 	}
 
 	@Override
@@ -129,6 +141,7 @@ public class ListOperationImpl<I extends PathItem> extends PathOperationImpl<I>
 		super.reset();
 		objectsListed = 0;
 		listedObjects = List.of();
+		deleteMarkersListed = 0;
 		bytesListed = 0;
 		truncated = false;
 		countBytesDone(0);

--- a/engine/core/spt-base/src/main/java/com/dell/spt/base/item/op/list/ListedObject.java
+++ b/engine/core/spt-base/src/main/java/com/dell/spt/base/item/op/list/ListedObject.java
@@ -1,7 +1,7 @@
 package com.dell.spt.base.item.op.list;
 
-/** One current object returned by a LIST page for integrity discovery. */
-public record ListedObject(String key, long size) {
+/** One exact object identity returned by a LIST page for integrity discovery. */
+public record ListedObject(String key, long size, String versionId) {
 
 	public ListedObject {
 		if (key == null || key.isEmpty()) {
@@ -10,5 +10,10 @@ public record ListedObject(String key, long size) {
 		if (size < 0) {
 			throw new IllegalArgumentException("listed object size must be nonnegative");
 		}
+		versionId = versionId == null || versionId.isEmpty() ? null : versionId;
+	}
+
+	public ListedObject(final String key, final long size) {
+		this(key, size, null);
 	}
 }

--- a/engine/core/spt-base/src/main/java/com/dell/spt/base/load/generator/LoadGeneratorBuilderImpl.java
+++ b/engine/core/spt-base/src/main/java/com/dell/spt/base/load/generator/LoadGeneratorBuilderImpl.java
@@ -484,6 +484,15 @@ public class LoadGeneratorBuilderImpl<I extends Item, O extends Operation<I>, T 
 		List<String> bestPrefixes = java.util.Collections.emptyList();
 		final boolean integrityDiscovery = opOutput instanceof StorageDriver<?, ?> storageDriver
 						&& storageDriver.metadataIntegrityEnabled();
+		final Config listConfig = opConfig.configVal("list");
+		final boolean allVersionIntegrityDiscovery = integrityDiscovery
+						&& listConfig != null
+						&& listConfig.boolVal("include_versions");
+		if (allVersionIntegrityDiscovery) {
+			Loggers.MSG.info(
+							"LIST all-version discovery uses one exact-prefix shard to preserve completeness");
+			return List.of(new ListShard(seedPrefix == null ? "" : seedPrefix, null, null, null));
+		}
 		if (opOutput instanceof ListDiscoveryProbe probe) {
 			for (int i = 0; i < delimiters.length(); i++) {
 				final String d = String.valueOf(delimiters.charAt(i));

--- a/engine/core/spt-base/src/main/java/com/dell/spt/base/load/step/client/CsvArtifactAggregator.java
+++ b/engine/core/spt-base/src/main/java/com/dell/spt/base/load/step/client/CsvArtifactAggregator.java
@@ -112,13 +112,21 @@ public final class CsvArtifactAggregator implements AutoCloseable {
 
 	@Override
 	public void close() {
+		close(OpType.LIST.equals(artifactOpType) ? -1 : 0);
+	}
+
+	void close(final long failedOperationCount) {
 		try {
-			collectAndPublish();
+			collectAndPublish(failedOperationCount);
 		} catch (final IntegrityTerminalException e) {
 			throw e;
 		} catch (final Exception e) {
 			throw terminal(Category.AGGREGATION, "failed to aggregate " + manifestPath.getFileName(), e);
 		}
+	}
+
+	OpType artifactOpType() {
+		return artifactOpType;
 	}
 
 	private static OpType legacyArtifactOpType(final String itemOutputFile) {
@@ -129,7 +137,22 @@ public final class CsvArtifactAggregator implements AutoCloseable {
 		return "written.csv".equals(name) ? OpType.CREATE : OpType.READ;
 	}
 
-	private void collectAndPublish() throws IOException {
+	private void collectAndPublish(final long failedOperationCount) throws IOException {
+		final boolean discovery = OpType.LIST.equals(artifactOpType);
+		if (discovery && failedOperationCount < 0) {
+			throw terminal(
+							Category.EXECUTION,
+							"terminal LIST failure count is unavailable; refusing to publish discovery evidence",
+							null);
+		}
+		if (discovery && failedOperationCount > 0) {
+			throw terminal(
+							Category.EXECUTION,
+							"LIST discovery recorded " + failedOperationCount
+											+ (failedOperationCount == 1 ? " failed operation" : " failed operations")
+											+ "; refusing to publish a partial manifest",
+							null);
+		}
 		final Path parent = manifestPath.toAbsolutePath().getParent();
 		Files.createDirectories(parent);
 		final Path marker = IntegrityManifestCompletion.completionPath(manifestPath);
@@ -137,7 +160,6 @@ public final class CsvArtifactAggregator implements AutoCloseable {
 			throw terminal(Category.PUBLICATION, "stale completion record exists: " + marker, null);
 		}
 
-		final boolean discovery = OpType.LIST.equals(artifactOpType);
 		final List<Path> nodeSources = new ArrayList<>(sourceNames.size());
 		final List<Path> emissionCounts = new ArrayList<>(sourceNames.size());
 		final List<Path> deleteMarkerCounts = new ArrayList<>(sourceNames.size());

--- a/engine/core/spt-base/src/main/java/com/dell/spt/base/load/step/client/CsvArtifactAggregator.java
+++ b/engine/core/spt-base/src/main/java/com/dell/spt/base/load/step/client/CsvArtifactAggregator.java
@@ -140,6 +140,7 @@ public final class CsvArtifactAggregator implements AutoCloseable {
 		final boolean discovery = OpType.LIST.equals(artifactOpType);
 		final List<Path> nodeSources = new ArrayList<>(sourceNames.size());
 		final List<Path> emissionCounts = new ArrayList<>(sourceNames.size());
+		final List<Path> deleteMarkerCounts = new ArrayList<>(sourceNames.size());
 		for (int i = 0; i < sourceNames.size(); i++) {
 			final Path nodePath = nodeSourcePath(manifestPath, i);
 			if (Files.exists(nodePath)) {
@@ -171,6 +172,24 @@ public final class CsvArtifactAggregator implements AutoCloseable {
 					copyRemoteSource(fileManagers.get(i), remoteCount, nodeCount);
 				}
 				emissionCounts.add(nodeCount);
+				final Path nodeDeleteMarkerCount = IntegrityManifestCompletion.deleteMarkerCountPath(nodePath);
+				if (Files.exists(nodeDeleteMarkerCount)) {
+					throw terminal(Category.PUBLICATION,
+									"stale node delete-marker count exists: " + nodeDeleteMarkerCount, null);
+				}
+				if (i == 0) {
+					final Path sourceDeleteMarkerCount = IntegrityManifestCompletion.deleteMarkerCountPath(manifestPath);
+					if (!Files.isRegularFile(sourceDeleteMarkerCount)) {
+						throw terminal(Category.AGGREGATION,
+										"entry-node LIST delete-marker count is missing", null);
+					}
+					IntegrityManifestCompletion.atomicMove(sourceDeleteMarkerCount, nodeDeleteMarkerCount);
+				} else {
+					final String remoteDeleteMarkerCount = IntegrityManifestCompletion.deleteMarkerCountPath(
+									Path.of(sourceNames.get(i))).toString();
+					copyRemoteSource(fileManagers.get(i), remoteDeleteMarkerCount, nodeDeleteMarkerCount);
+				}
+				deleteMarkerCounts.add(nodeDeleteMarkerCount);
 			}
 
 		}
@@ -188,10 +207,15 @@ public final class CsvArtifactAggregator implements AutoCloseable {
 			throw e;
 		}
 		long emittedCount = counts.source();
+		long excludedDeleteMarkerCount = 0;
 		if (discovery) {
 			emittedCount = 0;
 			for (final Path countPath : emissionCounts) {
 				emittedCount = Math.addExact(emittedCount, readEmissionCount(countPath));
+			}
+			for (final Path countPath : deleteMarkerCounts) {
+				excludedDeleteMarkerCount = Math.addExact(
+								excludedDeleteMarkerCount, readEmissionCount(countPath));
 			}
 			if (emittedCount != counts.source()) {
 				final IntegrityTerminalException failure = terminal(
@@ -210,7 +234,8 @@ public final class CsvArtifactAggregator implements AutoCloseable {
 						loadStepId,
 						counts.source(),
 						counts.unique(),
-						counts.selected());
+						counts.selected(),
+						excludedDeleteMarkerCount);
 		try {
 			completion.publish(manifestPath);
 		} catch (final IOException e) {

--- a/engine/core/spt-base/src/main/java/com/dell/spt/base/load/step/client/LoadStepClientBase.java
+++ b/engine/core/spt-base/src/main/java/com/dell/spt/base/load/step/client/LoadStepClientBase.java
@@ -31,6 +31,7 @@ import com.dell.spt.base.logging.Loggers;
 import com.dell.spt.base.metrics.MetricsManager;
 import com.dell.spt.base.metrics.context.DistributedMetricsContext;
 import com.dell.spt.base.metrics.context.DistributedMetricsContextImpl;
+import com.dell.spt.base.metrics.context.MetricsContext;
 import com.dell.spt.base.metrics.snapshot.AllMetricsSnapshot;
 import com.dell.spt.base.storage.driver.StorageDriver;
 import com.dell.spt.base.util.BinarySizeFormat;
@@ -625,6 +626,25 @@ public abstract class LoadStepClientBase<T extends LoadStepClient<T>>
 		return metricsAggregator == null ? Collections.emptyList() : metricsAggregator.metricsSnapshotsByIndex(originIndex);
 	}
 
+	static Map<OpType, Long> terminalFailureCounts(
+					final List<? extends MetricsContext<? extends AllMetricsSnapshot>> contexts) {
+		final Map<OpType, Long> counts = new HashMap<>();
+		for (final var context : contexts) {
+			final AllMetricsSnapshot snapshot = context.lastSnapshot();
+			if (snapshot == null || snapshot.failsSnapshot() == null) {
+				throw new IllegalStateException(
+								"terminal failure metrics are unavailable for " + context.opType());
+			}
+			final long failureCount = snapshot.failsSnapshot().count();
+			if (failureCount < 0) {
+				throw new IllegalStateException(
+								"terminal failure metrics are negative for " + context.opType());
+			}
+			counts.merge(context.opType(), failureCount, Math::addExact);
+		}
+		return counts;
+	}
+
 	@Override
 	protected final void doShutdown() {
 		stepSlices.stream().filter(s -> s != null).parallel().forEach(stepSlice -> {
@@ -718,6 +738,19 @@ public abstract class LoadStepClientBase<T extends LoadStepClient<T>>
 					throws IOException {
 		try (final var logCtx = put(KEY_STEP_ID, loadStepId()).put(KEY_CLASS_NAME, getClass().getSimpleName())) {
 			IntegrityTerminalException terminalCause = null;
+			Map<OpType, Long> terminalFailureCountsByOpType = Map.of();
+			if (integrityModeEnabled()) {
+				try {
+					terminalFailureCountsByOpType = terminalFailureCounts(metricsContexts);
+				} catch (final Throwable cause) {
+					throwUncheckedIfInterrupted(cause);
+					terminalCause = appendTerminalFailure(
+									terminalCause,
+									IntegrityTerminalException.Category.EXECUTION,
+									"failed to capture terminal metadata-mode operation failure counts",
+									cause);
+				}
+			}
 			try {
 				super.doClose();
 			} catch (final Throwable cause) {
@@ -818,7 +851,12 @@ public abstract class LoadStepClientBase<T extends LoadStepClient<T>>
 			itemInputFileSlicers.clear();
 			for (final var itemOutputFileAggregator : itemOutputFileAggregators) {
 				try {
-					itemOutputFileAggregator.close();
+					if (itemOutputFileAggregator instanceof CsvArtifactAggregator csvAggregator) {
+						csvAggregator.close(terminalFailureCountsByOpType.getOrDefault(
+										csvAggregator.artifactOpType(), -1L));
+					} else {
+						itemOutputFileAggregator.close();
+					}
 				} catch (final Exception e) {
 					throwUncheckedIfInterrupted(e);
 					if (integrityModeEnabled()) {

--- a/engine/core/spt-base/src/main/java/com/dell/spt/base/load/step/local/context/LoadStepContextImpl.java
+++ b/engine/core/spt-base/src/main/java/com/dell/spt/base/load/step/local/context/LoadStepContextImpl.java
@@ -440,7 +440,8 @@ public class LoadStepContextImpl<I extends Item, O extends Operation<I>> extends
 						resultCount > 0
 						&& resultCount >= generator.generatedOpCount()
 						&&
-						// no successful op results
+						// Metadata LIST publishes pages immediately and never populates this map,
+						// so this condition is meaningful only for other recycled workloads.
 						latestSuccOpResultByItem.size() == 0;
 	}
 
@@ -551,6 +552,9 @@ public class LoadStepContextImpl<I extends Item, O extends Operation<I>> extends
 					// recycled ops should only appear in output.csv only once unless
 					// outputDuplicates flag is specified
 					outputResults(opResult);
+					if (recycleFlag && opResult instanceof ListOperation) {
+						latestSuccOpResultByItem.remove(opResult.item());
+					}
 				} else {
 					// for recycled ops we might want to print them once or every time
 					// Metadata discovery must publish every page before the mutable LIST op is recycled.
@@ -664,6 +668,9 @@ public class LoadStepContextImpl<I extends Item, O extends Operation<I>> extends
 						// recycled ops should only appear in output.csv only once unless
 						// outputDuplicates flag is specified
 						outputResults(opResult);
+						if (recycleFlag && opResult instanceof ListOperation) {
+							latestSuccOpResultByItem.remove(opResult.item());
+						}
 					} else {
 						// for recycled ops we might want to print them once or every time
 						// Metadata discovery must publish every page before the mutable LIST op is recycled.
@@ -1365,6 +1372,10 @@ public class LoadStepContextImpl<I extends Item, O extends Operation<I>> extends
 
 	// Returns true if a split has been performed and parent should not be recycled
 	private boolean tryDelimiterSplit(final ListShard shard, final ListOperation<?> listOp) {
+		final ListOptions options = listOp.options();
+		if (options != null && options.includeVersions()) {
+			return false;
+		}
 		// Only consider ENUMERATE shards for splitting
 		final ListShard.Kind kind = shard.kind();
 		if (kind != null && kind != ListShard.Kind.ENUMERATE) {

--- a/engine/core/spt-base/src/main/java/com/dell/spt/base/load/step/local/context/LoadStepContextImpl.java
+++ b/engine/core/spt-base/src/main/java/com/dell/spt/base/load/step/local/context/LoadStepContextImpl.java
@@ -553,7 +553,8 @@ public class LoadStepContextImpl<I extends Item, O extends Operation<I>> extends
 					outputResults(opResult);
 				} else {
 					// for recycled ops we might want to print them once or every time
-					if (outputDuplicates) {
+					// Metadata discovery must publish every page before the mutable LIST op is recycled.
+					if (outputDuplicates || (opResult instanceof ListOperation && driver.metadataIntegrityEnabled())) {
 						outputResults(opResult);
 					} else {
 						// this way we only add duplicate items once to the output list
@@ -665,7 +666,8 @@ public class LoadStepContextImpl<I extends Item, O extends Operation<I>> extends
 						outputResults(opResult);
 					} else {
 						// for recycled ops we might want to print them once or every time
-						if (outputDuplicates) {
+						// Metadata discovery must publish every page before the mutable LIST op is recycled.
+						if (outputDuplicates || (opResult instanceof ListOperation && driver.metadataIntegrityEnabled())) {
 							outputResults(opResult);
 						} else {
 							// this way we only add duplicate items once to the output list

--- a/engine/core/spt-base/src/main/resources/log4j2.yaml
+++ b/engine/core/spt-base/src/main/resources/log4j2.yaml
@@ -271,11 +271,6 @@ Configuration:
         AppenderRef:
           ref: tablesMetricsFile
         additivity: false
-      - name: com.dell.spt.storage.driver.coop.aws.s3.S3AwsStorageDriver
-        level: INFO
-        AppenderRef:
-          ref: msgFile
-        additivity: false
       - name: com.github.akurilov
         level: WARN
         AppenderRef:

--- a/engine/core/spt-base/src/main/resources/log4j2.yaml
+++ b/engine/core/spt-base/src/main/resources/log4j2.yaml
@@ -271,6 +271,11 @@ Configuration:
         AppenderRef:
           ref: tablesMetricsFile
         additivity: false
+      - name: com.dell.spt.storage.driver.coop.aws.s3.S3AwsStorageDriver
+        level: INFO
+        AppenderRef:
+          ref: msgFile
+        additivity: false
       - name: com.github.akurilov
         level: WARN
         AppenderRef:

--- a/engine/core/spt-base/src/test/java/com/dell/spt/base/item/io/IntegrityOperationManifestOutputTest.java
+++ b/engine/core/spt-base/src/test/java/com/dell/spt/base/item/io/IntegrityOperationManifestOutputTest.java
@@ -60,18 +60,23 @@ class IntegrityOperationManifestOutputTest {
 		final Path manifest = tempDir.resolve("verify-input.csv");
 		final var op = new ListOperationImpl<PathItemImpl>(
 						0, OpType.LIST, new PathItemImpl("prefix"), Credential.NONE);
-		op.listedObjects(List.of(new ListedObject("prefix/a", 7), new ListedObject("prefix/b", 8)));
+		op.listedObjects(List.of(new ListedObject("prefix/a", 7, "null"), new ListedObject("prefix/b", 8, "v2")));
+		op.deleteMarkersListed(3);
 		try (final var output = new IntegrityOperationManifestOutput<>(manifest, "/bucket", OpType.LIST)) {
 			output.put(op);
 		}
 		assertEquals("2", java.nio.file.Files.readString(
 						IntegrityManifestCompletion.emissionCountPath(manifest)).trim());
+		assertEquals("3", java.nio.file.Files.readString(
+						IntegrityManifestCompletion.deleteMarkerCountPath(manifest)).trim());
 
 		final var records = CSVFormat.RFC4180.parse(java.nio.file.Files.newBufferedReader(manifest)).getRecords();
 		assertEquals(3, records.size());
 		assertEquals("prefix/a", records.get(1).get(1));
 		assertEquals("7", records.get(1).get(2));
+		assertEquals("null", records.get(1).get(3));
 		assertEquals("prefix/b", records.get(2).get(1));
+		assertEquals("v2", records.get(2).get(3));
 	}
 
 	@Test

--- a/engine/core/spt-base/src/test/java/com/dell/spt/base/load/generator/LoadGeneratorBuilderImplTest.java
+++ b/engine/core/spt-base/src/test/java/com/dell/spt/base/load/generator/LoadGeneratorBuilderImplTest.java
@@ -276,6 +276,21 @@ public class LoadGeneratorBuilderImplTest {
 	}
 
 	@Test
+	void allVersionIntegrityDiscoveryAlwaysUsesOneExactPrefixShard() throws Exception {
+		final var result = new ListDiscoveryProbe.DiscoverResult(
+						List.of("campaign/a/", "campaign/b/", "campaign/c/", "campaign/d/"),
+						false,
+						false);
+
+		final var seeds = integrityListSeeds(result, null, true);
+
+		assertEquals(
+						List.of("campaign/!unicode/"),
+						seeds.stream().map(ListShard::prefix).toList(),
+						"current-object delimiter partitions cannot prove all-version completeness");
+	}
+
+	@Test
 	void integrityDiscoveryDoesNotSwallowUnexpectedProbeFailures() {
 		assertThrows(
 						IllegalStateException.class,
@@ -287,9 +302,17 @@ public class LoadGeneratorBuilderImplTest {
 	private static List<ListShard> integrityListSeeds(
 					final ListDiscoveryProbe.DiscoverResult result, final Throwable failure)
 					throws Exception {
+		return integrityListSeeds(result, failure, false);
+	}
+
+	private static List<ListShard> integrityListSeeds(
+					final ListDiscoveryProbe.DiscoverResult result,
+					final Throwable failure,
+					final boolean includeVersions) throws Exception {
 		final Config opConfig = Mockito.mock(Config.class);
 		final Config listConfig = Mockito.mock(Config.class);
 		Mockito.when(opConfig.configVal("list")).thenReturn(listConfig);
+		Mockito.when(listConfig.boolVal("include_versions")).thenReturn(includeVersions);
 		final StorageDriver driver = Mockito.mock(
 						StorageDriver.class,
 						Mockito.withSettings().extraInterfaces(ListDiscoveryProbe.class));

--- a/engine/core/spt-base/src/test/java/com/dell/spt/base/load/step/client/CsvArtifactAggregatorTest.java
+++ b/engine/core/spt-base/src/test/java/com/dell/spt/base/load/step/client/CsvArtifactAggregatorTest.java
@@ -6,16 +6,25 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.dell.spt.base.integrity.IntegrityInputProvenance;
 import com.dell.spt.base.integrity.IntegrityManifestCompletion;
 import com.dell.spt.base.integrity.IntegrityTerminalException;
 import com.dell.spt.base.load.step.file.FileManager;
+import com.dell.spt.base.load.step.service.file.FileManagerService;
+import com.github.akurilov.confuse.Config;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import org.apache.commons.csv.CSVFormat;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -109,6 +118,71 @@ class CsvArtifactAggregatorTest {
 		assertEquals(4, completion.excludedDeleteMarkerCount());
 		assertEquals(1, completion.selectedRecordCount());
 		assertFalse(Files.exists(tempDir.resolve("verify-input.node-001.csv")));
+	}
+
+	@Test
+	void distributedDiscoverySumsDeleteMarkersAcrossNodes() throws Exception {
+		final Path manifest = tempDir.resolve("verify-input.csv");
+		Files.writeString(manifest, "bucket,key,size,version_id\r\nb,a,1,v1\r\n");
+		Files.writeString(IntegrityManifestCompletion.emissionCountPath(manifest), "1\n");
+		Files.writeString(IntegrityManifestCompletion.deleteMarkerCountPath(manifest), "2\n");
+		final String remoteManifest = "/remote/verify-input.csv";
+		final FileManagerService remote = remoteFileManager(remoteManifest, Map.of(
+						remoteManifest, "bucket,key,size,version_id\r\nb,b,2,v2\r\n",
+						remoteManifest + ".emitted.count", "1\n",
+						remoteManifest + ".delete-markers.count", "3\n"));
+
+		new CsvArtifactAggregator(
+						"list-step", List.of(FileManager.INSTANCE, remote),
+						List.of(mock(Config.class), mock(Config.class)),
+						manifest.toString(), 105, 0, com.dell.spt.base.item.op.OpType.LIST).close();
+
+		final var completion = IntegrityManifestCompletion.validate(
+						manifest, 105, IntegrityInputProvenance.ENGINE_STEP, "list-step");
+		assertEquals(2, completion.sourceRecordCount());
+		assertEquals(5, completion.excludedDeleteMarkerCount());
+		assertTrue(Files.isRegularFile(CsvArtifactAggregator.nodeSourcePath(manifest, 1)));
+		assertEquals("3", Files.readString(IntegrityManifestCompletion.deleteMarkerCountPath(
+						CsvArtifactAggregator.nodeSourcePath(manifest, 1))).trim());
+	}
+
+	@Test
+	void distributedDiscoveryRejectsStaleNodeDeleteMarkerCount() throws Exception {
+		final Path manifest = tempDir.resolve("verify-input.csv");
+		Files.writeString(manifest, "bucket,key,size,version_id\r\nb,a,1,v1\r\n");
+		Files.writeString(IntegrityManifestCompletion.emissionCountPath(manifest), "1\n");
+		Files.writeString(IntegrityManifestCompletion.deleteMarkerCountPath(manifest), "0\n");
+		Files.writeString(IntegrityManifestCompletion.deleteMarkerCountPath(
+						CsvArtifactAggregator.nodeSourcePath(manifest, 0)), "stale\n");
+		final FileManagerService remote = remoteFileManager("/remote/verify-input.csv", Map.of());
+
+		final var failure = assertThrows(
+						IntegrityTerminalException.class,
+						() -> new CsvArtifactAggregator(
+										"list-step", List.of(FileManager.INSTANCE, remote),
+										List.of(mock(Config.class), mock(Config.class)),
+										manifest.toString(), 106, 0, com.dell.spt.base.item.op.OpType.LIST).close());
+
+		assertEquals(IntegrityTerminalException.Category.PUBLICATION, failure.category());
+		assertTrue(failure.getMessage().contains("stale node delete-marker count"));
+	}
+
+	@Test
+	void distributedDiscoveryRejectsMissingEntryNodeDeleteMarkerCount() throws Exception {
+		final Path manifest = tempDir.resolve("verify-input.csv");
+		Files.writeString(manifest, "bucket,key,size,version_id\r\nb,a,1,v1\r\n");
+		Files.writeString(IntegrityManifestCompletion.emissionCountPath(manifest), "1\n");
+		final FileManagerService remote = remoteFileManager("/remote/verify-input.csv", Map.of());
+
+		final var failure = assertThrows(
+						IntegrityTerminalException.class,
+						() -> new CsvArtifactAggregator(
+										"list-step", List.of(FileManager.INSTANCE, remote),
+										List.of(mock(Config.class), mock(Config.class)),
+										manifest.toString(), 107, 0, com.dell.spt.base.item.op.OpType.LIST).close());
+
+		assertEquals(IntegrityTerminalException.Category.AGGREGATION, failure.category());
+		assertTrue(failure.getMessage().contains("entry-node LIST delete-marker count is missing"));
 	}
 
 	@Test
@@ -211,6 +285,26 @@ class CsvArtifactAggregatorTest {
 		assertTrue(thrown.getMessage().contains("noncanonical header"));
 		assertEquals(1, thrown.getSuppressed().length);
 		assertSame(cleanup, thrown.getSuppressed()[0]);
+	}
+
+	private FileManagerService remoteFileManager(
+					final String manifestName, final Map<String, String> contents) throws IOException {
+		final FileManagerService remote = mock(FileManagerService.class);
+		when(remote.newTmpFileName()).thenReturn(manifestName);
+		when(remote.readFromFile(anyString(), anyLong())).thenAnswer(invocation -> {
+			final String fileName = invocation.getArgument(0);
+			final long offset = invocation.getArgument(1);
+			final String content = contents.get(fileName);
+			if (content == null) {
+				throw new IOException("missing remote fixture " + fileName);
+			}
+			final byte[] bytes = content.getBytes(StandardCharsets.UTF_8);
+			if (offset >= bytes.length) {
+				return FileManager.EMPTY;
+			}
+			return Arrays.copyOfRange(bytes, Math.toIntExact(offset), bytes.length);
+		});
+		return remote;
 	}
 
 	@Test

--- a/engine/core/spt-base/src/test/java/com/dell/spt/base/load/step/client/CsvArtifactAggregatorTest.java
+++ b/engine/core/spt-base/src/test/java/com/dell/spt/base/load/step/client/CsvArtifactAggregatorTest.java
@@ -106,7 +106,7 @@ class CsvArtifactAggregatorTest {
 						manifest.toString(),
 						100,
 						1)
-						.close();
+						.close(0);
 
 		final var records = CSVFormat.RFC4180.parse(Files.newBufferedReader(manifest)).getRecords();
 		assertEquals(2, records.size());
@@ -135,7 +135,7 @@ class CsvArtifactAggregatorTest {
 		new CsvArtifactAggregator(
 						"list-step", List.of(FileManager.INSTANCE, remote),
 						List.of(mock(Config.class), mock(Config.class)),
-						manifest.toString(), 105, 0, com.dell.spt.base.item.op.OpType.LIST).close();
+						manifest.toString(), 105, 0, com.dell.spt.base.item.op.OpType.LIST).close(0);
 
 		final var completion = IntegrityManifestCompletion.validate(
 						manifest, 105, IntegrityInputProvenance.ENGINE_STEP, "list-step");
@@ -161,7 +161,7 @@ class CsvArtifactAggregatorTest {
 						() -> new CsvArtifactAggregator(
 										"list-step", List.of(FileManager.INSTANCE, remote),
 										List.of(mock(Config.class), mock(Config.class)),
-										manifest.toString(), 106, 0, com.dell.spt.base.item.op.OpType.LIST).close());
+										manifest.toString(), 106, 0, com.dell.spt.base.item.op.OpType.LIST).close(0));
 
 		assertEquals(IntegrityTerminalException.Category.PUBLICATION, failure.category());
 		assertTrue(failure.getMessage().contains("stale node delete-marker count"));
@@ -179,7 +179,7 @@ class CsvArtifactAggregatorTest {
 						() -> new CsvArtifactAggregator(
 										"list-step", List.of(FileManager.INSTANCE, remote),
 										List.of(mock(Config.class), mock(Config.class)),
-										manifest.toString(), 107, 0, com.dell.spt.base.item.op.OpType.LIST).close());
+										manifest.toString(), 107, 0, com.dell.spt.base.item.op.OpType.LIST).close(0));
 
 		assertEquals(IntegrityTerminalException.Category.AGGREGATION, failure.category());
 		assertTrue(failure.getMessage().contains("entry-node LIST delete-marker count is missing"));
@@ -196,9 +196,49 @@ class CsvArtifactAggregatorTest {
 						IntegrityTerminalException.class,
 						() -> new CsvArtifactAggregator(
 										"list-step", List.of(FileManager.INSTANCE), List.of(),
-										manifest.toString(), 102, 0, com.dell.spt.base.item.op.OpType.LIST).close());
+										manifest.toString(), 102, 0, com.dell.spt.base.item.op.OpType.LIST).close(0));
 
 		assertEquals(IntegrityTerminalException.Category.AGGREGATION, failure.category());
+		assertFalse(Files.exists(IntegrityManifestCompletion.completionPath(manifest)));
+	}
+
+	@Test
+	void discoveryRejectsUnavailableListFailureCountWithoutPublishingCompletion() throws Exception {
+		final Path manifest = tempDir.resolve("verify-input.csv");
+		Files.writeString(manifest, "bucket,key,size,version_id\r\n");
+		Files.writeString(IntegrityManifestCompletion.emissionCountPath(manifest), "0\n");
+		Files.writeString(IntegrityManifestCompletion.deleteMarkerCountPath(manifest), "0\n");
+
+		final var failure = assertThrows(
+						IntegrityTerminalException.class,
+						() -> new CsvArtifactAggregator(
+										"list-step", List.of(FileManager.INSTANCE), List.of(),
+										manifest.toString(), 109, 0, com.dell.spt.base.item.op.OpType.LIST).close());
+
+		assertEquals(IntegrityTerminalException.Category.EXECUTION, failure.category());
+		assertTrue(failure.getMessage().contains("failure count is unavailable"));
+		assertFalse(Files.exists(IntegrityManifestCompletion.completionPath(manifest)));
+	}
+
+	@Test
+	void discoveryRejectsFailedListOperationsWithoutPublishingPartialCompletion() throws Exception {
+		final Path manifest = tempDir.resolve("verify-input.csv");
+		Files.writeString(
+						manifest,
+						"bucket,key,size,version_id\r\n"
+										+ "b,first-page-object,1,v1\r\n");
+		Files.writeString(IntegrityManifestCompletion.emissionCountPath(manifest), "1\n");
+		Files.writeString(IntegrityManifestCompletion.deleteMarkerCountPath(manifest), "0\n");
+
+		final var aggregator = new CsvArtifactAggregator(
+						"list-step", List.of(FileManager.INSTANCE), List.of(),
+						manifest.toString(), 108, 0, com.dell.spt.base.item.op.OpType.LIST);
+		final var failure = assertThrows(IntegrityTerminalException.class, () -> aggregator.close(1));
+
+		assertEquals(IntegrityTerminalException.Category.EXECUTION, failure.category());
+		assertTrue(failure.getMessage().contains("1 failed operation"));
+		assertTrue(Files.isRegularFile(manifest));
+		assertFalse(Files.exists(CsvArtifactAggregator.nodeSourcePath(manifest, 0)));
 		assertFalse(Files.exists(IntegrityManifestCompletion.completionPath(manifest)));
 	}
 

--- a/engine/core/spt-base/src/test/java/com/dell/spt/base/load/step/client/CsvArtifactAggregatorTest.java
+++ b/engine/core/spt-base/src/test/java/com/dell/spt/base/load/step/client/CsvArtifactAggregatorTest.java
@@ -88,6 +88,7 @@ class CsvArtifactAggregatorTest {
 										+ "b,a,2,\r\n"
 										+ "b,a,2,\r\n");
 		Files.writeString(IntegrityManifestCompletion.emissionCountPath(manifest), "3\n");
+		Files.writeString(IntegrityManifestCompletion.deleteMarkerCountPath(manifest), "4\n");
 
 		new CsvArtifactAggregator(
 						"list-step",
@@ -105,6 +106,7 @@ class CsvArtifactAggregatorTest {
 						manifest, 100, IntegrityInputProvenance.ENGINE_STEP, "list-step");
 		assertEquals(3, completion.sourceRecordCount());
 		assertEquals(2, completion.uniqueRecordCount());
+		assertEquals(4, completion.excludedDeleteMarkerCount());
 		assertEquals(1, completion.selectedRecordCount());
 		assertFalse(Files.exists(tempDir.resolve("verify-input.node-001.csv")));
 	}
@@ -114,6 +116,7 @@ class CsvArtifactAggregatorTest {
 		final Path manifest = tempDir.resolve("verify-input.csv");
 		Files.writeString(manifest, "bucket,key,size,version_id\r\nb,a,1,\r\n");
 		Files.writeString(IntegrityManifestCompletion.emissionCountPath(manifest), "2\n");
+		Files.writeString(IntegrityManifestCompletion.deleteMarkerCountPath(manifest), "0\n");
 
 		final var failure = assertThrows(
 						IntegrityTerminalException.class,

--- a/engine/core/spt-base/src/test/java/com/dell/spt/base/load/step/client/LoadStepClientBaseTest.java
+++ b/engine/core/spt-base/src/test/java/com/dell/spt/base/load/step/client/LoadStepClientBaseTest.java
@@ -2,22 +2,31 @@ package com.dell.spt.base.load.step.client;
 
 import com.dell.spt.base.config.TestConfigBuilder;
 import com.dell.spt.base.env.Extension;
+import com.dell.spt.base.integrity.IntegrityManifestCompletion;
 import com.dell.spt.base.integrity.IntegrityTerminalException;
 import com.dell.spt.base.load.step.LoadStep;
 import com.dell.spt.base.load.step.linear.LinearLoadStepClient;
+import com.dell.spt.base.item.op.OpType;
 import com.dell.spt.base.metrics.MetricsManager;
+import com.dell.spt.base.metrics.context.MetricsContext;
+import com.dell.spt.base.metrics.snapshot.AllMetricsSnapshot;
+import com.dell.spt.base.metrics.snapshot.RateMetricSnapshot;
 import com.github.akurilov.confuse.Config;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
 import java.lang.reflect.Field;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.rmi.RemoteException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
@@ -38,6 +47,9 @@ class LoadStepClientBaseTest {
 	private List<Extension> extensions;
 	private List<Config> ctxConfigs;
 	private MetricsManager mockMetricsManager;
+
+	@TempDir
+	Path tempDir;
 
 	@BeforeEach
 	void setUp() {
@@ -67,6 +79,76 @@ class LoadStepClientBaseTest {
 						IntegrityTerminalException.class,
 						() -> LoadStepClientBase.requireMatchingRunId(mock(LoadStep.class), 0L));
 		assertEquals(IntegrityTerminalException.Category.CONFIGURATION, failure.category());
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	void terminalFailureCountsSumEveryContextByOperationType() {
+		final MetricsContext<AllMetricsSnapshot> listA = mock(MetricsContext.class);
+		final MetricsContext<AllMetricsSnapshot> listB = mock(MetricsContext.class);
+		final MetricsContext<AllMetricsSnapshot> read = mock(MetricsContext.class);
+		final AllMetricsSnapshot listASnapshot = mock(AllMetricsSnapshot.class);
+		final AllMetricsSnapshot listBSnapshot = mock(AllMetricsSnapshot.class);
+		final AllMetricsSnapshot readSnapshot = mock(AllMetricsSnapshot.class);
+		final RateMetricSnapshot listAFailures = mock(RateMetricSnapshot.class);
+		final RateMetricSnapshot listBFailures = mock(RateMetricSnapshot.class);
+		final RateMetricSnapshot readFailures = mock(RateMetricSnapshot.class);
+		when(listA.opType()).thenReturn(OpType.LIST);
+		when(listB.opType()).thenReturn(OpType.LIST);
+		when(read.opType()).thenReturn(OpType.READ);
+		when(listA.lastSnapshot()).thenReturn(listASnapshot);
+		when(listB.lastSnapshot()).thenReturn(listBSnapshot);
+		when(read.lastSnapshot()).thenReturn(readSnapshot);
+		when(listASnapshot.failsSnapshot()).thenReturn(listAFailures);
+		when(listBSnapshot.failsSnapshot()).thenReturn(listBFailures);
+		when(readSnapshot.failsSnapshot()).thenReturn(readFailures);
+		when(listAFailures.count()).thenReturn(1L);
+		when(listBFailures.count()).thenReturn(2L);
+		when(readFailures.count()).thenReturn(4L);
+
+		assertEquals(
+						Map.of(OpType.LIST, 3L, OpType.READ, 4L),
+						LoadStepClientBase.terminalFailureCounts(List.of(listA, listB, read)));
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	void metadataClientCloseRejectsPartialDiscoveryWhenTerminalListFailed() throws Exception {
+		final Config config = TestConfigBuilder.config();
+		config.val("load-step-id", "list-step");
+		config.val("run-id", 110L);
+		config.val("storage-driver-type", "s3");
+		config.val("storage-integrity-mode", "metadata");
+		config.val("storage-integrity-input-provenance", "external");
+		config.val("load-op-type", "list");
+		final TestLoadStepClient client = new TestLoadStepClient(
+						config, extensions, ctxConfigs, mockMetricsManager);
+		final MetricsContext<AllMetricsSnapshot> listMetrics = mock(MetricsContext.class);
+		final AllMetricsSnapshot snapshot = mock(AllMetricsSnapshot.class);
+		final RateMetricSnapshot failures = mock(RateMetricSnapshot.class);
+		when(listMetrics.opType()).thenReturn(OpType.LIST);
+		when(listMetrics.lastSnapshot()).thenReturn(snapshot);
+		when(snapshot.failsSnapshot()).thenReturn(failures);
+		when(failures.count()).thenReturn(1L);
+		client.addMetricsContextForTest(listMetrics);
+
+		final Path manifest = tempDir.resolve("verify-input.csv");
+		Files.writeString(
+						manifest,
+						"bucket,key,size,version_id\r\n"
+										+ "b,first-page-object,1,v1\r\n");
+		Files.writeString(IntegrityManifestCompletion.emissionCountPath(manifest), "1\n");
+		Files.writeString(IntegrityManifestCompletion.deleteMarkerCountPath(manifest), "0\n");
+		addItemOutputAggregator(client, new CsvArtifactAggregator(
+						"list-step", List.of(com.dell.spt.base.load.step.file.FileManager.INSTANCE), List.of(),
+						manifest.toString(), 110, 0, OpType.LIST));
+
+		final var failure = assertThrows(IntegrityTerminalException.class, client::doClose);
+
+		assertEquals(IntegrityTerminalException.Category.EXECUTION, failure.category());
+		assertTrue(failure.getMessage().contains("1 failed operation"));
+		assertFalse(Files.exists(CsvArtifactAggregator.nodeSourcePath(manifest, 0)));
+		assertFalse(Files.exists(IntegrityManifestCompletion.completionPath(manifest)));
 	}
 
 	@Nested
@@ -886,6 +968,18 @@ class LoadStepClientBaseTest {
 			assertDoesNotThrow(() -> linearClient.doShutdown());
 			assertDoesNotThrow(() -> linearClient.doClose());
 			assertDoesNotThrow(() -> linearClient.doStop());
+		}
+	}
+
+	@SuppressWarnings("unchecked")
+	private static void addItemOutputAggregator(
+					final LoadStepClientBase<?> client, final AutoCloseable aggregator) {
+		try {
+			final Field field = LoadStepClientBase.class.getDeclaredField("itemOutputFileAggregators");
+			field.setAccessible(true);
+			((List<AutoCloseable>) field.get(client)).add(aggregator);
+		} catch (final ReflectiveOperationException e) {
+			throw new LinkageError(e.getMessage(), e);
 		}
 	}
 

--- a/engine/core/spt-base/src/test/java/com/dell/spt/base/load/step/client/TestLoadStepClient.java
+++ b/engine/core/spt-base/src/test/java/com/dell/spt/base/load/step/client/TestLoadStepClient.java
@@ -2,6 +2,8 @@ package com.dell.spt.base.load.step.client;
 
 import com.dell.spt.base.env.Extension;
 import com.dell.spt.base.metrics.MetricsManager;
+import com.dell.spt.base.metrics.context.MetricsContext;
+import com.dell.spt.base.metrics.snapshot.AllMetricsSnapshot;
 import com.github.akurilov.confuse.Config;
 
 import java.rmi.RemoteException;
@@ -67,6 +69,10 @@ public class TestLoadStepClient extends LoadStepClientBase<TestLoadStepClient> {
 		initCalled = false;
 		copyInstanceCalled = false;
 		copyInstanceCallCount = 0;
+	}
+
+	void addMetricsContextForTest(final MetricsContext<? extends AllMetricsSnapshot> context) {
+		metricsContexts.add(context);
 	}
 
 	// Expose effective config and ctx config count for targeted assertions

--- a/engine/core/spt-base/src/test/java/com/dell/spt/base/load/step/local/context/LoadStepContextImplTest.java
+++ b/engine/core/spt-base/src/test/java/com/dell/spt/base/load/step/local/context/LoadStepContextImplTest.java
@@ -1119,6 +1119,57 @@ public class LoadStepContextImplTest {
 	}
 
 	@Test
+	void metadataListPublishesTruncatedPageBeforeSingleResultRecycle() throws Exception {
+		assertMetadataListPagePublished(false);
+	}
+
+	@Test
+	void metadataListPublishesTruncatedPageBeforeBatchResultRecycle() throws Exception {
+		assertMetadataListPagePublished(true);
+	}
+
+	@SuppressWarnings({"unchecked", "rawtypes"
+	})
+	private void assertMetadataListPagePublished(final boolean batched) throws Exception {
+		final Config listConfig = TestConfigBuilder.config();
+		listConfig.val("item-type", "path");
+		listConfig.val("load-op-type", "list");
+		listConfig.val("load-op-recycle-mode", true);
+		listConfig.val("load-op-recycle-content-update", false);
+
+		final LoadGenerator<Item, Operation<Item>> listGenerator = mock(LoadGenerator.class);
+		final StorageDriver<Item, Operation<Item>> listDriver = mock(StorageDriver.class);
+		when(listDriver.metadataIntegrityEnabled()).thenReturn(true);
+		final Output<Operation<Item>> resultsOutput = mock(Output.class);
+		when(resultsOutput.put(any(Operation.class))).thenReturn(true);
+		final LoadStepContextImpl<Item, Operation<Item>> stepCtx = new LoadStepContextImpl<>(
+						"metadata-list-page",
+						listGenerator,
+						listDriver,
+						buildMetricsCtx("metadata-list-page"),
+						listConfig.configVal("load"),
+						false);
+		stepCtx.operationsResultsOutput(resultsOutput);
+
+		final ListOperationImpl<PathItemImpl> page = new ListOperationImpl<>(
+						0, OpType.LIST, new PathItemImpl("prefix/"), null);
+		page.status(Operation.Status.SUCC);
+		page.objectsListed(1000);
+		page.truncated(true);
+		page.continuationToken("next-page");
+		final Operation<Item> result = (Operation<Item>) (Operation<?>) page;
+
+		if (batched) {
+			assertEquals(1, stepCtx.put(List.of(result), 0, 1));
+		} else {
+			assertTrue(stepCtx.put(result));
+		}
+
+		verify(resultsOutput).put(result);
+		verify(listGenerator).recycle(result);
+	}
+
+	@Test
 	public void listWorkloadCompletesOnceNamespaceExhausted() {
 		final Config listConfig = TestConfigBuilder.config();
 		listConfig.val("item-type", "path");

--- a/engine/core/spt-base/src/test/java/com/dell/spt/base/load/step/local/context/LoadStepContextImplTest.java
+++ b/engine/core/spt-base/src/test/java/com/dell/spt/base/load/step/local/context/LoadStepContextImplTest.java
@@ -16,6 +16,7 @@ import com.dell.spt.base.item.Item;
 import com.dell.spt.base.item.ItemFactory;
 import com.dell.spt.base.item.ItemType;
 import com.dell.spt.base.item.PathItemImpl;
+import com.dell.spt.base.item.io.IntegrityOperationManifestOutput;
 import com.dell.spt.base.item.io.ItemInfoFileOutput;
 import com.dell.spt.base.item.io.ItemInputFactory;
 import com.dell.spt.base.item.op.OpType;
@@ -24,6 +25,7 @@ import com.dell.spt.base.item.op.data.DataOperation;
 import com.dell.spt.base.item.op.data.DataOperationImpl;
 import com.dell.spt.base.item.op.list.ListOperation;
 import com.dell.spt.base.item.op.list.ListOperationImpl;
+import com.dell.spt.base.item.op.list.ListedObject;
 import com.dell.spt.base.item.op.list.shard.ListShard;
 import com.dell.spt.base.item.op.list.shard.ListShardMetricsRecorder;
 import com.dell.spt.base.item.op.list.shard.ListShardMetricsRecorderImpl;
@@ -43,6 +45,7 @@ import com.github.akurilov.commons.system.SizeInBytes;
 import com.github.akurilov.confuse.Config;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;
@@ -60,6 +63,7 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -75,6 +79,9 @@ import static org.mockito.Mockito.when;
 
 /* Alot of the functionality from ItemInputFactoryTest is used here since need an ItemInputFactory */
 public class LoadStepContextImplTest {
+	@TempDir
+	Path tempDir;
+
 	private static Path TMP_DIR_PATH = null;
 	private LoadGeneratorBuilder generatorBuilder = null;
 	private LoadGenerator generator = null;
@@ -1116,6 +1123,113 @@ public class LoadStepContextImplTest {
 		assertTrue(stepCtx.put((Operation<DataItem>) op));
 
 		assertEquals(100L, trackingCtx.singleTtfb.get());
+	}
+
+	@Test
+	@SuppressWarnings({"unchecked", "rawtypes"
+	})
+	void metadataListPublishesThreePagesExactlyOnceWithMatchingEmissionCount() throws Exception {
+		final Config listConfig = TestConfigBuilder.config();
+		listConfig.val("item-type", "path");
+		listConfig.val("load-op-type", "list");
+		listConfig.val("load-op-recycle-mode", true);
+		listConfig.val("load-op-recycle-content-update", false);
+
+		final LoadGenerator<Item, Operation<Item>> listGenerator = mock(LoadGenerator.class);
+		final StorageDriver<Item, Operation<Item>> listDriver = mock(StorageDriver.class);
+		when(listDriver.metadataIntegrityEnabled()).thenReturn(true);
+		final LoadStepContextImpl<Item, Operation<Item>> stepCtx = new LoadStepContextImpl<>(
+						"metadata-list-three-pages",
+						listGenerator,
+						listDriver,
+						buildMetricsCtx("metadata-list-three-pages"),
+						listConfig.configVal("load"),
+						false);
+		final Path manifest = tempDir.resolve("verify-input.csv");
+		final IntegrityOperationManifestOutput<Operation<Item>> output = new IntegrityOperationManifestOutput<>(manifest, "/bucket", OpType.LIST);
+		stepCtx.operationsResultsOutput(output);
+		final PathItemImpl seed = new PathItemImpl("prefix/");
+		final ListOperationImpl<PathItemImpl> page = new ListOperationImpl<>(
+						0, OpType.LIST, seed, null);
+		page.status(Operation.Status.SUCC);
+		final Operation<Item> result = (Operation<Item>) (Operation<?>) page;
+
+		page.listedObjects(List.of(new ListedObject("prefix/a", 1, "a-v1")));
+		page.objectsListed(1);
+		page.truncated(true);
+		page.continuationToken("page-2");
+		assertTrue(stepCtx.put(result));
+
+		page.listedObjects(List.of(new ListedObject("prefix/b", 2, "b-v1")));
+		page.objectsListed(1);
+		page.truncated(true);
+		page.continuationToken("page-3");
+		assertTrue(stepCtx.put(result));
+
+		page.listedObjects(List.of(new ListedObject("prefix/c", 3, "c-v1")));
+		page.objectsListed(1);
+		page.truncated(false);
+		page.continuationToken(null);
+		assertTrue(stepCtx.put(result));
+		output.close();
+
+		assertEquals(
+						List.of(
+										"bucket,key,size,version_id",
+										"bucket,prefix/a,1,a-v1",
+										"bucket,prefix/b,2,b-v1",
+										"bucket,prefix/c,3,c-v1"),
+						Files.readAllLines(manifest));
+		assertEquals(
+						"3",
+						Files.readString(com.dell.spt.base.integrity.IntegrityManifestCompletion
+										.emissionCountPath(manifest)).trim());
+		verify(listGenerator, times(2)).recycle(result);
+	}
+
+	@Test
+	@SuppressWarnings({"unchecked", "rawtypes"
+	})
+	void ordinaryRecycledListRetainsOnlyIntermediatePageAndEmitsFinalPageOnce() throws Exception {
+		final Config listConfig = TestConfigBuilder.config();
+		listConfig.val("item-type", "path");
+		listConfig.val("load-op-type", "list");
+		listConfig.val("load-op-recycle-mode", true);
+		listConfig.val("load-op-recycle-content-update", false);
+
+		final LoadGenerator<Item, Operation<Item>> listGenerator = mock(LoadGenerator.class);
+		final StorageDriver<Item, Operation<Item>> listDriver = mock(StorageDriver.class);
+		when(listDriver.metadataIntegrityEnabled()).thenReturn(false);
+		final Output<Operation<Item>> resultsOutput = mock(Output.class);
+		when(resultsOutput.put(any(Operation.class))).thenReturn(true);
+		final LoadStepContextImpl<Item, Operation<Item>> stepCtx = new LoadStepContextImpl<>(
+						"ordinary-list-pages",
+						listGenerator,
+						listDriver,
+						buildMetricsCtx("ordinary-list-pages"),
+						listConfig.configVal("load"),
+						false);
+		stepCtx.operationsResultsOutput(resultsOutput);
+		final PathItemImpl seed = new PathItemImpl("prefix/");
+		final ListOperationImpl<PathItemImpl> page = new ListOperationImpl<>(
+						0, OpType.LIST, seed, null);
+		page.status(Operation.Status.SUCC);
+		page.objectsListed(1);
+		page.truncated(true);
+		final Operation<Item> result = (Operation<Item>) (Operation<?>) page;
+
+		assertTrue(stepCtx.put(result));
+		verify(resultsOutput, never()).put(result);
+		final var retainedField = LoadStepContextImpl.class.getDeclaredField(
+						"latestSuccOpResultByItem");
+		retainedField.setAccessible(true);
+		assertEquals(1, ((Map<?, ?>) retainedField.get(stepCtx)).size());
+
+		page.truncated(false);
+		assertTrue(stepCtx.put(result));
+		verify(resultsOutput, times(1)).put(result);
+		assertTrue(((Map<?, ?>) retainedField.get(stepCtx)).isEmpty());
+		verify(listGenerator, times(1)).recycle(result);
 	}
 
 	@Test

--- a/engine/core/spt-base/src/test/java/com/dell/spt/base/load/step/local/context/LoadStepContextSplitGateTest.java
+++ b/engine/core/spt-base/src/test/java/com/dell/spt/base/load/step/local/context/LoadStepContextSplitGateTest.java
@@ -326,6 +326,32 @@ public class LoadStepContextSplitGateTest {
 	}
 
 	@Test
+	public void allVersionListNeverAttemptsDelimiterSplit() throws Exception {
+		final var metrics = new FakeMetrics(64, 1);
+		final var driver = com.dell.spt.base.storage.driver.mock.DummyStorageDriverMock
+						.<Item, Operation<Item>> create();
+		final LoadStepContextImpl<Item, Operation<Item>> ctx = new LoadStepContextImpl<>(
+						"all-version-split-test",
+						null,
+						driver,
+						metrics,
+						minimalLoadConfig(),
+						false);
+		final ListShard shard = new ListShard("prefix/", null, null, null);
+		final ListOperation<?> listOp = newListOp(
+						"/bucket", "prefix/a", "prefix/z", shard);
+		listOp.options(listOp.options().toBuilder().includeVersions(true).build());
+		final Method method = LoadStepContextImpl.class.getDeclaredMethod(
+						"tryDelimiterSplit", ListShard.class, ListOperation.class);
+		method.setAccessible(true);
+
+		assertEquals(Boolean.FALSE, method.invoke(ctx, shard, listOp));
+		final Field windowsField = LoadStepContextImpl.class.getDeclaredField("splitWindows");
+		windowsField.setAccessible(true);
+		assertTrue(((ConcurrentMap<?, ?>) windowsField.get(ctx)).isEmpty());
+	}
+
+	@Test
 	public void delimiterSplitLogsRecorderFailuresAndContinues() throws Exception {
 		final var metrics = new FakeMetrics(10, 1); // concCurr < concLimit
 		final StorageDriver<Item, Operation<Item>> driverMock = mock(

--- a/engine/extensions/storage-drivers/implementations/s3-aws/build.gradle
+++ b/engine/extensions/storage-drivers/implementations/s3-aws/build.gradle
@@ -19,6 +19,7 @@ dependencies {
 	implementation libs.aws.sts
 	implementation libs.aws.http.client.spi
 	implementation libs.aws.crt
+	implementation libs.aws.crt.client
 	implementation libs.aws.sdk.core
 	implementation libs.aws.utils
 	implementation libs.aws.profiles

--- a/engine/extensions/storage-drivers/implementations/s3-aws/src/main/java/com/dell/spt/storage/driver/coop/aws/s3/S3AwsStorageDriver.java
+++ b/engine/extensions/storage-drivers/implementations/s3-aws/src/main/java/com/dell/spt/storage/driver/coop/aws/s3/S3AwsStorageDriver.java
@@ -62,6 +62,8 @@ import java.util.HexFormat;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 /**
@@ -89,7 +91,8 @@ public class S3AwsStorageDriver<I extends Item, O extends Operation<I>> extends 
 	private static final String KEY_MPU_FAILURE = "mpuFailure";
 
 	private final S3AsyncClient s3AsyncClient;
-	private final S3AsyncClient exactVersionS3Client;
+	private final Supplier<S3AsyncClient> exactVersionS3ClientSupplier;
+	private volatile S3AsyncClient exactVersionS3Client;
 	private final ExecutorService executor; // For read operations
 	private final ExecutorService uploadExecutor; // Dedicated for upload operations
 	private final String bucketName;
@@ -126,6 +129,38 @@ public class S3AwsStorageDriver<I extends Item, O extends Operation<I>> extends 
 					final long smallObjectThresholdBytes,
 					final long partSizeBytes)
 					throws IllegalConfigurationException {
+		this(stepId, dataInput, config, verifyFlag, batchSize, s3AsyncClient,
+						exactVersionS3Client, null, smallObjectThresholdBytes, partSizeBytes);
+	}
+
+	S3AwsStorageDriver(
+					final String stepId,
+					final DataInput dataInput,
+					final Config config,
+					final boolean verifyFlag,
+					final int batchSize,
+					final S3AsyncClient s3AsyncClient,
+					final Supplier<S3AsyncClient> exactVersionS3ClientSupplier,
+					final long smallObjectThresholdBytes,
+					final long partSizeBytes)
+					throws IllegalConfigurationException {
+		this(stepId, dataInput, config, verifyFlag, batchSize, s3AsyncClient,
+						null, Objects.requireNonNull(exactVersionS3ClientSupplier),
+						smallObjectThresholdBytes, partSizeBytes);
+	}
+
+	private S3AwsStorageDriver(
+					final String stepId,
+					final DataInput dataInput,
+					final Config config,
+					final boolean verifyFlag,
+					final int batchSize,
+					final S3AsyncClient s3AsyncClient,
+					final S3AsyncClient exactVersionS3Client,
+					final Supplier<S3AsyncClient> exactVersionS3ClientSupplier,
+					final long smallObjectThresholdBytes,
+					final long partSizeBytes)
+					throws IllegalConfigurationException {
 		super(stepId, dataInput, config, verifyFlag, batchSize);
 		if (verifyFlag) {
 			throw new IllegalConfigurationException(
@@ -134,6 +169,7 @@ public class S3AwsStorageDriver<I extends Item, O extends Operation<I>> extends 
 		}
 		this.s3AsyncClient = s3AsyncClient;
 		this.exactVersionS3Client = exactVersionS3Client;
+		this.exactVersionS3ClientSupplier = exactVersionS3ClientSupplier;
 		this.smallObjectThresholdBytes = smallObjectThresholdBytes;
 		this.partSizeBytes = partSizeBytes;
 
@@ -806,7 +842,7 @@ public class S3AwsStorageDriver<I extends Item, O extends Operation<I>> extends 
 
 		final S3AsyncClient readClient = versionId == null || versionId.isEmpty()
 						? s3AsyncClient
-						: exactVersionS3Client;
+						: exactVersionS3Client();
 		try (var response = readClient.getObject(
 						reqBuilder.build(),
 						AsyncResponseTransformer.toBlockingInputStream()).join()) {
@@ -848,6 +884,22 @@ public class S3AwsStorageDriver<I extends Item, O extends Operation<I>> extends 
 		}
 
 		return CompletableFuture.completedFuture(null);
+	}
+
+	private S3AsyncClient exactVersionS3Client() {
+		S3AsyncClient client = exactVersionS3Client;
+		if (client == null) {
+			synchronized (this) {
+				client = exactVersionS3Client;
+				if (client == null) {
+					client = Objects.requireNonNull(
+									exactVersionS3ClientSupplier.get(),
+									"Exact-version S3 client supplier returned null");
+					exactVersionS3Client = client;
+				}
+			}
+		}
+		return client;
 	}
 
 	private CompletableFuture<Void> deleteObject(final O op) {
@@ -997,9 +1049,19 @@ public class S3AwsStorageDriver<I extends Item, O extends Operation<I>> extends 
 
 		return s3AsyncClient.listObjectVersions(request.build())
 						.thenAccept(response -> {
+							final boolean truncated = Boolean.TRUE.equals(response.isTruncated());
+							if (truncated
+											&& (response.nextKeyMarker() == null
+															|| response.nextKeyMarker().isEmpty()
+															|| response.nextVersionIdMarker() == null
+															|| response.nextVersionIdMarker().isEmpty())) {
+								throw new IllegalStateException(
+												"Truncated S3 version LIST result is missing its next markers");
+							}
 							final List<ListedObject> listedObjects = new ArrayList<>(response.versions().size());
 							long bytesTotal = 0;
 							String firstKey = null;
+							String lastKey = null;
 							for (final ObjectVersion version : response.versions()) {
 								final String key = version.key();
 								final String versionId = version.versionId();
@@ -1007,23 +1069,39 @@ public class S3AwsStorageDriver<I extends Item, O extends Operation<I>> extends 
 									throw new IllegalStateException(
 													"ListObjectVersions returned a data version without an exact identity");
 								}
-								final long size = Math.max(0L, version.size());
+								final Long responseSize = version.size();
+								if (responseSize == null) {
+									throw new IllegalStateException(
+													"S3 LIST entry is missing Size for key \"" + key + "\"");
+								}
+								final long size = Math.max(0L, responseSize);
 								listedObjects.add(new ListedObject(key, size, versionId));
 								if (options.fetchMetadata()) {
 									bytesTotal = Math.addExact(bytesTotal, size);
 								}
-								if (firstKey == null) {
+								if (firstKey == null || key.compareTo(firstKey) < 0) {
 									firstKey = key;
 								}
+								if (lastKey == null || key.compareTo(lastKey) > 0) {
+									lastKey = key;
+								}
 							}
-							if (firstKey == null && !response.deleteMarkers().isEmpty()) {
-								firstKey = response.deleteMarkers().get(0).key();
+							for (final DeleteMarkerEntry deleteMarker : response.deleteMarkers()) {
+								final String key = deleteMarker.key();
+								if (key != null && !key.isEmpty()) {
+									if (firstKey == null || key.compareTo(firstKey) < 0) {
+										firstKey = key;
+									}
+									if (lastKey == null || key.compareTo(lastKey) > 0) {
+										lastKey = key;
+									}
+								}
 							}
 							listOp.objectsListed(listedObjects.size() + response.deleteMarkers().size());
 							listOp.listedObjects(listedObjects);
 							listOp.deleteMarkersListed(response.deleteMarkers().size());
 							listOp.bytesListed(options.fetchMetadata() ? bytesTotal : 0);
-							listOp.truncated(Boolean.TRUE.equals(response.isTruncated()));
+							listOp.truncated(truncated);
 							if (firstKey != null) {
 								listOp.pageFirstKey(firstKey);
 							}
@@ -1034,6 +1112,9 @@ public class S3AwsStorageDriver<I extends Item, O extends Operation<I>> extends 
 															.keyMarker(response.nextKeyMarker())
 															.versionIdMarker(response.nextVersionIdMarker())
 															.build());
+							if (lastKey != null) {
+								listOp.startAfter(lastKey);
+							}
 							listOp.countBytesDone(listOp.bytesListed());
 							if (listOp.respDataTimeStart() == 0) {
 								LOG.debug(

--- a/engine/extensions/storage-drivers/implementations/s3-aws/src/main/java/com/dell/spt/storage/driver/coop/aws/s3/S3AwsStorageDriver.java
+++ b/engine/extensions/storage-drivers/implementations/s3-aws/src/main/java/com/dell/spt/storage/driver/coop/aws/s3/S3AwsStorageDriver.java
@@ -89,6 +89,7 @@ public class S3AwsStorageDriver<I extends Item, O extends Operation<I>> extends 
 	private static final String KEY_MPU_FAILURE = "mpuFailure";
 
 	private final S3AsyncClient s3AsyncClient;
+	private final S3AsyncClient exactVersionS3Client;
 	private final ExecutorService executor; // For read operations
 	private final ExecutorService uploadExecutor; // Dedicated for upload operations
 	private final String bucketName;
@@ -110,6 +111,21 @@ public class S3AwsStorageDriver<I extends Item, O extends Operation<I>> extends 
 					final long smallObjectThresholdBytes,
 					final long partSizeBytes)
 					throws IllegalConfigurationException {
+		this(stepId, dataInput, config, verifyFlag, batchSize, s3AsyncClient, s3AsyncClient,
+						smallObjectThresholdBytes, partSizeBytes);
+	}
+
+	public S3AwsStorageDriver(
+					final String stepId,
+					final DataInput dataInput,
+					final Config config,
+					final boolean verifyFlag,
+					final int batchSize,
+					final S3AsyncClient s3AsyncClient,
+					final S3AsyncClient exactVersionS3Client,
+					final long smallObjectThresholdBytes,
+					final long partSizeBytes)
+					throws IllegalConfigurationException {
 		super(stepId, dataInput, config, verifyFlag, batchSize);
 		if (verifyFlag) {
 			throw new IllegalConfigurationException(
@@ -117,6 +133,7 @@ public class S3AwsStorageDriver<I extends Item, O extends Operation<I>> extends 
 											+ "use storage.integrity.mode=metadata for whole-object verification");
 		}
 		this.s3AsyncClient = s3AsyncClient;
+		this.exactVersionS3Client = exactVersionS3Client;
 		this.smallObjectThresholdBytes = smallObjectThresholdBytes;
 		this.partSizeBytes = partSizeBytes;
 
@@ -342,7 +359,12 @@ public class S3AwsStorageDriver<I extends Item, O extends Operation<I>> extends 
 				}
 			}
 			op.status(originalStatus);
-			LOG.error("{} {} failed: {}", op.type(), op.item().name(), originalStatus);
+			final Throwable failure = e instanceof java.util.concurrent.CompletionException
+							&& e.getCause() != null ? e.getCause() : e;
+			LOG.error(
+							"{} {} requested version {} failed: {}: {}",
+							op.type(), op.item().name(), op.requestedVersionId(),
+							originalStatus, failure);
 			LOG.debug("{} {} stack trace", op.type(), op.item().name(), e);
 			try {
 				op.startResponse();
@@ -782,7 +804,10 @@ public class S3AwsStorageDriver<I extends Item, O extends Operation<I>> extends 
 			reqBuilder.versionId(versionId);
 		}
 
-		try (var response = s3AsyncClient.getObject(
+		final S3AsyncClient readClient = versionId == null || versionId.isEmpty()
+						? s3AsyncClient
+						: exactVersionS3Client;
+		try (var response = readClient.getObject(
 						reqBuilder.build(),
 						AsyncResponseTransformer.toBlockingInputStream()).join()) {
 			final GetObjectResponse getResponse = response.response();
@@ -1472,14 +1497,20 @@ public class S3AwsStorageDriver<I extends Item, O extends Operation<I>> extends 
 	protected void doClose()
 					throws IOException {
 		try {
-			// Close the S3AsyncClient to release native CRT resources
-			// This closes the underlying event loops and connection pools
 			if (s3AsyncClient != null) {
 				s3AsyncClient.close();
 				LOG.info("S3AsyncClient closed successfully");
 			}
 		} catch (Exception e) {
 			LOG.warn("Failed to close S3AsyncClient: {}", e.getMessage());
+		}
+		try {
+			if (exactVersionS3Client != null && exactVersionS3Client != s3AsyncClient) {
+				exactVersionS3Client.close();
+				LOG.info("Exact-version S3AsyncClient closed successfully");
+			}
+		} catch (Exception e) {
+			LOG.warn("Failed to close exact-version S3AsyncClient: {}", e.getMessage());
 		}
 
 		try {

--- a/engine/extensions/storage-drivers/implementations/s3-aws/src/main/java/com/dell/spt/storage/driver/coop/aws/s3/S3AwsStorageDriver.java
+++ b/engine/extensions/storage-drivers/implementations/s3-aws/src/main/java/com/dell/spt/storage/driver/coop/aws/s3/S3AwsStorageDriver.java
@@ -862,6 +862,9 @@ public class S3AwsStorageDriver<I extends Item, O extends Operation<I>> extends 
 		}
 
 		final var maxKeys = options.maxKeys() > 0 ? Math.min(options.maxKeys(), 1000) : 1000;
+		if (options.includeVersions()) {
+			return listObjectVersions(op, listOp, options, targetBucket, maxKeys);
+		}
 
 		ListObjectsV2Request.Builder reqBuilder = ListObjectsV2Request.builder()
 						.bucket(targetBucket)
@@ -937,6 +940,80 @@ public class S3AwsStorageDriver<I extends Item, O extends Operation<I>> extends 
 							listOp.countBytesDone(listOp.bytesListed());
 							if (listOp.respDataTimeStart() == 0) {
 								LOG.debug("{}: LIST completed before first body byte was observed; TTFB unavailable", listOp);
+							}
+						});
+	}
+
+	private CompletableFuture<Void> listObjectVersions(
+					final O op,
+					final ListOperation<? extends PathItem> listOp,
+					final ListOptions options,
+					final String targetBucket,
+					final int maxKeys) {
+		final ListObjectVersionsRequest.Builder request = ListObjectVersionsRequest.builder()
+						.bucket(targetBucket)
+						.maxKeys(maxKeys)
+						.overrideConfiguration(b -> b
+										.putExecutionAttribute(LIST_TTFB_OPERATION_ATTRIBUTE, listOp)
+										.addPlugin(LIST_TTFB_SDK_PLUGIN));
+		final String prefix = op.item().name();
+		if (prefix != null && !prefix.isEmpty()) {
+			request.prefix(prefix.startsWith("/") ? prefix.substring(1) : prefix);
+		}
+		if (options.delimiter() != null && !options.delimiter().isEmpty()) {
+			request.delimiter(options.delimiter());
+		}
+		if (options.keyMarker() != null && !options.keyMarker().isEmpty()) {
+			request.keyMarker(options.keyMarker());
+		}
+		if (options.versionIdMarker() != null && !options.versionIdMarker().isEmpty()) {
+			request.versionIdMarker(options.versionIdMarker());
+		}
+
+		return s3AsyncClient.listObjectVersions(request.build())
+						.thenAccept(response -> {
+							final List<ListedObject> listedObjects = new ArrayList<>(response.versions().size());
+							long bytesTotal = 0;
+							String firstKey = null;
+							for (final ObjectVersion version : response.versions()) {
+								final String key = version.key();
+								final String versionId = version.versionId();
+								if (key == null || key.isEmpty() || versionId == null || versionId.isEmpty()) {
+									throw new IllegalStateException(
+													"ListObjectVersions returned a data version without an exact identity");
+								}
+								final long size = Math.max(0L, version.size());
+								listedObjects.add(new ListedObject(key, size, versionId));
+								if (options.fetchMetadata()) {
+									bytesTotal = Math.addExact(bytesTotal, size);
+								}
+								if (firstKey == null) {
+									firstKey = key;
+								}
+							}
+							if (firstKey == null && !response.deleteMarkers().isEmpty()) {
+								firstKey = response.deleteMarkers().get(0).key();
+							}
+							listOp.objectsListed(listedObjects.size() + response.deleteMarkers().size());
+							listOp.listedObjects(listedObjects);
+							listOp.deleteMarkersListed(response.deleteMarkers().size());
+							listOp.bytesListed(options.fetchMetadata() ? bytesTotal : 0);
+							listOp.truncated(Boolean.TRUE.equals(response.isTruncated()));
+							if (firstKey != null) {
+								listOp.pageFirstKey(firstKey);
+							}
+							listOp.continuationToken(response.nextKeyMarker());
+							listOp.options(
+											options.toBuilder()
+															.continuationToken(null)
+															.keyMarker(response.nextKeyMarker())
+															.versionIdMarker(response.nextVersionIdMarker())
+															.build());
+							listOp.countBytesDone(listOp.bytesListed());
+							if (listOp.respDataTimeStart() == 0) {
+								LOG.debug(
+												"{}: LIST versions completed before first body byte was observed; TTFB unavailable",
+												listOp);
 							}
 						});
 	}

--- a/engine/extensions/storage-drivers/implementations/s3-aws/src/main/java/com/dell/spt/storage/driver/coop/aws/s3/S3AwsStorageDriverFactory.java
+++ b/engine/extensions/storage-drivers/implementations/s3-aws/src/main/java/com/dell/spt/storage/driver/coop/aws/s3/S3AwsStorageDriverFactory.java
@@ -194,19 +194,9 @@ public final class S3AwsStorageDriverFactory<I extends Item, O extends Operation
 		// The CRT manages part size internally based on minimumPartSizeInBytes
 
 		S3AsyncClient s3AsyncClient = crtBuilder.build();
-		S3AsyncClient exactVersionS3Client = null;
+		final String exactClientRegion = region;
+		final int exactClientMaxConcurrency = maxConcurrency;
 		try {
-			// The CRT S3 transfer client may synthesize conditional multipart GETs from a
-			// current-object HEAD. Use the ordinary protocol client when a version ID is exact.
-			exactVersionS3Client = S3AsyncClient.builder()
-							.credentialsProvider(StaticCredentialsProvider.create(creds))
-							.region(Region.of(region))
-							.endpointOverride(URI.create(endpoint))
-							.forcePathStyle(pathStyle)
-							.httpClientBuilder(AwsCrtAsyncHttpClient.builder()
-											.maxConcurrency(maxConcurrency))
-							.build();
-
 			return new S3AwsStorageDriver<>(
 							stepId,
 							dataInput,
@@ -214,17 +204,22 @@ public final class S3AwsStorageDriverFactory<I extends Item, O extends Operation
 							verifyFlag,
 							batchSize,
 							s3AsyncClient,
-							exactVersionS3Client,
+							() -> {
+								// The CRT S3 transfer client may synthesize conditional multipart GETs
+								// from a current-object HEAD. Build the ordinary protocol client only
+								// when an exact version ID is first requested.
+								return S3AsyncClient.builder()
+												.credentialsProvider(StaticCredentialsProvider.create(creds))
+												.region(Region.of(exactClientRegion))
+												.endpointOverride(URI.create(endpoint))
+												.forcePathStyle(pathStyle)
+												.httpClientBuilder(AwsCrtAsyncHttpClient.builder()
+																.maxConcurrency(exactClientMaxConcurrency))
+												.build();
+							},
 							smallObjectThresholdBytes,
 							partSizeBytes);
 		} catch (RuntimeException e) {
-			try {
-				if (exactVersionS3Client != null) {
-					exactVersionS3Client.close();
-				}
-			} catch (RuntimeException closeFailure) {
-				e.addSuppressed(closeFailure);
-			}
 			try {
 				s3AsyncClient.close();
 			} catch (RuntimeException closeFailure) {

--- a/engine/extensions/storage-drivers/implementations/s3-aws/src/main/java/com/dell/spt/storage/driver/coop/aws/s3/S3AwsStorageDriverFactory.java
+++ b/engine/extensions/storage-drivers/implementations/s3-aws/src/main/java/com/dell/spt/storage/driver/coop/aws/s3/S3AwsStorageDriverFactory.java
@@ -14,6 +14,7 @@ import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.http.crt.AwsCrtAsyncHttpClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -193,16 +194,44 @@ public final class S3AwsStorageDriverFactory<I extends Item, O extends Operation
 		// The CRT manages part size internally based on minimumPartSizeInBytes
 
 		S3AsyncClient s3AsyncClient = crtBuilder.build();
+		S3AsyncClient exactVersionS3Client = null;
+		try {
+			// The CRT S3 transfer client may synthesize conditional multipart GETs from a
+			// current-object HEAD. Use the ordinary protocol client when a version ID is exact.
+			exactVersionS3Client = S3AsyncClient.builder()
+							.credentialsProvider(StaticCredentialsProvider.create(creds))
+							.region(Region.of(region))
+							.endpointOverride(URI.create(endpoint))
+							.forcePathStyle(pathStyle)
+							.httpClientBuilder(AwsCrtAsyncHttpClient.builder()
+											.maxConcurrency(maxConcurrency))
+							.build();
 
-		return new S3AwsStorageDriver<>(
-						stepId,
-						dataInput,
-						storageConfig,
-						verifyFlag,
-						batchSize,
-						s3AsyncClient,
-						smallObjectThresholdBytes,
-						partSizeBytes);
+			return new S3AwsStorageDriver<>(
+							stepId,
+							dataInput,
+							storageConfig,
+							verifyFlag,
+							batchSize,
+							s3AsyncClient,
+							exactVersionS3Client,
+							smallObjectThresholdBytes,
+							partSizeBytes);
+		} catch (RuntimeException e) {
+			try {
+				if (exactVersionS3Client != null) {
+					exactVersionS3Client.close();
+				}
+			} catch (RuntimeException closeFailure) {
+				e.addSuppressed(closeFailure);
+			}
+			try {
+				s3AsyncClient.close();
+			} catch (RuntimeException closeFailure) {
+				e.addSuppressed(closeFailure);
+			}
+			throw e;
+		}
 	}
 
 	/**

--- a/engine/extensions/storage-drivers/implementations/s3-aws/src/test/java/com/dell/spt/storage/driver/coop/aws/s3/S3AwsStorageDriverTest.java
+++ b/engine/extensions/storage-drivers/implementations/s3-aws/src/test/java/com/dell/spt/storage/driver/coop/aws/s3/S3AwsStorageDriverTest.java
@@ -67,6 +67,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
@@ -260,6 +261,41 @@ public class S3AwsStorageDriverTest {
 			assertEquals("requested-version", request.getValue().versionId());
 			assertEquals("returned-version", op.returnedVersionId());
 			assertNotNull(op.integrityVerificationResult());
+			assertTrue(op.integrityVerificationResult().verified());
+			assertEquals(Operation.Status.SUCC, op.status());
+		}
+
+		@Test
+		@SuppressWarnings("unchecked")
+		void noVersionReadUsesPrimaryClientWithoutTouchingExactClient() throws Exception {
+			enableIntegrityMetadata(drv);
+			final S3AsyncClient exactVersionS3Client = mock(S3AsyncClient.class);
+			final Field exactClientField = S3AwsStorageDriver.class.getDeclaredField("exactVersionS3Client");
+			exactClientField.setAccessible(true);
+			exactClientField.set(drv, exactVersionS3Client);
+			final byte[] content = "body".getBytes(StandardCharsets.UTF_8);
+			final GetObjectResponse getResponse = GetObjectResponse.builder()
+							.metadata(IntegrityMetadataCodec.logicalMetadata(metadataFor(content)))
+							.contentLength((long) content.length)
+							.build();
+			when(mockS3Client.getObject(
+							any(GetObjectRequest.class), any(AsyncResponseTransformer.class)))
+							.thenReturn(CompletableFuture.completedFuture(
+											new ResponseInputStream<>(getResponse, new ByteArrayInputStream(content))));
+
+			final IntegrityManifestDataItem item = new IntegrityManifestDataItem(
+							"bucket", "key", content.length, null);
+			final DataOperationImpl<IntegrityManifestDataItem> op = new DataOperationImpl<>(
+							0, OpType.READ, item, null, "/bucket", TEST_CRED, null, 0);
+			op.startRequest();
+			op.finishRequest();
+
+			drv.invokeNio((Operation<Item>) (Operation<?>) op);
+
+			final ArgumentCaptor<GetObjectRequest> request = ArgumentCaptor.forClass(GetObjectRequest.class);
+			verify(mockS3Client).getObject(request.capture(), any(AsyncResponseTransformer.class));
+			verifyNoInteractions(exactVersionS3Client);
+			assertNull(request.getValue().versionId());
 			assertTrue(op.integrityVerificationResult().verified());
 			assertEquals(Operation.Status.SUCC, op.status());
 		}
@@ -1567,6 +1603,123 @@ public class S3AwsStorageDriverTest {
 						() -> drv.execute((Operation<Item>) (Operation<?>) op).join());
 		assertInstanceOf(IllegalStateException.class, failure.getCause());
 		verify(op, never()).listedObjects(anyList());
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
+	void allVersionDiscoveryRejectsTruncatedPageWithoutNextMarkers() {
+		ListOperation<PathItem> op = mock(ListOperation.class);
+		PathItem item = mock(PathItem.class);
+		when(op.type()).thenReturn(OpType.LIST);
+		when(op.srcPath()).thenReturn("/bucket");
+		when(item.name()).thenReturn("prefix/");
+		when(op.item()).thenReturn(item);
+		when(op.options()).thenReturn(ListOptions.builder().includeVersions(true).build());
+		ListObjectVersionsResponse response = ListObjectVersionsResponse.builder()
+						.versions(ObjectVersion.builder()
+										.key("prefix/key")
+										.versionId("v1")
+										.size(1L)
+										.build())
+						.isTruncated(true)
+						.build();
+		when(mockS3Client.listObjectVersions(any(ListObjectVersionsRequest.class)))
+						.thenReturn(CompletableFuture.completedFuture(response));
+
+		CompletionException failure = assertThrows(
+						CompletionException.class,
+						() -> drv.execute((Operation<Item>) (Operation<?>) op).join());
+
+		assertInstanceOf(IllegalStateException.class, failure.getCause());
+		assertEquals(
+						"Truncated S3 version LIST result is missing its next markers",
+						failure.getCause().getMessage());
+		verify(op, never()).listedObjects(anyList());
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
+	void allVersionDiscoveryRejectsMissingSizeWithoutPublishingResults() {
+		ListOperation<PathItem> op = mock(ListOperation.class);
+		PathItem item = mock(PathItem.class);
+		when(op.type()).thenReturn(OpType.LIST);
+		when(op.srcPath()).thenReturn("/bucket");
+		when(item.name()).thenReturn("prefix/");
+		when(op.item()).thenReturn(item);
+		when(op.options()).thenReturn(ListOptions.builder().includeVersions(true).build());
+		ListObjectVersionsResponse response = ListObjectVersionsResponse.builder()
+						.versions(ObjectVersion.builder()
+										.key("prefix/key")
+										.versionId("v1")
+										.build())
+						.isTruncated(false)
+						.build();
+		when(mockS3Client.listObjectVersions(any(ListObjectVersionsRequest.class)))
+						.thenReturn(CompletableFuture.completedFuture(response));
+
+		CompletionException failure = assertThrows(
+						CompletionException.class,
+						() -> drv.execute((Operation<Item>) (Operation<?>) op).join());
+
+		assertInstanceOf(IllegalStateException.class, failure.getCause());
+		assertEquals(
+						"S3 LIST entry is missing Size for key \"prefix/key\"",
+						failure.getCause().getMessage());
+		verify(op, never()).listedObjects(anyList());
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
+	void allVersionDiscoveryCarriesBothMarkersAcrossTwoPages() {
+		ListOperation<PathItem> op = mock(ListOperation.class);
+		PathItem item = mock(PathItem.class);
+		when(op.type()).thenReturn(OpType.LIST);
+		when(op.srcPath()).thenReturn("/bucket");
+		when(item.name()).thenReturn("prefix/");
+		when(op.item()).thenReturn(item);
+		when(op.respDataTimeStart()).thenReturn(1L);
+		AtomicReference<ListOptions> options = new AtomicReference<>(
+						ListOptions.builder().includeVersions(true).fetchMetadata(true).build());
+		when(op.options()).thenAnswer(invocation -> options.get());
+		doAnswer(invocation -> {
+			options.set(invocation.getArgument(0));
+			return null;
+		}).when(op).options(any(ListOptions.class));
+		ListObjectVersionsResponse firstPage = ListObjectVersionsResponse.builder()
+						.versions(ObjectVersion.builder()
+										.key("prefix/a")
+										.versionId("a-v1")
+										.size(1L)
+										.build())
+						.isTruncated(true)
+						.nextKeyMarker("prefix/a")
+						.nextVersionIdMarker("a-v1")
+						.build();
+		ListObjectVersionsResponse secondPage = ListObjectVersionsResponse.builder()
+						.versions(ObjectVersion.builder()
+										.key("prefix/b")
+										.versionId("b-v1")
+										.size(2L)
+										.build())
+						.isTruncated(false)
+						.build();
+		when(mockS3Client.listObjectVersions(any(ListObjectVersionsRequest.class)))
+						.thenReturn(
+										CompletableFuture.completedFuture(firstPage),
+										CompletableFuture.completedFuture(secondPage));
+
+		drv.execute((Operation<Item>) (Operation<?>) op).join();
+		drv.execute((Operation<Item>) (Operation<?>) op).join();
+
+		ArgumentCaptor<ListObjectVersionsRequest> requests = ArgumentCaptor.forClass(ListObjectVersionsRequest.class);
+		verify(mockS3Client, times(2)).listObjectVersions(requests.capture());
+		assertNull(requests.getAllValues().get(0).keyMarker());
+		assertNull(requests.getAllValues().get(0).versionIdMarker());
+		assertEquals("prefix/a", requests.getAllValues().get(1).keyMarker());
+		assertEquals("a-v1", requests.getAllValues().get(1).versionIdMarker());
+		verify(op).startAfter("prefix/a");
+		verify(op).startAfter("prefix/b");
+		verify(op, times(2)).listedObjects(anyList());
 	}
 
 	@SuppressWarnings("unchecked")
@@ -2914,41 +3067,54 @@ public class S3AwsStorageDriverTest {
 	@Nested
 	class ResourceCleanupTest {
 
-		@Test
-		void doClose_closesS3AsyncClientAndExecutors() throws Exception {
-			S3AsyncClient mockClient = mock(S3AsyncClient.class);
-			S3AsyncClient exactVersionClient = mock(S3AsyncClient.class);
-
-			// Mock parent class config requirements
-			Config driverConfig = mock(Config.class);
-			Config limitConfig = mock(Config.class);
+		private Config mockDriverConfig() {
+			final Config driverConfig = mock(Config.class);
+			final Config limitConfig = mock(Config.class);
 			when(limitConfig.intVal("concurrency")).thenReturn(1);
 			when(driverConfig.configVal("limit")).thenReturn(limitConfig);
 			when(driverConfig.intVal("threads")).thenReturn(1);
 
-			Config authConfig = mock(Config.class);
+			final Config authConfig = mock(Config.class);
 			when(authConfig.stringVal("uid")).thenReturn("test-user");
 			when(authConfig.stringVal("secret")).thenReturn("test-secret");
 			when(authConfig.stringVal("token")).thenReturn(null);
 
-			Config config = mock(Config.class);
+			final Config config = mock(Config.class);
 			disableIntegrity(config);
 			when(config.configVal("driver")).thenReturn(driverConfig);
 			when(config.stringVal("namespace")).thenReturn("test-ns");
 			when(config.configVal("auth")).thenReturn(authConfig);
-
-			// Mock CoopStorageDriverBase config requirements
 			when(config.intVal("driver-limit-queue-input")).thenReturn(100);
-
-			// Mock other S3AwsStorageDriver config requirements
 			when(config.configVal("object")).thenThrow(new RuntimeException("no object config"));
 			when(config.configVal("item")).thenThrow(new RuntimeException("no item config"));
 			when(config.configVal("checksum")).thenThrow(new RuntimeException("no checksum config"));
 			when(config.listVal("net.node.addrs")).thenThrow(new RuntimeException("no net config"));
 			when(config.stringVal("storage-net-node-addrs")).thenThrow(new RuntimeException("no net config"));
-
-			// Try to mock crt config, though optional
 			when(config.configVal("crt")).thenThrow(new RuntimeException("no crt config"));
+			return config;
+		}
+
+		@Test
+		void disabledIntegrityDoesNotCreateExactVersionClientOnConstructionOrClose() throws Exception {
+			final S3AsyncClient primaryClient = mock(S3AsyncClient.class);
+			@SuppressWarnings("unchecked")
+			final Supplier<S3AsyncClient> exactVersionClientSupplier = mock(Supplier.class);
+			final S3AwsStorageDriver<Item, Operation<Item>> driver = new S3AwsStorageDriver<>(
+							"step-1", mock(com.dell.spt.base.data.DataInput.class), mockDriverConfig(),
+							false, 1, primaryClient, exactVersionClientSupplier,
+							100 * 1024L, 8 * 1024 * 1024L);
+
+			driver.close();
+
+			verify(primaryClient).close();
+			verifyNoInteractions(exactVersionClientSupplier);
+		}
+
+		@Test
+		void doClose_closesS3AsyncClientAndExecutors() throws Exception {
+			S3AsyncClient mockClient = mock(S3AsyncClient.class);
+			S3AsyncClient exactVersionClient = mock(S3AsyncClient.class);
+			final Config config = mockDriverConfig();
 
 			// Create the driver so it initializes its executors
 			S3AwsStorageDriver<Item, Operation<Item>> driver = new S3AwsStorageDriver<>(

--- a/engine/extensions/storage-drivers/implementations/s3-aws/src/test/java/com/dell/spt/storage/driver/coop/aws/s3/S3AwsStorageDriverTest.java
+++ b/engine/extensions/storage-drivers/implementations/s3-aws/src/test/java/com/dell/spt/storage/driver/coop/aws/s3/S3AwsStorageDriverTest.java
@@ -19,6 +19,7 @@ import com.dell.spt.base.item.op.data.DataOperationImpl;
 import com.dell.spt.base.item.op.Operation;
 import com.dell.spt.base.item.op.partial.data.PartialDataOperation;
 import com.dell.spt.base.item.op.list.ListOperation;
+import com.dell.spt.base.item.op.list.ListedObject;
 import com.dell.spt.base.storage.Credential;
 import com.dell.spt.base.storage.driver.ListDiscoveryProbe;
 import com.dell.spt.base.storage.driver.ListOptions;
@@ -1474,6 +1475,112 @@ public class S3AwsStorageDriverTest {
 
 			verify(op).bytesListed(0L);
 		}
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
+	void listsAllVersionsWithExactIdsMarkersAndDeleteMarkerCount() throws Exception {
+		ListOperation<PathItem> op = mock(ListOperation.class);
+		PathItem item = mock(PathItem.class);
+		when(op.type()).thenReturn(OpType.LIST);
+		when(op.srcPath()).thenReturn("/bucket");
+		when(item.name()).thenReturn("/prefix/");
+		when(op.item()).thenReturn(item);
+		when(op.respDataTimeStart()).thenReturn(1L);
+		ListOptions options = ListOptions.builder()
+						.includeVersions(true)
+						.fetchMetadata(true)
+						.keyMarker("prior-key")
+						.versionIdMarker("prior-version")
+						.maxKeys(1000)
+						.build();
+		when(op.options()).thenReturn(options);
+		ListObjectVersionsResponse response = ListObjectVersionsResponse.builder()
+						.versions(
+										ObjectVersion.builder().key("prefix/key").versionId("v2").size(7L).build(),
+										ObjectVersion.builder().key("prefix/key").versionId("null").size(5L).build())
+						.deleteMarkers(
+										DeleteMarkerEntry.builder().key("prefix/key").versionId("marker-v").build())
+						.isTruncated(true)
+						.nextKeyMarker("next-key")
+						.nextVersionIdMarker("next-version")
+						.build();
+		when(mockS3Client.listObjectVersions(any(ListObjectVersionsRequest.class)))
+						.thenReturn(CompletableFuture.completedFuture(response));
+
+		drv.execute((Operation<Item>) (Operation<?>) op).join();
+
+		ArgumentCaptor<ListObjectVersionsRequest> request = ArgumentCaptor.forClass(ListObjectVersionsRequest.class);
+		verify(mockS3Client).listObjectVersions(request.capture());
+		verify(mockS3Client, never()).listObjectsV2(any(ListObjectsV2Request.class));
+		assertEquals("bucket", request.getValue().bucket());
+		assertEquals("prefix/", request.getValue().prefix());
+		assertEquals("prior-key", request.getValue().keyMarker());
+		assertEquals("prior-version", request.getValue().versionIdMarker());
+
+		@SuppressWarnings("rawtypes")
+		ArgumentCaptor<List> objects = ArgumentCaptor.forClass(List.class);
+		verify(op).listedObjects(objects.capture());
+		ListedObject first = (ListedObject) objects.getValue().get(0);
+		ListedObject second = (ListedObject) objects.getValue().get(1);
+		assertEquals("v2", first.versionId());
+		assertEquals("null", second.versionId());
+		verify(op).objectsListed(3);
+		verify(op).deleteMarkersListed(1);
+		verify(op).bytesListed(12L);
+		verify(op).truncated(true);
+		ArgumentCaptor<ListOptions> next = ArgumentCaptor.forClass(ListOptions.class);
+		verify(op).options(next.capture());
+		assertEquals("next-key", next.getValue().keyMarker());
+		assertEquals("next-version", next.getValue().versionIdMarker());
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
+	void allVersionDiscoveryRejectsMissingExactVersionId() {
+		ListOperation<PathItem> op = mock(ListOperation.class);
+		PathItem item = mock(PathItem.class);
+		when(op.type()).thenReturn(OpType.LIST);
+		when(op.srcPath()).thenReturn("/bucket");
+		when(item.name()).thenReturn("");
+		when(op.item()).thenReturn(item);
+		when(op.options()).thenReturn(ListOptions.builder().includeVersions(true).build());
+		ListObjectVersionsResponse response = ListObjectVersionsResponse.builder()
+						.versions(ObjectVersion.builder().key("key").size(1L).build())
+						.isTruncated(false)
+						.build();
+		when(mockS3Client.listObjectVersions(any(ListObjectVersionsRequest.class)))
+						.thenReturn(CompletableFuture.completedFuture(response));
+
+		CompletionException failure = assertThrows(
+						CompletionException.class,
+						() -> drv.execute((Operation<Item>) (Operation<?>) op).join());
+		assertInstanceOf(IllegalStateException.class, failure.getCause());
+		verify(op, never()).listedObjects(anyList());
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
+	void allVersionDiscoveryPropagatesPermissionDeniedWithoutResults() {
+		ListOperation<PathItem> op = mock(ListOperation.class);
+		PathItem item = mock(PathItem.class);
+		when(op.type()).thenReturn(OpType.LIST);
+		when(op.srcPath()).thenReturn("/bucket");
+		when(item.name()).thenReturn("prefix/");
+		when(op.item()).thenReturn(item);
+		when(op.options()).thenReturn(ListOptions.builder().includeVersions(true).build());
+		S3Exception denied = (S3Exception) S3Exception.builder()
+						.statusCode(403)
+						.message("AccessDenied")
+						.build();
+		when(mockS3Client.listObjectVersions(any(ListObjectVersionsRequest.class)))
+						.thenReturn(CompletableFuture.failedFuture(denied));
+
+		CompletionException failure = assertThrows(
+						CompletionException.class,
+						() -> drv.execute((Operation<Item>) (Operation<?>) op).join());
+		assertSame(denied, failure.getCause());
+		verify(op, never()).listedObjects(anyList());
 	}
 
 	// -----------------------------------------------------------------------

--- a/engine/extensions/storage-drivers/implementations/s3-aws/src/test/java/com/dell/spt/storage/driver/coop/aws/s3/S3AwsStorageDriverTest.java
+++ b/engine/extensions/storage-drivers/implementations/s3-aws/src/test/java/com/dell/spt/storage/driver/coop/aws/s3/S3AwsStorageDriverTest.java
@@ -118,6 +118,9 @@ public class S3AwsStorageDriverTest {
 		Field clientField = S3AwsStorageDriver.class.getDeclaredField("s3AsyncClient");
 		clientField.setAccessible(true);
 		clientField.set(driver, s3Client);
+		Field exactClientField = S3AwsStorageDriver.class.getDeclaredField("exactVersionS3Client");
+		exactClientField.setAccessible(true);
+		exactClientField.set(driver, s3Client);
 	}
 
 	private void setChecksumFields(
@@ -223,6 +226,11 @@ public class S3AwsStorageDriverTest {
 		@SuppressWarnings("unchecked")
 		void readUsesExactManifestVersionAndVerifiesTheCompleteBody() throws Exception {
 			enableIntegrityMetadata(drv);
+			final S3AsyncClient exactVersionS3Client = mock(S3AsyncClient.class);
+			setS3Client(drv, mockS3Client);
+			final Field exactClientField = S3AwsStorageDriver.class.getDeclaredField("exactVersionS3Client");
+			exactClientField.setAccessible(true);
+			exactClientField.set(drv, exactVersionS3Client);
 			final byte[] content = "body".getBytes(StandardCharsets.UTF_8);
 			final IntegrityMetadata metadata = metadataFor(content);
 			final GetObjectResponse getResponse = GetObjectResponse.builder()
@@ -230,7 +238,7 @@ public class S3AwsStorageDriverTest {
 							.contentLength((long) content.length)
 							.versionId("returned-version")
 							.build();
-			when(mockS3Client.getObject(
+			when(exactVersionS3Client.getObject(
 							any(GetObjectRequest.class), any(AsyncResponseTransformer.class)))
 							.thenReturn(CompletableFuture.completedFuture(
 											new ResponseInputStream<>(getResponse, new ByteArrayInputStream(content))));
@@ -245,7 +253,9 @@ public class S3AwsStorageDriverTest {
 			drv.invokeNio((Operation<Item>) (Operation<?>) op);
 
 			final ArgumentCaptor<GetObjectRequest> request = ArgumentCaptor.forClass(GetObjectRequest.class);
-			verify(mockS3Client).getObject(request.capture(), any(AsyncResponseTransformer.class));
+			verify(exactVersionS3Client).getObject(request.capture(), any(AsyncResponseTransformer.class));
+			verify(mockS3Client, never()).getObject(
+							any(GetObjectRequest.class), any(AsyncResponseTransformer.class));
 			assertEquals("folder/key~literal", request.getValue().key());
 			assertEquals("requested-version", request.getValue().versionId());
 			assertEquals("returned-version", op.returnedVersionId());
@@ -2907,6 +2917,7 @@ public class S3AwsStorageDriverTest {
 		@Test
 		void doClose_closesS3AsyncClientAndExecutors() throws Exception {
 			S3AsyncClient mockClient = mock(S3AsyncClient.class);
+			S3AsyncClient exactVersionClient = mock(S3AsyncClient.class);
 
 			// Mock parent class config requirements
 			Config driverConfig = mock(Config.class);
@@ -2941,13 +2952,14 @@ public class S3AwsStorageDriverTest {
 
 			// Create the driver so it initializes its executors
 			S3AwsStorageDriver<Item, Operation<Item>> driver = new S3AwsStorageDriver<>(
-							"step-1", mock(com.dell.spt.base.data.DataInput.class), config, false, 1, mockClient, 100 * 1024L, 8 * 1024 * 1024L);
+							"step-1", mock(com.dell.spt.base.data.DataInput.class), config, false, 1, mockClient, exactVersionClient, 100 * 1024L, 8 * 1024 * 1024L);
 
 			// Act: Call the close method on the driver
 			driver.close();
 
 			// Assert: Verify the S3 client was closed
 			verify(mockClient, times(1)).close();
+			verify(exactVersionClient, times(1)).close();
 
 			// Assert: Verify the thread pools were shut down
 			Field executorField = S3AwsStorageDriver.class.getDeclaredField("executor");

--- a/engine/extensions/storage-drivers/implementations/s3/src/main/java/com/dell/spt/storage/driver/coop/netty/http/s3/ListObjectsXmlHandler.java
+++ b/engine/extensions/storage-drivers/implementations/s3/src/main/java/com/dell/spt/storage/driver/coop/netty/http/s3/ListObjectsXmlHandler.java
@@ -17,7 +17,7 @@ final class ListObjectsXmlHandler extends DefaultHandler {
 		CONTENT, VERSION, DELETE_MARKER
 	}
 
-	private record PageEntry(String key, long size, EntryKind kind) {}
+	private record PageEntry(String key, long size, String versionId, EntryKind kind) {}
 
 	private final ListOperation<?> listOp;
 	private final boolean includeVersions;
@@ -32,8 +32,10 @@ final class ListObjectsXmlHandler extends DefaultHandler {
 	private EntryKind currentEntry;
 	private boolean currentKeySeen;
 	private boolean currentSizeSeen;
+	private boolean currentVersionIdSeen;
 	private String currentKey;
 	private long currentSize;
+	private String currentVersionId;
 	private boolean truncationSeen;
 	private boolean truncated;
 	private boolean nextContinuationTokenSeen;
@@ -125,6 +127,17 @@ final class ListObjectsXmlHandler extends DefaultHandler {
 				throw new SAXException("Duplicate Key in S3 LIST entry");
 			}
 			currentKeySeen = true;
+			activeScalar = qName;
+			break;
+		case S3Api.QNAME_VERSION_ID:
+			requireEntryChild(qName, parent);
+			if (!includeVersions || currentEntry == EntryKind.CONTENT) {
+				throw new SAXException("VersionId is invalid in a current-object LIST entry");
+			}
+			if (currentVersionIdSeen) {
+				throw new SAXException("Duplicate VersionId in S3 LIST entry");
+			}
+			currentVersionIdSeen = true;
 			activeScalar = qName;
 			break;
 		case S3Api.QNAME_ITEM_SIZE:
@@ -233,8 +246,10 @@ final class ListObjectsXmlHandler extends DefaultHandler {
 		currentEntry = kind;
 		currentKeySeen = false;
 		currentSizeSeen = false;
+		currentVersionIdSeen = false;
 		currentKey = null;
 		currentSize = 0;
+		currentVersionId = null;
 	}
 
 	@Override
@@ -254,6 +269,9 @@ final class ListObjectsXmlHandler extends DefaultHandler {
 			break;
 		case S3Api.QNAME_ITEM_SIZE:
 			currentSize = parseSize(grammarValue());
+			break;
+		case S3Api.QNAME_VERSION_ID:
+			currentVersionId = exactValue();
 			break;
 		case S3Api.QNAME_IS_TRUNCATED:
 			truncated = parseBoolean(grammarValue());
@@ -303,7 +321,11 @@ final class ListObjectsXmlHandler extends DefaultHandler {
 		if (currentEntry != EntryKind.DELETE_MARKER && !currentSizeSeen) {
 			throw new SAXException("S3 LIST entry is missing Size for key \"" + currentKey + "\"");
 		}
-		pageEntries.add(new PageEntry(currentKey, currentSize, currentEntry));
+		if (currentEntry != EntryKind.CONTENT
+						&& (!currentVersionIdSeen || currentVersionId == null || currentVersionId.isEmpty())) {
+			throw new SAXException("S3 version LIST entry is missing a nonempty VersionId");
+		}
+		pageEntries.add(new PageEntry(currentKey, currentSize, currentVersionId, currentEntry));
 		currentEntry = null;
 	}
 
@@ -335,6 +357,7 @@ final class ListObjectsXmlHandler extends DefaultHandler {
 
 	private void commitPage() throws SAXException {
 		final List<ListedObject> listedObjects = new ArrayList<>();
+		int deleteMarkers = 0;
 		String firstKey = null;
 		String lastKey = null;
 		long bytesTotal = 0;
@@ -343,8 +366,10 @@ final class ListObjectsXmlHandler extends DefaultHandler {
 				firstKey = entry.key();
 			}
 			lastKey = entry.key();
-			if (entry.kind() != EntryKind.DELETE_MARKER) {
-				listedObjects.add(new ListedObject(entry.key(), entry.size()));
+			if (entry.kind() == EntryKind.DELETE_MARKER) {
+				deleteMarkers++;
+			} else {
+				listedObjects.add(new ListedObject(entry.key(), entry.size(), entry.versionId()));
 				if (fetchMetadata) {
 					try {
 						bytesTotal = Math.addExact(bytesTotal, entry.size());
@@ -356,6 +381,7 @@ final class ListObjectsXmlHandler extends DefaultHandler {
 		}
 		listOp.objectsListed(pageEntries.size());
 		listOp.listedObjects(List.copyOf(listedObjects));
+		listOp.deleteMarkersListed(deleteMarkers);
 		listOp.bytesListed(fetchMetadata ? bytesTotal : 0);
 		listOp.truncated(truncated);
 		if (firstKey != null) {

--- a/engine/extensions/storage-drivers/implementations/s3/src/test/java/com/dell/spt/storage/driver/coop/netty/http/s3/ListObjectsXmlHandlerTest.java
+++ b/engine/extensions/storage-drivers/implementations/s3/src/test/java/com/dell/spt/storage/driver/coop/netty/http/s3/ListObjectsXmlHandlerTest.java
@@ -58,6 +58,32 @@ final class ListObjectsXmlHandlerTest {
 		assertEquals("version-marker", op.options().versionIdMarker());
 		assertEquals(1, op.listedObjects().size());
 		assertEquals("a.txt", op.listedObjects().get(0).key());
+		assertEquals("version-1", op.listedObjects().get(0).versionId());
+		assertEquals(1, op.deleteMarkersListed());
+	}
+
+	@Test
+	void preservesLiteralNullVersionAndRejectsMissingVersionIds() throws Exception {
+		final var valid = newOperation(true);
+		parse(
+						"<ListVersionsResult><IsTruncated>false</IsTruncated>"
+										+ "<Version><Key>k</Key><VersionId>null</VersionId><Size>1</Size></Version>"
+										+ "</ListVersionsResult>",
+						valid,
+						true);
+		assertEquals("null", valid.listedObjects().get(0).versionId());
+
+		for (final String entry : List.of(
+						"<Version><Key>k</Key><Size>1</Size></Version>",
+						"<DeleteMarker><Key>k</Key></DeleteMarker>",
+						"<Version><Key>k</Key><VersionId></VersionId><Size>1</Size></Version>")) {
+			final var invalid = newOperation(true);
+			final String xml = "<ListVersionsResult><IsTruncated>false</IsTruncated>"
+							+ entry + "</ListVersionsResult>";
+			assertThrows(Exception.class, () -> parse(xml, invalid, true), xml);
+			assertEquals(0, invalid.objectsListed(), xml);
+			assertTrue(invalid.listedObjects().isEmpty(), xml);
+		}
 	}
 
 	@Test
@@ -149,8 +175,8 @@ final class ListObjectsXmlHandlerTest {
 
 	private static final String LIST_VERSIONS_RESPONSE = "<ListVersionsResult>" +
 					"<IsTruncated>true</IsTruncated>" +
-					"<Version><Key>a.txt</Key><Size>42</Size></Version>" +
-					"<DeleteMarker><Key>a.txt</Key></DeleteMarker>" +
+					"<Version><Key>a.txt</Key><VersionId>version-1</VersionId><Size>42</Size></Version>" +
+					"<DeleteMarker><Key>a.txt</Key><VersionId>marker-1</VersionId></DeleteMarker>" +
 					"<NextKeyMarker>key-marker</NextKeyMarker>" +
 					"<NextVersionIdMarker>version-marker</NextVersionIdMarker>" +
 					"</ListVersionsResult>";

--- a/engine/extensions/storage-drivers/implementations/s3/src/test/java/com/dell/spt/storage/driver/coop/netty/http/s3/S3StorageDriverTest.java
+++ b/engine/extensions/storage-drivers/implementations/s3/src/test/java/com/dell/spt/storage/driver/coop/netty/http/s3/S3StorageDriverTest.java
@@ -9,12 +9,16 @@ import com.dell.spt.base.item.Item;
 import com.dell.spt.base.item.ItemFactory;
 import com.dell.spt.base.item.ItemFactoryImpl;
 import com.dell.spt.base.item.ItemImpl;
+import com.dell.spt.base.item.io.IntegrityManifestItemInput;
+import com.dell.spt.base.item.io.IntegrityOperationManifestOutput;
 import com.dell.spt.base.item.io.TerminalItemInputException;
 import com.dell.spt.base.item.op.OpType;
 import com.dell.spt.base.item.op.Operation;
 import com.dell.spt.base.item.op.OperationImpl;
 import com.dell.spt.base.item.op.data.DataOperationImpl;
 import com.dell.spt.base.item.op.list.ListOperation;
+import com.dell.spt.base.item.op.list.ListOperationImpl;
+import com.dell.spt.base.item.op.list.ListedObject;
 import com.dell.spt.base.item.op.path.PathOperation;
 import com.dell.spt.base.item.op.path.PathOperationsBuilderImpl;
 import com.dell.spt.base.storage.Credential;
@@ -53,6 +57,7 @@ import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.appender.AbstractAppender;
 import org.apache.logging.log4j.core.config.Property;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mockito;
 
 import java.io.IOException;
@@ -61,6 +66,7 @@ import java.lang.reflect.Method;
 import java.net.ConnectException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
 import java.util.Base64;
 import java.util.ArrayDeque;
 import java.util.AbstractList;
@@ -90,6 +96,9 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.CALLS_REAL_METHODS;
 
 public class S3StorageDriverTest {
+
+	@TempDir
+	Path tempDir;
 
 	private S3StorageDriver<Item, Operation<Item>> newDriverMock() {
 		// Create a mock that calls real methods; constructor is not invoked
@@ -2183,6 +2192,30 @@ public class S3StorageDriverTest {
 						"/bucket/prefix/key~literal?versionId=version%2Fwith%2Bchars", request.uri());
 		assertEquals("prefix/key~literal", item.name());
 		assertNull(request.headers().get("x-amz-version-id"));
+	}
+
+	@Test
+	void suspendedBucketNullVersionSurvivesManifestRoundTripIntoGetQuery() throws Exception {
+		final Path manifest = tempDir.resolve("verify-input.csv");
+		final var listOp = new ListOperationImpl<PathItemImpl>(
+						0, OpType.LIST, new PathItemImpl("prefix"), Credential.NONE);
+		listOp.listedObjects(List.of(new ListedObject("prefix/key", 3, "null")));
+		try (final var output = new IntegrityOperationManifestOutput<>(
+						manifest, "/bucket", OpType.LIST)) {
+			output.put(listOp);
+		}
+
+		final IntegrityManifestDataItem item;
+		try (final var input = new IntegrityManifestItemInput(manifest)) {
+			item = input.get();
+		}
+		final Operation<Item> op = new OperationImpl<>(
+						1, OpType.READ, item, null, null, TEST_CRED);
+		assertEquals("null", op.requestedVersionId());
+
+		final var driver = new TestS3Driver(metadataConfig(false));
+		final HttpRequest request = driver.httpRequest(op, "s3.us-east-1.amazonaws.com:443");
+		assertEquals("/bucket/prefix/key?versionId=null", request.uri());
 	}
 
 	@Test

--- a/engine/gradle/libs.versions.toml
+++ b/engine/gradle/libs.versions.toml
@@ -160,6 +160,7 @@ aws-sdk-core = { module = "software.amazon.awssdk:sdk-core", version.ref = "awsS
 aws-utils = { module = "software.amazon.awssdk:utils", version.ref = "awsSdk" }
 aws-profiles = { module = "software.amazon.awssdk:profiles", version.ref = "awsSdk" }
 aws-crt = { module = "software.amazon.awssdk.crt:aws-crt", version.ref = "awsCrt" }
+aws-crt-client = { module = "software.amazon.awssdk:aws-crt-client", version.ref = "awsSdk" }
 
 # Bouncy Castle
 bouncycastle-bcprov-jdk18on = { module = "org.bouncycastle:bcprov-jdk18on", version.ref = "bouncycastle" }


### PR DESCRIPTION
## Summary

- add `read-verify --versions=current|all`, preserving the existing current-version default
- discover exact `(bucket,key,version_id)` identities across every `ListObjectVersions` page with both Netty and AWS drivers
- exclude and account for delete markers in schema-v2 completion evidence and result summaries
- fail closed on incomplete or failed LIST discovery before publishing or promoting verification manifests
- add a reusable local and distributed qualification harness plus user documentation and CHANGELOG entries
