### PR TITLE
fix recycled read working-set circulation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Fixed
+
+- **Recycled read working-set coverage** — Route completed operations back through the shared generator so low-concurrency duration reads circulate through the complete input manifest before repeating objects.
+
 ## [5.14.1] - 2026-08-11
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Changed
+
+- **Recycled read dispatch** — Disabled the low-concurrency fast-recycle bypass introduced in v5.7.0 because directly resubmitting the same in-flight operations could restrict a duration-based read to a working set equal to concurrency. Completed operations now return through shared generator circulation, trading some low-concurrency dispatch efficiency for complete manifest coverage.
+
 ### Fixed
 
-- **Recycled read working-set coverage** — Route completed operations back through the shared generator so low-concurrency duration reads circulate through the complete input manifest before repeating objects.
+- **Recycled read working-set coverage** — Low-concurrency duration reads now circulate through the complete input manifest before repeating objects.
 
 ## [5.14.1] - 2026-08-11
 

--- a/engine/core/spt-base/src/main/java/com/dell/spt/base/item/op/Operation.java
+++ b/engine/core/spt-base/src/main/java/com/dell/spt/base/item/op/Operation.java
@@ -111,14 +111,23 @@ public interface Operation<I extends Item> {
 	void resetTiming();
 
 	/**
-	 * Returns {@code true} if the storage driver has already recycled this operation
-	 * via the fast-recycle path (re-submitted directly without going through the
-	 * LoadGenerator recycle queue).  When set, {@code LoadStepContextImpl} must
-	 * skip calling {@code generator.recycle()} to avoid double-recycling.
+	 * Legacy compatibility accessor for the removed direct fast-recycle path.
+	 *
+	 * @deprecated always returns {@code false}
 	 */
-	boolean driverRecycled();
+	@Deprecated
+	default boolean driverRecycled() {
+		return false;
+	}
 
-	void driverRecycled(boolean flag);
+	/**
+	 * Legacy compatibility mutator for the removed direct fast-recycle path.
+	 *
+	 * @param flag ignored
+	 * @deprecated always a no-op
+	 */
+	@Deprecated
+	default void driverRecycled(final boolean flag) {}
 
 	/**
 	 * Number of times this operation has been retried after a failure via {@code
@@ -136,7 +145,7 @@ public interface Operation<I extends Item> {
 
 	/**
 	 * Reset the whole-operation retry counter, e.g. after a terminal success, so a
-	 * recycled/fast-recycled operation starts its next logical attempt with a clean budget
+	 * recycled operation starts its next logical attempt with a clean budget
 	 * instead of accumulating retry counts across unrelated cycles.
 	 */
 	default void resetOpRetryCount() {}

--- a/engine/core/spt-base/src/main/java/com/dell/spt/base/item/op/OperationImpl.java
+++ b/engine/core/spt-base/src/main/java/com/dell/spt/base/item/op/OperationImpl.java
@@ -25,7 +25,10 @@ public class OperationImpl<I extends Item> implements Operation<I> {
 	protected volatile long reqTimeDone;
 	protected volatile long respTimeStart;
 	protected volatile long respTimeDone;
-	/** @deprecated inert compatibility field for subclasses compiled against the removed fast-recycle path */
+	/**
+	 * @deprecated retained for binary compatibility only; SPT never reads this field and writes
+	 *             have no effect
+	 */
 	@Deprecated
 	protected volatile boolean driverRecycled;
 	protected volatile int opRetryCount;

--- a/engine/core/spt-base/src/main/java/com/dell/spt/base/item/op/OperationImpl.java
+++ b/engine/core/spt-base/src/main/java/com/dell/spt/base/item/op/OperationImpl.java
@@ -25,6 +25,8 @@ public class OperationImpl<I extends Item> implements Operation<I> {
 	protected volatile long reqTimeDone;
 	protected volatile long respTimeStart;
 	protected volatile long respTimeDone;
+	/** @deprecated inert compatibility field for subclasses compiled against the removed fast-recycle path */
+	@Deprecated
 	protected volatile boolean driverRecycled;
 	protected volatile int opRetryCount;
 	protected volatile String requestedVersionId;
@@ -95,7 +97,6 @@ public class OperationImpl<I extends Item> implements Operation<I> {
 		this.reqTimeDone = other.reqTimeDone;
 		this.respTimeStart = other.respTimeStart;
 		this.respTimeDone = other.respTimeDone;
-		this.driverRecycled = other.driverRecycled;
 		// Deliberately propagated (not reset in reset() below): this must survive across
 		// the reset()+redispatch cycle a retried operation goes through, or the retry
 		// counter added for load-op-retry could never reach its limit.
@@ -127,17 +128,6 @@ public class OperationImpl<I extends Item> implements Operation<I> {
 		returnedVersionId = null;
 		responseRequestId = null;
 		integrityVerificationResult = null;
-		driverRecycled = false;
-	}
-
-	@Override
-	public final boolean driverRecycled() {
-		return driverRecycled;
-	}
-
-	@Override
-	public final void driverRecycled(final boolean flag) {
-		this.driverRecycled = flag;
 	}
 
 	@Override

--- a/engine/core/spt-base/src/main/java/com/dell/spt/base/load/generator/LoadGenerator.java
+++ b/engine/core/spt-base/src/main/java/com/dell/spt/base/load/generator/LoadGenerator.java
@@ -76,12 +76,11 @@ public interface LoadGenerator<I extends Item, O extends Operation<I>> extends T
 	}
 
 	/**
-	 * Enable idle-task quiescing for fast-recycle workloads. When enabled, the
-	 * generator parks its task thread (instead of spin-waiting/yielding) when the recycle
-	 * queue is empty, because the driver is handling recycling inline.  The
-	 * {@link #recycle} method will unpark the task immediately if an op falls back
-	 * to the normal path.
+	 * Legacy compatibility hook for the removed direct fast-recycle path.
+	 *
+	 * @deprecated always a no-op; completed operations must return through {@link #recycle}
 	 */
+	@Deprecated
 	default void enableFastRecycleQuiesce() {}
 
 	/**

--- a/engine/core/spt-base/src/main/java/com/dell/spt/base/load/generator/LoadGeneratorImpl.java
+++ b/engine/core/spt-base/src/main/java/com/dell/spt/base/load/generator/LoadGeneratorImpl.java
@@ -32,7 +32,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.atomic.LongAdder;
 import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.LockSupport;
 import java.util.concurrent.locks.ReentrantLock;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.ThreadContext;
@@ -71,9 +70,6 @@ public class LoadGeneratorImpl<I extends Item, O extends Operation<I>> extends T
 	private final boolean shuffleFlag;
 	private final Random rnd;
 	private final String name;
-	private volatile boolean fastRecycleQuiesce = false;
-	private volatile boolean generatorParked = false;
-	private volatile Thread generatorThread;
 	private final ThreadLocal<CircularBuffer<O>> threadLocalOpBuff;
 	private final LongAdder builtTasksCounter = new LongAdder();
 	private final LongAdder recycledOpCounter = new LongAdder();
@@ -144,7 +140,6 @@ public class LoadGeneratorImpl<I extends Item, O extends Operation<I>> extends T
 	@Override
 	protected void doInit() {
 		ThreadContext.put(KEY_CLASS_NAME, CLS_NAME);
-		generatorThread = Thread.currentThread();
 	}
 
 	@Override
@@ -194,20 +189,9 @@ public class LoadGeneratorImpl<I extends Item, O extends Operation<I>> extends T
 							pendingOpCount += n;
 							recycledOpCounter.add(n);
 						} else {
-							// No recycled ops available right now.
-							if (fastRecycleQuiesce) {
-								// Fast-recycle is handling ops inline in the driver;
-								// park this task thread until recycle() unparks us or the
-								// timeout expires. 10ms keeps it idle
-								// while still bounding wake-up latency for fallback ops.
-								generatorParked = true;
-								LockSupport.parkNanos(10_000_000);
-								generatorParked = false;
-							} else {
-								// Yield the task thread so in-flight ops can complete
-								// without a timed parking syscall.
-								yieldThread();
-							}
+							// Yield so in-flight operations can complete and return through
+							// recycleQueue without imposing a timed parking syscall.
+							yieldThread();
 						}
 					}
 				} else {
@@ -453,21 +437,11 @@ public class LoadGeneratorImpl<I extends Item, O extends Operation<I>> extends T
 			recycleQueueFullState = true;
 			Loggers.ERR.warn("{}: recycle queue exceeded configured capacity ({})", name, recycleQueueCapacity);
 		}
-		// Wake the generator task if it's actually parked in the quiesce state.
-		// Checking generatorParked avoids spurious unpark() calls when the
-		// generator is running (e.g. at higher concurrency where fast-recycle
-		// doesn't handle all ops).
-		if (fastRecycleQuiesce && generatorParked) {
-			LockSupport.unpark(generatorThread);
-		}
 	}
 
 	@Override
 	public final void retry(final O op) {
 		retryQueue.add(op);
-		if (fastRecycleQuiesce && generatorParked) {
-			LockSupport.unpark(generatorThread);
-		}
 	}
 
 	/**
@@ -564,10 +538,8 @@ public class LoadGeneratorImpl<I extends Item, O extends Operation<I>> extends T
 	}
 
 	@Override
-	public void enableFastRecycleQuiesce() {
-		fastRecycleQuiesce = true;
-		Loggers.MSG.info("{}: fast-recycle quiesce enabled (generator task will park when idle)", name);
-	}
+	@Deprecated
+	public void enableFastRecycleQuiesce() {}
 
 	private boolean isFinished() {
 		// Never actually finish while a load-op-retry redispatch is still waiting to be

--- a/engine/core/spt-base/src/main/java/com/dell/spt/base/load/generator/LoadGeneratorImpl.java
+++ b/engine/core/spt-base/src/main/java/com/dell/spt/base/load/generator/LoadGeneratorImpl.java
@@ -537,10 +537,6 @@ public class LoadGeneratorImpl<I extends Item, O extends Operation<I>> extends T
 		return drained;
 	}
 
-	@Override
-	@Deprecated
-	public void enableFastRecycleQuiesce() {}
-
 	private boolean isFinished() {
 		// Never actually finish while a load-op-retry redispatch is still waiting to be
 		// drained - otherwise stop() below would tear this generator down before

--- a/engine/core/spt-base/src/main/java/com/dell/spt/base/load/step/local/context/LoadStepContextImpl.java
+++ b/engine/core/spt-base/src/main/java/com/dell/spt/base/load/step/local/context/LoadStepContextImpl.java
@@ -281,25 +281,6 @@ public class LoadStepContextImpl<I extends Item, O extends Operation<I>> extends
 							com.dell.spt.base.metrics.MetricsConstants.METADATA_LIST_SHARD_METRICS,
 							this.listShardMetricsRecorder);
 		}
-		// Enable fast-recycle on the driver when recycling simple data ops
-		// without content updates.  The threshold is the configured concurrency
-		// limit (or a cap of 8 for unlimited).  updateContents is excluded
-		// because the driver re-submits the original op directly and cannot
-		// safely mutate the shared DataItem offset concurrently with metrics.
-		if (this.recycleFlag && !this.updateContents && !this.listPathWorkload) {
-			final int driverConcurrency = this.driver.concurrencyLimit();
-			final int threshold = driverConcurrency > 0 ? Math.min(driverConcurrency, 8) : 8;
-			this.driver.enableFastRecycle(threshold);
-			// Only quiesce when the configured concurrency is low enough that
-			// fast-recycle handles most operations inline.  At higher concurrency
-			// (T8+), fast-recycle rarely fires and the generator/dispatch VTs
-			// need to stay responsive — yield is faster than park+unpark when
-			// ops flow through the recycleQueue continuously.
-			if (driverConcurrency > 0 && driverConcurrency <= 4) {
-				this.generator.enableFastRecycleQuiesce();
-				this.driver.enableFastRecycleQuiesce();
-			}
-		}
 	}
 
 	/** Resolve the MetricsContext for a given operation type (mixed-mode routing). */

--- a/engine/core/spt-base/src/main/java/com/dell/spt/base/load/step/local/context/LoadStepContextImpl.java
+++ b/engine/core/spt-base/src/main/java/com/dell/spt/base/load/step/local/context/LoadStepContextImpl.java
@@ -503,9 +503,9 @@ public class LoadStepContextImpl<I extends Item, O extends Operation<I>> extends
 		final Status status = opResult.status();
 		if (Status.SUCC.equals(status)) {
 			// A terminal success ends this operation's current retry episode - clear the
-			// counter now so a recycled/fast-recycled reuse of this object (read-recycle
-			// mode, or Netty's fast-recycle short-circuit) starts its next attempt with a
-			// clean budget instead of accumulating retry counts across unrelated cycles.
+			// counter now so a recycled reuse of this object (read-recycle mode) starts its
+			// next attempt with a clean budget instead of accumulating retry counts across
+			// unrelated cycles.
 			opResult.resetOpRetryCount();
 			final long reqDuration = opResult.duration();
 			final long respLatency = opResult.latency();
@@ -553,12 +553,7 @@ public class LoadStepContextImpl<I extends Item, O extends Operation<I>> extends
 						// TODO: possible change: remove dataItem.offset() to improve perf and increase variability
 						dataItem.offset(dataItem.offset() + rand.get().nextLong());
 					}
-					// Skip generator.recycle() when the driver already re-submitted the
-					// original op via the fast-recycle path — calling recycle here would
-					// create a duplicate in-flight operation.
-					if (!opResult.driverRecycled()) {
-						generator.recycle(opResult);
-					}
+					generator.recycle(opResult);
 				}
 
 				// each recycled op's lat and dur should be written to file each time
@@ -675,9 +670,7 @@ public class LoadStepContextImpl<I extends Item, O extends Operation<I>> extends
 								listShardMetricsRecorder.onRequeue(shardRef);
 							}
 						}
-						if (!opResult.driverRecycled()) {
-							generator.recycle(opResult);
-						}
+						generator.recycle(opResult);
 					}
 
 					// each recycled op's lat and dur should be written to file each time

--- a/engine/core/spt-base/src/main/java/com/dell/spt/base/storage/driver/StorageDriver.java
+++ b/engine/core/spt-base/src/main/java/com/dell/spt/base/storage/driver/StorageDriver.java
@@ -88,29 +88,22 @@ public interface StorageDriver<I extends Item, O extends Operation<I>>
 	void adjustIoBuffers(final long avgTransferSize, final OpType opType);
 
 	/**
-	 * Enable the fast-recycle dispatch path.  When active and the current
-	 * active-op count is at or below {@code concurrencyThreshold}, the driver
-	 * will re-submit a successfully completed simple operation directly on the
-	 * I/O thread instead of returning it through the LoadGenerator recycle queue.
-	 * <p>
-	 * The default implementation is a no-op; subclasses that support the
-	 * optimisation (e.g. Netty-based drivers) override this.
+	 * Legacy compatibility hook. Direct driver resubmission bypasses the shared
+	 * generator and can prevent undispatched input items from entering circulation,
+	 * so this method no longer enables an optimization.
 	 *
-	 * @param concurrencyThreshold maximum active-op count at which the
-	 *                             fast-recycle path is used (0 = disabled)
+	 * @param concurrencyThreshold ignored
+	 * @deprecated always a no-op; completed operations must return through the load generator
 	 */
+	@Deprecated
 	default void enableFastRecycle(final int concurrencyThreshold) {}
 
 	/**
-	 * Signal that the fast-recycle path is expected to handle most operations
-	 * and the dispatch/generator VTs may quiesce (park on long waits).  Only
-	 * called when the configured concurrency is low enough that fast-recycle
-	 * dominates; at higher concurrency the normal pipeline needs to stay
-	 * responsive.
-	 * <p>
-	 * Default is a no-op; cooperative drivers override to inform their
-	 * dispatch task.
+	 * Legacy compatibility hook for the removed direct fast-recycle path.
+	 *
+	 * @deprecated always a no-op; generator and dispatch tasks retain their normal lifecycle
 	 */
+	@Deprecated
 	default void enableFastRecycleQuiesce() {}
 
 	@Override

--- a/engine/core/spt-base/src/test/java/com/dell/spt/base/item/op/OperationImplTest.java
+++ b/engine/core/spt-base/src/test/java/com/dell/spt/base/item/op/OperationImplTest.java
@@ -142,36 +142,4 @@ class OperationImplTest {
 						"latency must not be epoch-scale in normal lifecycle");
 	}
 
-	// ---------- driverRecycled flag tests ----------
-
-	@Test
-	void driverRecycled_defaultIsFalse() {
-		final var op = new OperationImpl<>(0, OpType.READ, new ItemImpl("item"), null, null, null);
-		assertFalse(op.driverRecycled(), "driverRecycled should default to false");
-	}
-
-	@Test
-	void driverRecycled_setAndGet() {
-		final var op = new OperationImpl<>(0, OpType.READ, new ItemImpl("item"), null, null, null);
-		op.driverRecycled(true);
-		assertTrue(op.driverRecycled(), "driverRecycled should be true after setting");
-		op.driverRecycled(false);
-		assertFalse(op.driverRecycled(), "driverRecycled should be false after clearing");
-	}
-
-	@Test
-	void driverRecycled_copiedByResult() {
-		final var op = new OperationImpl<>(0, OpType.READ, new ItemImpl("item"), null, "/path", null);
-		op.driverRecycled(true);
-		final var copy = op.result();
-		assertTrue(copy.driverRecycled(), "driverRecycled should be preserved in result copy");
-	}
-
-	@Test
-	void driverRecycled_clearedByReset() {
-		final var op = new OperationImpl<>(0, OpType.READ, new ItemImpl("item"), null, "/path", null);
-		op.driverRecycled(true);
-		op.reset();
-		assertFalse(op.driverRecycled(), "driverRecycled should be cleared by reset()");
-	}
 }

--- a/engine/core/spt-base/src/test/java/com/dell/spt/base/item/op/OperationResultCopyTest.java
+++ b/engine/core/spt-base/src/test/java/com/dell/spt/base/item/op/OperationResultCopyTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Tests that {@link OperationImpl#result()} produces a truly independent copy
- * whose timing, status, and flag fields survive mutation of the original.
+ * whose timing and status fields survive mutation of the original.
  * These guarantees are critical because the completion path calls
  * {@code op.result()} to snapshot metrics, then the original op may be
  * recycled/reset/re-submitted.
@@ -67,33 +67,9 @@ class OperationResultCopyTest {
 	}
 
 	@Test
-	void resultCopy_preservesDriverRecycledFlag() {
-		final var op = newTimedOp();
-		op.driverRecycled(true);
-		op.finishResponse();
-
-		final var copy = op.result();
-
-		assertTrue(copy.driverRecycled(),
-						"driverRecycled flag must be preserved in the copy");
-	}
-
-	@Test
-	void resultCopy_driverRecycledDefaultsFalse() {
-		final var op = newTimedOp();
-		op.finishResponse();
-
-		final var copy = op.result();
-
-		assertFalse(copy.driverRecycled(),
-						"driverRecycled should default to false in the copy");
-	}
-
-	@Test
 	void resetAfterResultCopy_doesNotAffectCopy() {
 		final var op = newTimedOp();
 		op.finishResponse();
-		op.driverRecycled(true);
 
 		final long origDuration = op.duration();
 		final long origReqTimeStart = op.reqTimeStart();
@@ -108,16 +84,12 @@ class OperationResultCopyTest {
 						"copy duration must survive original reset");
 		assertEquals(origReqTimeStart, copy.reqTimeStart(),
 						"copy reqTimeStart must survive original reset");
-		assertTrue(copy.driverRecycled(),
-						"copy driverRecycled must survive original reset");
 
 		// Verify original was actually reset
 		assertEquals(Operation.Status.PENDING, op.status(),
 						"original should be PENDING after reset");
 		assertEquals(0, op.reqTimeStart(),
 						"original timing should be zeroed after reset");
-		assertFalse(op.driverRecycled(),
-						"original driverRecycled should be false after reset");
 	}
 
 	@Test
@@ -226,8 +198,8 @@ class OperationResultCopyTest {
 
 	@Test
 	void resetOpRetryCount_zeroesTheCounter() {
-		// Finding: without an explicit reset hook, a recycled (read-loop or Netty
-		// fast-recycle) operation that failed and retried once before eventually succeeding
+		// Finding: without an explicit reset hook, a recycled read-loop operation that failed
+		// and retried once before eventually succeeding
 		// would keep an elevated opRetryCount forever across every future successful cycle,
 		// eventually exhausting its retry budget from unrelated, non-consecutive failures.
 		final var op = newTimedOp();

--- a/engine/core/spt-base/src/test/java/com/dell/spt/base/load/generator/LoadGeneratorImplRecycleTest.java
+++ b/engine/core/spt-base/src/test/java/com/dell/spt/base/load/generator/LoadGeneratorImplRecycleTest.java
@@ -17,6 +17,7 @@ import com.dell.spt.base.storage.driver.ListOptions;
 import com.dell.spt.base.storage.driver.StorageDriver;
 import com.github.akurilov.commons.io.Input;
 import com.github.akurilov.commons.io.Output;
+import java.io.EOFException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -143,6 +144,68 @@ class LoadGeneratorImplRecycleTest {
 			assertSame(ops.get(i), output.received.get(i));
 		}
 		assertEquals(BATCH_SIZE, generator.generatedOpCount());
+	}
+
+	@Test
+	void initialManifestCirculatesCompletelyBeforeAnyRecycledOperation() throws Exception {
+		final int itemCount = 10;
+		final List<DataItem> sourceItems = new ArrayList<>();
+		for (int i = 0; i < itemCount; i++) {
+			sourceItems.add(new DataItemImpl("manifest-" + i, 0, 1024));
+		}
+		final AtomicInteger nextItem = new AtomicInteger();
+		doAnswer(invocation -> {
+			@SuppressWarnings("unchecked")
+			final List<DataItem> buffer = invocation.getArgument(0);
+			final int limit = invocation.getArgument(1);
+			final int from = nextItem.get();
+			if (from >= sourceItems.size()) {
+				throw new EOFException("end of manifest");
+			}
+			final int to = Math.min(from + limit, sourceItems.size());
+			buffer.addAll(sourceItems.subList(from, to));
+			nextItem.set(to);
+			return to - from;
+		}).when(itemInput).get(anyList(), anyInt());
+		doAnswer(invocation -> {
+			@SuppressWarnings("unchecked")
+			final List<DataItem> items = invocation.getArgument(0);
+			@SuppressWarnings("unchecked")
+			final List<DataOperation<DataItem>> operations = invocation.getArgument(1);
+			for (final DataItem item : items) {
+				operations.add(newOp(item.name()));
+			}
+			return null;
+		}).when(opsBuilder).buildOps(anyList(), anyList());
+
+		final LoadGeneratorImpl<DataItem, DataOperation<DataItem>> circulatingGenerator = new LoadGeneratorImpl<>(
+						itemInput, opsBuilder, List.of(), output, BATCH_SIZE,
+						0, 1000, true, false);
+		try {
+			for (int batch = 0; batch < 3; batch++) {
+				final int from = output.received.size();
+				circulatingGenerator.doWork();
+				final int to = output.received.size();
+				for (int i = from; i < to; i++) {
+					circulatingGenerator.recycle(output.received.get(i));
+				}
+			}
+			assertEquals(itemCount, output.received.size());
+			assertEquals(
+							sourceItems.stream().map(DataItem::name).toList(),
+							output.received.stream().map(op -> op.item().name()).toList());
+
+			circulatingGenerator.doWork();
+			assertTrue(circulatingGenerator.isItemInputFinished());
+			circulatingGenerator.doWork();
+			assertEquals(itemCount + BATCH_SIZE, output.received.size());
+			assertEquals(
+							List.of("manifest-0", "manifest-1", "manifest-2", "manifest-3"),
+							output.received.subList(itemCount, itemCount + BATCH_SIZE)
+											.stream().map(op -> op.item().name()).toList());
+		} finally {
+			circulatingGenerator.close();
+		}
 	}
 
 	/**

--- a/engine/core/spt-base/src/test/java/com/dell/spt/base/load/generator/LoadGeneratorImplRecycleTest.java
+++ b/engine/core/spt-base/src/test/java/com/dell/spt/base/load/generator/LoadGeneratorImplRecycleTest.java
@@ -17,7 +17,6 @@ import com.dell.spt.base.storage.driver.ListOptions;
 import com.dell.spt.base.storage.driver.StorageDriver;
 import com.github.akurilov.commons.io.Input;
 import com.github.akurilov.commons.io.Output;
-import java.io.EOFException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -33,7 +32,7 @@ import org.junit.jupiter.api.Test;
  * Characterization tests for the recycle-poll path in {@link LoadGeneratorImpl#doWork()}.
  * <p>
  * These tests document the current behavior of the spin-wait, yield, and output
- * logic in the recycle branch, plus the fast-recycle quiesce behavior (park/unpark).
+ * logic in the shared recycle-queue branch.
  */
 @SuppressWarnings("unchecked")
 class LoadGeneratorImplRecycleTest {
@@ -146,78 +145,6 @@ class LoadGeneratorImplRecycleTest {
 		assertEquals(BATCH_SIZE, generator.generatedOpCount());
 	}
 
-	@Test
-	void initialManifestCirculatesCompletelyBeforeAnyRecycledOperation() throws Exception {
-		final int itemCount = 10;
-		final List<DataItem> sourceItems = new ArrayList<>();
-		for (int i = 0; i < itemCount; i++) {
-			sourceItems.add(new DataItemImpl("manifest-" + i, 0, 1024));
-		}
-		final AtomicInteger nextItem = new AtomicInteger();
-		doAnswer(invocation -> {
-			@SuppressWarnings("unchecked")
-			final List<DataItem> buffer = invocation.getArgument(0);
-			final int limit = invocation.getArgument(1);
-			final int from = nextItem.get();
-			if (from >= sourceItems.size()) {
-				throw new EOFException("end of manifest");
-			}
-			final int to = Math.min(from + limit, sourceItems.size());
-			buffer.addAll(sourceItems.subList(from, to));
-			nextItem.set(to);
-			return to - from;
-		}).when(itemInput).get(anyList(), anyInt());
-		doAnswer(invocation -> {
-			@SuppressWarnings("unchecked")
-			final List<DataItem> items = invocation.getArgument(0);
-			@SuppressWarnings("unchecked")
-			final List<DataOperation<DataItem>> operations = invocation.getArgument(1);
-			for (final DataItem item : items) {
-				operations.add(newOp(item.name()));
-			}
-			return null;
-		}).when(opsBuilder).buildOps(anyList(), anyList());
-
-		final LoadGeneratorImpl<DataItem, DataOperation<DataItem>> circulatingGenerator = new LoadGeneratorImpl<>(
-						itemInput, opsBuilder, List.of(), output, BATCH_SIZE,
-						0, 1000, true, false);
-		try {
-			for (int batch = 0; batch < 3; batch++) {
-				final int from = output.received.size();
-				circulatingGenerator.doWork();
-				final int to = output.received.size();
-				for (int i = from; i < to; i++) {
-					circulatingGenerator.recycle(output.received.get(i));
-				}
-			}
-			assertEquals(itemCount, output.received.size());
-			assertEquals(
-							sourceItems.stream().map(DataItem::name).toList(),
-							output.received.stream().map(op -> op.item().name()).toList());
-
-			circulatingGenerator.doWork();
-			assertTrue(circulatingGenerator.isItemInputFinished());
-			final List<String> expectedNames = sourceItems.stream().map(DataItem::name).toList();
-			for (int cycle = 0; cycle < 2; cycle++) {
-				final int from = output.received.size();
-				for (int batch = 0; batch < 3; batch++) {
-					circulatingGenerator.doWork();
-				}
-				final int to = output.received.size();
-				assertEquals(itemCount, to - from);
-				assertEquals(
-								expectedNames,
-								output.received.subList(from, to)
-												.stream().map(op -> op.item().name()).toList());
-				for (int i = from; i < to; i++) {
-					circulatingGenerator.recycle(output.received.get(i));
-				}
-			}
-		} finally {
-			circulatingGenerator.close();
-		}
-	}
-
 	/**
 	 * Start the generator VT loop, recycle ops from the test thread,
 	 * and verify all ops eventually reach the output.
@@ -285,125 +212,6 @@ class LoadGeneratorImplRecycleTest {
 		assertTrue(generator.isNothingToRecycle());
 		assertEquals(3, generator.generatedOpCount());
 		assertEquals(3, output.received.size());
-	}
-
-	// --- fast-recycle quiesce tests ---
-
-	/**
-	 * With quiesce enabled and empty recycle queue, doWork() parks for up to 10ms
-	 * instead of yielding.  Verify it returns within a bounded time.
-	 */
-	@Test
-	void quiesceParksOnEmptyRecycleQueue() throws Exception {
-		generator.enableFastRecycleQuiesce();
-		// Exhaust item input
-		generator.doWork();
-		assertTrue(generator.isItemInputFinished());
-
-		// doWork with quiesce + empty queue parks for up to 10ms
-		final long start = System.nanoTime();
-		generator.doWork();
-		final long elapsedMs = (System.nanoTime() - start) / 1_000_000;
-
-		// Should park for ~10ms (timeout), bounded well under 100ms
-		assertTrue(elapsedMs < 100, "doWork took " + elapsedMs + "ms; expected < 100ms");
-		assertEquals(0, output.received.size());
-	}
-
-	/**
-	 * With quiesce enabled, recycle() unparks the generator VT so it picks
-	 * up the op quickly rather than waiting the full 10ms timeout.
-	 */
-	@Test
-	void recycleUnparksQuiescedGenerator() throws Exception {
-		final int opCount = 10;
-		final ConcurrentCollectingOutput<DataOperation<DataItem>> concurrentOutput = new ConcurrentCollectingOutput<>(opCount);
-
-		final LoadGeneratorImpl<DataItem, DataOperation<DataItem>> quiescedGen = new LoadGeneratorImpl<>(
-						itemInput,
-						opsBuilder,
-						List.of(),
-						concurrentOutput,
-						BATCH_SIZE,
-						0,
-						1000,
-						true,
-						false);
-		quiescedGen.enableFastRecycleQuiesce();
-
-		try {
-			quiescedGen.start();
-			assertEventually(quiescedGen::isItemInputFinished, 2000);
-
-			// Recycle ops with slight spacing to exercise the unpark path
-			final long t0 = System.nanoTime();
-			for (int i = 0; i < opCount; i++) {
-				quiescedGen.recycle(newOp("quiesce-" + i));
-				Thread.sleep(1);
-			}
-
-			// All ops should arrive well under 10ms * opCount since unpark wakes
-			// the generator immediately for each one
-			assertTrue(
-							concurrentOutput.latch.await(5, TimeUnit.SECONDS),
-							"Expected " + opCount + " ops but got " + concurrentOutput.received.size());
-			final long elapsedMs = (System.nanoTime() - t0) / 1_000_000;
-			assertTrue(
-							elapsedMs < 2000,
-							"Took " + elapsedMs + "ms for " + opCount + " ops; unpark may not be working");
-			assertEquals(opCount, concurrentOutput.received.size());
-		} finally {
-			quiescedGen.stop();
-			quiescedGen.await(5, TimeUnit.SECONDS);
-			quiescedGen.close();
-		}
-	}
-
-	/**
-	 * Without quiesce, the existing yield path is used (characterization of
-	 * the non-quiesce path when fast-recycle is not enabled).
-	 */
-	@Test
-	void nonQuiesceUsesYieldPath() throws Exception {
-		// quiesce NOT enabled — default
-		generator.doWork(); // exhaust item input
-
-		// doWork with empty queue should return very quickly (yield, not 10ms park)
-		final long start = System.nanoTime();
-		generator.doWork();
-		final long elapsedMs = (System.nanoTime() - start) / 1_000_000;
-
-		// Yield returns in microseconds, not milliseconds
-		assertTrue(elapsedMs < 5, "doWork took " + elapsedMs + "ms; yield should be sub-millisecond");
-	}
-
-	/**
-	 * Verify the generatorParked flag guards against spurious unpark calls.
-	 * When quiesce is enabled but the generator is NOT parked (e.g. actively
-	 * processing ops), recycle() should still enqueue ops and they should be
-	 * picked up via the normal polling path in doWork().
-	 */
-	@Test
-	void recycleWithQuiesceEnabledButGeneratorNotParked() throws Exception {
-		// Enable quiesce, but we'll call doWork() manually so the generator
-		// VT is never actually parked (doWork returns after one spin).
-		generator.enableFastRecycleQuiesce();
-		generator.doWork(); // exhaust item input
-
-		// generatorParked should be false since we're not in the park path
-		final var parkedField = LoadGeneratorImpl.class.getDeclaredField("generatorParked");
-		parkedField.setAccessible(true);
-		assertFalse(parkedField.getBoolean(generator),
-						"generatorParked should be false when not in park path");
-
-		// Recycle an op while the generator is not parked
-		final DataOperation<DataItem> op = newOp("not-parked-1");
-		generator.recycle(op);
-
-		// doWork should still pick up the op via polling
-		generator.doWork();
-		assertEquals(1, output.received.size());
-		assertSame(op, output.received.get(0));
 	}
 
 	@Test

--- a/engine/core/spt-base/src/test/java/com/dell/spt/base/load/generator/LoadGeneratorImplRecycleTest.java
+++ b/engine/core/spt-base/src/test/java/com/dell/spt/base/load/generator/LoadGeneratorImplRecycleTest.java
@@ -197,12 +197,22 @@ class LoadGeneratorImplRecycleTest {
 
 			circulatingGenerator.doWork();
 			assertTrue(circulatingGenerator.isItemInputFinished());
-			circulatingGenerator.doWork();
-			assertEquals(itemCount + BATCH_SIZE, output.received.size());
-			assertEquals(
-							List.of("manifest-0", "manifest-1", "manifest-2", "manifest-3"),
-							output.received.subList(itemCount, itemCount + BATCH_SIZE)
-											.stream().map(op -> op.item().name()).toList());
+			final List<String> expectedNames = sourceItems.stream().map(DataItem::name).toList();
+			for (int cycle = 0; cycle < 2; cycle++) {
+				final int from = output.received.size();
+				for (int batch = 0; batch < 3; batch++) {
+					circulatingGenerator.doWork();
+				}
+				final int to = output.received.size();
+				assertEquals(itemCount, to - from);
+				assertEquals(
+								expectedNames,
+								output.received.subList(from, to)
+												.stream().map(op -> op.item().name()).toList());
+				for (int i = from; i < to; i++) {
+					circulatingGenerator.recycle(output.received.get(i));
+				}
+			}
 		} finally {
 			circulatingGenerator.close();
 		}

--- a/engine/core/spt-base/src/test/java/com/dell/spt/base/load/step/local/context/LoadStepContextImplTest.java
+++ b/engine/core/spt-base/src/test/java/com/dell/spt/base/load/step/local/context/LoadStepContextImplTest.java
@@ -134,8 +134,10 @@ public class LoadStepContextImplTest {
 		Assertions.assertTrue(stepCtx.isDone());
 	}
 
-	@Test
-	public void recycleWorkloadUsesSharedGeneratorCirculation() {
+	@org.junit.jupiter.params.ParameterizedTest
+	@org.junit.jupiter.params.provider.ValueSource(ints = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10
+	})
+	public void recycleWorkloadUsesSharedGeneratorCirculation(final int concurrency) {
 		testConfig.val("load-op-retry", false);
 		testConfig.val("load-op-recycle-mode", true);
 
@@ -143,7 +145,7 @@ public class LoadStepContextImplTest {
 		final LoadGenerator<DataItem, Operation<DataItem>> generatorMock = mock(LoadGenerator.class);
 		@SuppressWarnings("unchecked")
 		final StorageDriver<DataItem, Operation<DataItem>> driverMock = mock(StorageDriver.class);
-		when(driverMock.concurrencyLimit()).thenReturn(4);
+		when(driverMock.concurrencyLimit()).thenReturn(concurrency);
 
 		new LoadStepContextImpl<>(
 						"recycle-through-generator", generatorMock, driverMock, null,

--- a/engine/core/spt-base/src/test/java/com/dell/spt/base/load/step/local/context/LoadStepContextImplTest.java
+++ b/engine/core/spt-base/src/test/java/com/dell/spt/base/load/step/local/context/LoadStepContextImplTest.java
@@ -66,6 +66,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.after;
 import static org.mockito.Mockito.doNothing;
@@ -131,6 +132,26 @@ public class LoadStepContextImplTest {
 		assertDoesNotThrow(() -> stepCtx.doClose());
 		assertDoesNotThrow(() -> stepCtx.doStop());
 		Assertions.assertTrue(stepCtx.isDone());
+	}
+
+	@Test
+	public void recycleWorkloadUsesSharedGeneratorCirculation() {
+		testConfig.val("load-op-retry", false);
+		testConfig.val("load-op-recycle-mode", true);
+
+		@SuppressWarnings("unchecked")
+		final LoadGenerator<DataItem, Operation<DataItem>> generatorMock = mock(LoadGenerator.class);
+		@SuppressWarnings("unchecked")
+		final StorageDriver<DataItem, Operation<DataItem>> driverMock = mock(StorageDriver.class);
+		when(driverMock.concurrencyLimit()).thenReturn(4);
+
+		new LoadStepContextImpl<>(
+						"recycle-through-generator", generatorMock, driverMock, null,
+						testConfig.configVal("load"), false);
+
+		verify(driverMock, never()).enableFastRecycle(anyInt());
+		verify(driverMock, never()).enableFastRecycleQuiesce();
+		verify(generatorMock, never()).enableFastRecycleQuiesce();
 	}
 
 	@Test

--- a/engine/core/spt-base/src/test/java/com/dell/spt/base/load/step/local/context/LoadStepContextImplTest.java
+++ b/engine/core/spt-base/src/test/java/com/dell/spt/base/load/step/local/context/LoadStepContextImplTest.java
@@ -66,7 +66,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.after;
 import static org.mockito.Mockito.doNothing;
@@ -132,28 +131,6 @@ public class LoadStepContextImplTest {
 		assertDoesNotThrow(() -> stepCtx.doClose());
 		assertDoesNotThrow(() -> stepCtx.doStop());
 		Assertions.assertTrue(stepCtx.isDone());
-	}
-
-	@org.junit.jupiter.params.ParameterizedTest
-	@org.junit.jupiter.params.provider.ValueSource(ints = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10
-	})
-	public void recycleWorkloadUsesSharedGeneratorCirculation(final int concurrency) {
-		testConfig.val("load-op-retry", false);
-		testConfig.val("load-op-recycle-mode", true);
-
-		@SuppressWarnings("unchecked")
-		final LoadGenerator<DataItem, Operation<DataItem>> generatorMock = mock(LoadGenerator.class);
-		@SuppressWarnings("unchecked")
-		final StorageDriver<DataItem, Operation<DataItem>> driverMock = mock(StorageDriver.class);
-		when(driverMock.concurrencyLimit()).thenReturn(concurrency);
-
-		new LoadStepContextImpl<>(
-						"recycle-through-generator", generatorMock, driverMock, null,
-						testConfig.configVal("load"), false);
-
-		verify(driverMock, never()).enableFastRecycle(anyInt());
-		verify(driverMock, never()).enableFastRecycleQuiesce();
-		verify(generatorMock, never()).enableFastRecycleQuiesce();
 	}
 
 	@Test

--- a/engine/core/spt-base/src/test/java/com/dell/spt/base/load/step/local/context/RecycleCirculationIntegrationTest.java
+++ b/engine/core/spt-base/src/test/java/com/dell/spt/base/load/step/local/context/RecycleCirculationIntegrationTest.java
@@ -1,0 +1,390 @@
+package com.dell.spt.base.load.step.local.context;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.dell.spt.base.concurrent.AsyncRunnableBase;
+import com.dell.spt.base.config.TestConfigBuilder;
+import com.dell.spt.base.item.DataItem;
+import com.dell.spt.base.item.DataItemImpl;
+import com.dell.spt.base.item.ItemFactory;
+import com.dell.spt.base.item.ItemType;
+import com.dell.spt.base.item.op.OpType;
+import com.dell.spt.base.item.op.Operation;
+import com.dell.spt.base.item.op.data.DataOperation;
+import com.dell.spt.base.load.generator.LoadGenerator;
+import com.dell.spt.base.load.generator.LoadGeneratorBuilder;
+import com.dell.spt.base.load.generator.LoadGeneratorBuilderImpl;
+import com.dell.spt.base.load.generator.LoadGeneratorImpl;
+import com.dell.spt.base.metrics.context.MetricsContext;
+import com.dell.spt.base.metrics.context.MetricsContextImpl;
+import com.dell.spt.base.metrics.snapshot.AllMetricsSnapshot;
+import com.dell.spt.base.storage.driver.ListOptions;
+import com.dell.spt.base.storage.driver.StorageDriver;
+import com.github.akurilov.commons.io.Input;
+import com.github.akurilov.commons.io.Output;
+import com.github.akurilov.commons.system.SizeInBytes;
+import com.github.akurilov.confuse.Config;
+import java.io.EOFException;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/** End-to-end in-process coverage for duration-style recycled workload circulation. */
+@SuppressWarnings({"deprecation", "unchecked"
+})
+class RecycleCirculationIntegrationTest {
+
+	private static final int MANIFEST_ITEM_COUNT = 50;
+	private static final int COMPLETION_COUNT = 200;
+	private static final long ITEM_SIZE = 64;
+	private static final int COMPLETION_TIMEOUT_SECONDS = 10;
+
+	/**
+	 * Proves the product invariant at every low-concurrency shape affected by the former
+	 * fast-recycle optimization: all manifest items enter circulation before any item is
+	 * repeated. The test driver models the old public fast-recycle contract so replaying
+	 * this test against v5.14.1 activates the broken direct-resubmission path and fails.
+	 */
+	@ParameterizedTest
+	@ValueSource(ints = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10
+	})
+	void completeManifestCirculatesBeforeAnyRepeat(final int concurrency) throws Exception {
+		final Config config = TestConfigBuilder.config();
+		config.val("item-type", "data");
+		config.val("item-data-ranges-concat", null);
+		config.val("load-op-type", "read");
+		config.val("load-op-retry", false);
+		config.val("load-op-recycle-mode", true);
+		config.val("load-op-recycle-content-update", false);
+		config.val("load-op-limit-count", COMPLETION_COUNT);
+		config.val("load-op-wait-finish", true);
+		config.val("load-op-wait-limit", COMPLETION_TIMEOUT_SECONDS);
+
+		final var itemInput = new ManifestItemInput(MANIFEST_ITEM_COUNT);
+		final var driver = new CirculationCanaryDriver(concurrency, COMPLETION_COUNT);
+		final ItemType itemType = ItemType.DATA;
+		final ItemFactory<DataItem> itemFactory = (ItemFactory<DataItem>) ItemType.getItemFactory(itemType);
+		final LoadGeneratorBuilder<DataItem, Operation<DataItem>, LoadGeneratorImpl<DataItem, Operation<DataItem>>> generatorBuilder = new LoadGeneratorBuilderImpl<DataItem, Operation<DataItem>, LoadGeneratorImpl<DataItem, Operation<DataItem>>>()
+						.itemConfig(config.configVal("item"))
+						.loadConfig(config.configVal("load"))
+						.itemType(itemType)
+						.itemFactory(itemFactory)
+						.itemInput(itemInput)
+						.loadOperationsOutput(driver)
+						.authConfig(config.configVal("storage").configVal("auth"))
+						.originIndex(0);
+		final LoadGenerator<DataItem, Operation<DataItem>> generator = generatorBuilder.build();
+		final MetricsContext<AllMetricsSnapshot> metrics = buildMetrics(concurrency);
+		final var stepContext = new LoadStepContextImpl<>(
+						"recycle-circulation-t" + concurrency,
+						generator,
+						driver,
+						metrics,
+						config.configVal("load"),
+						false);
+
+		stepContext.start();
+		try {
+			assertTrue(
+							driver.awaitCompletions(COMPLETION_TIMEOUT_SECONDS, TimeUnit.SECONDS),
+							"timed out after " + driver.completedOpCount() + " completions at T" + concurrency);
+
+			final List<String> observed = driver.observedItemNames();
+			assertEquals(COMPLETION_COUNT, observed.size());
+			assertEquals(
+							MANIFEST_ITEM_COUNT,
+							new HashSet<>(observed.subList(0, MANIFEST_ITEM_COUNT)).size(),
+							"an item repeated before the complete manifest entered circulation at T" + concurrency);
+
+			final Set<String> expectedNames = ManifestItemInput.expectedNames(MANIFEST_ITEM_COUNT);
+			assertEquals(expectedNames, new HashSet<>(observed), "the driver saw an unexpected or missing item");
+			final Map<String, Integer> counts = new HashMap<>();
+			observed.forEach(name -> counts.merge(name, 1, Integer::sum));
+			final int minCount = counts.values().stream().mapToInt(Integer::intValue).min().orElseThrow();
+			final int maxCount = counts.values().stream().mapToInt(Integer::intValue).max().orElseThrow();
+			assertTrue(
+							maxCount - minCount <= concurrency,
+							"circulation imbalance exceeds the in-flight boundary at T" + concurrency + ": " + counts);
+
+			assertEquals(COMPLETION_COUNT, driver.scheduledOpCount());
+			assertEquals(COMPLETION_COUNT, driver.completedOpCount());
+			assertEquals(0, driver.activeOpCount(), "all bounded concurrency permits must be released");
+		} finally {
+			stepContext.stop();
+			stepContext.shutdown();
+			stepContext.close();
+		}
+	}
+
+	private static MetricsContext<AllMetricsSnapshot> buildMetrics(final int concurrency) {
+		final MetricsContext<AllMetricsSnapshot> metrics = MetricsContextImpl.builder()
+						.loadStepId("recycle-circulation-t" + concurrency)
+						.opType(OpType.READ)
+						.actualConcurrencyGauge(() -> 0)
+						.concurrencyLimit(concurrency)
+						.concurrencyThreshold(0)
+						.itemDataSize(new SizeInBytes(ITEM_SIZE))
+						.outputPeriodSec(1)
+						.stdOutColorFlag(false)
+						.runId(0)
+						.build();
+		metrics.start();
+		return metrics;
+	}
+
+	private static final class ManifestItemInput implements Input<DataItem> {
+		private final int itemCount;
+		private int nextIndex;
+
+		ManifestItemInput(final int itemCount) {
+			this.itemCount = itemCount;
+		}
+
+		static Set<String> expectedNames(final int itemCount) {
+			final Set<String> names = new HashSet<>();
+			for (int i = 0; i < itemCount; i++) {
+				names.add(itemName(i));
+			}
+			return names;
+		}
+
+		private static String itemName(final int index) {
+			return String.format("manifest-item-%03d", index);
+		}
+
+		@Override
+		public DataItem get() {
+			return nextIndex < itemCount ? new DataItemImpl(itemName(nextIndex++), 0, ITEM_SIZE) : null;
+		}
+
+		@Override
+		public int get(final List<DataItem> buffer, final int limit) {
+			if (nextIndex >= itemCount) {
+				com.github.akurilov.commons.lang.Exceptions.throwUnchecked(new EOFException());
+			}
+			final int start = nextIndex;
+			while (nextIndex < itemCount && nextIndex - start < limit) {
+				buffer.add(new DataItemImpl(itemName(nextIndex++), 0, ITEM_SIZE));
+			}
+			return nextIndex - start;
+		}
+
+		@Override
+		public long skip(final long itemsCount) {
+			final long skipped = Math.min(itemsCount, itemCount - nextIndex);
+			nextIndex += (int) skipped;
+			return skipped;
+		}
+
+		@Override
+		public void reset() {
+			nextIndex = 0;
+		}
+
+		@Override
+		public void close() {}
+
+		@Override
+		public String toString() {
+			return "ManifestItemInput";
+		}
+	}
+
+	/** Protocol-free asynchronous driver with a bounded, observable concurrency contract. */
+	private static final class CirculationCanaryDriver extends AsyncRunnableBase
+					implements StorageDriver<DataItem, Operation<DataItem>> {
+		private final int concurrency;
+		private final int completionLimit;
+		private final Semaphore permits;
+		private final ExecutorService executor;
+		private final AtomicInteger scheduled = new AtomicInteger();
+		private final AtomicInteger completed = new AtomicInteger();
+		private final CountDownLatch completionLatch;
+		private final List<String> observedNames = new CopyOnWriteArrayList<>();
+		private volatile Output<Operation<DataItem>> resultOutput;
+		private volatile boolean legacyDirectRecycle;
+
+		CirculationCanaryDriver(final int concurrency, final int completionLimit) {
+			this.concurrency = concurrency;
+			this.completionLimit = completionLimit;
+			this.permits = new Semaphore(concurrency, true);
+			this.executor = Executors.newFixedThreadPool(concurrency);
+			this.completionLatch = new CountDownLatch(completionLimit);
+		}
+
+		@Override
+		public boolean put(final Operation<DataItem> op) {
+			if (!isStarted() || !permits.tryAcquire()) {
+				return false;
+			}
+			if (!claimCompletion()) {
+				permits.release();
+				return false;
+			}
+			recordDispatch(op);
+			executor.execute(() -> complete(op));
+			return true;
+		}
+
+		@Override
+		public int put(final List<Operation<DataItem>> ops, final int from, final int to) {
+			int i = from;
+			while (i < to && put(ops.get(i))) {
+				i++;
+			}
+			return i - from;
+		}
+
+		@Override
+		public int put(final List<Operation<DataItem>> ops) {
+			return put(ops, 0, ops.size());
+		}
+
+		private boolean claimCompletion() {
+			int current;
+			do {
+				current = scheduled.get();
+				if (current >= completionLimit) {
+					return false;
+				}
+			} while (!scheduled.compareAndSet(current, current + 1));
+			return true;
+		}
+
+		private void recordDispatch(final Operation<DataItem> op) {
+			final String itemName = op.item().name();
+			observedNames.add(itemName.startsWith("/") ? itemName.substring(1) : itemName);
+		}
+
+		private void complete(final Operation<DataItem> op) {
+			op.reset();
+			op.startRequest();
+			op.finishRequest();
+			op.startResponse();
+			if (op instanceof DataOperation<?> dataOperation) {
+				dataOperation.startDataResponse();
+				try {
+					dataOperation.countBytesDone(op.item().size());
+				} catch (final IOException e) {
+					throw new AssertionError(e);
+				}
+			}
+			op.finishResponse();
+			op.status(Operation.Status.SUCC);
+			completed.incrementAndGet();
+
+			if (legacyDirectRecycle) {
+				op.driverRecycled(true);
+				resultOutput.put(op.result());
+				if (claimCompletion()) {
+					recordDispatch(op);
+					executor.execute(() -> complete(op));
+				} else {
+					permits.release();
+				}
+			} else {
+				permits.release();
+				resultOutput.put(op.result());
+			}
+			completionLatch.countDown();
+		}
+
+		@Override
+		public void operationResultOutput(final Output<Operation<DataItem>> resultOutput) {
+			this.resultOutput = resultOutput;
+		}
+
+		@Override
+		public List<DataItem> list(
+						final ItemFactory<DataItem> itemFactory,
+						final String path,
+						final String prefix,
+						final int idRadix,
+						final DataItem lastPrevItem,
+						final int count) {
+			return List.of();
+		}
+
+		@Override
+		public List<DataItem> list(
+						final ItemFactory<DataItem> itemFactory,
+						final String path,
+						final String prefix,
+						final int idRadix,
+						final DataItem lastPrevItem,
+						final int count,
+						final ListOptions options) {
+			return List.of();
+		}
+
+		@Override
+		public Input<Operation<DataItem>> getInput() {
+			throw new AssertionError();
+		}
+
+		@Override
+		public int concurrencyLimit() {
+			return concurrency;
+		}
+
+		@Override
+		public int activeOpCount() {
+			return concurrency - permits.availablePermits();
+		}
+
+		@Override
+		public long scheduledOpCount() {
+			return scheduled.get();
+		}
+
+		@Override
+		public long completedOpCount() {
+			return completed.get();
+		}
+
+		@Override
+		public boolean isIdle() {
+			return activeOpCount() == 0;
+		}
+
+		@Override
+		public void adjustIoBuffers(final long avgTransferSize, final OpType opType) {}
+
+		@Override
+		public void enableFastRecycle(final int concurrencyThreshold) {
+			legacyDirectRecycle = concurrencyThreshold > 0;
+		}
+
+		boolean awaitCompletions(final long timeout, final TimeUnit unit) throws InterruptedException {
+			return completionLatch.await(timeout, unit);
+		}
+
+		List<String> observedItemNames() {
+			return new ArrayList<>(observedNames);
+		}
+
+		@Override
+		protected void doShutdown() {
+			executor.shutdown();
+		}
+
+		@Override
+		protected void doClose() {
+			executor.shutdownNow();
+		}
+	}
+}

--- a/engine/core/spt-base/src/test/java/com/dell/spt/base/load/step/local/context/RecycleCirculationIntegrationTest.java
+++ b/engine/core/spt-base/src/test/java/com/dell/spt/base/load/step/local/context/RecycleCirculationIntegrationTest.java
@@ -1,6 +1,8 @@
 package com.dell.spt.base.load.step.local.context;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.dell.spt.base.concurrent.AsyncRunnableBase;
@@ -40,6 +42,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -63,6 +66,65 @@ class RecycleCirculationIntegrationTest {
 	@ValueSource(ints = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10
 	})
 	void completeManifestCirculatesBeforeAnyRepeat(final int concurrency) throws Exception {
+		try (final var fixture = newFixture(concurrency)) {
+			fixture.start();
+			final var driver = fixture.driver();
+			assertTrue(
+							driver.awaitCompletions(COMPLETION_TIMEOUT_SECONDS, TimeUnit.SECONDS),
+							"timed out after " + driver.completedOpCount() + " completions at T" + concurrency);
+
+			assertCirculationInvariant(driver, concurrency);
+			assertFalse(
+							driver.legacyDirectRecycleEnabled(),
+							"the production step context must not activate the legacy direct-recycle model");
+		}
+	}
+
+	@Test
+	void legacyDirectRecycleNegativeControlBreaksCirculationInvariant() throws Exception {
+		final int concurrency = 4;
+		try (final var fixture = newFixture(concurrency)) {
+			final var driver = fixture.driver();
+			driver.enableLegacyDirectRecycleForNegativeControl();
+			assertTrue(driver.legacyDirectRecycleEnabled(), "negative control must activate the legacy model");
+			fixture.start();
+			assertTrue(
+							driver.awaitCompletions(COMPLETION_TIMEOUT_SECONDS, TimeUnit.SECONDS),
+							"negative control timed out after " + driver.completedOpCount() + " completions");
+
+			final AssertionError failure = assertThrows(
+							AssertionError.class, () -> assertCirculationInvariant(driver, concurrency));
+			assertTrue(
+							failure.getMessage().contains("repeated before the complete manifest"),
+							"negative control must fail the first-circulation assertion: " + failure.getMessage());
+		}
+	}
+
+	private static void assertCirculationInvariant(
+					final CirculationCanaryDriver driver, final int concurrency) {
+		final List<String> observed = driver.observedItemNames();
+		assertEquals(COMPLETION_COUNT, observed.size());
+		assertEquals(
+						MANIFEST_ITEM_COUNT,
+						new HashSet<>(observed.subList(0, MANIFEST_ITEM_COUNT)).size(),
+						"an item repeated before the complete manifest entered circulation at T" + concurrency);
+
+		final Set<String> expectedNames = ManifestItemInput.expectedNames(MANIFEST_ITEM_COUNT);
+		assertEquals(expectedNames, new HashSet<>(observed), "the driver saw an unexpected or missing item");
+		final Map<String, Integer> counts = new HashMap<>();
+		observed.forEach(name -> counts.merge(name, 1, Integer::sum));
+		final int minCount = counts.values().stream().mapToInt(Integer::intValue).min().orElseThrow();
+		final int maxCount = counts.values().stream().mapToInt(Integer::intValue).max().orElseThrow();
+		assertTrue(
+						maxCount - minCount <= concurrency,
+						"circulation imbalance exceeds the in-flight boundary at T" + concurrency + ": " + counts);
+
+		assertEquals(COMPLETION_COUNT, driver.scheduledOpCount());
+		assertEquals(COMPLETION_COUNT, driver.completedOpCount());
+		assertEquals(0, driver.activeOpCount(), "all bounded concurrency permits must be released");
+	}
+
+	private static CirculationFixture newFixture(final int concurrency) throws IOException {
 		final Config config = TestConfigBuilder.config();
 		config.val("item-type", "data");
 		config.val("item-data-ranges-concat", null);
@@ -96,38 +158,7 @@ class RecycleCirculationIntegrationTest {
 						metrics,
 						config.configVal("load"),
 						false);
-
-		stepContext.start();
-		try {
-			assertTrue(
-							driver.awaitCompletions(COMPLETION_TIMEOUT_SECONDS, TimeUnit.SECONDS),
-							"timed out after " + driver.completedOpCount() + " completions at T" + concurrency);
-
-			final List<String> observed = driver.observedItemNames();
-			assertEquals(COMPLETION_COUNT, observed.size());
-			assertEquals(
-							MANIFEST_ITEM_COUNT,
-							new HashSet<>(observed.subList(0, MANIFEST_ITEM_COUNT)).size(),
-							"an item repeated before the complete manifest entered circulation at T" + concurrency);
-
-			final Set<String> expectedNames = ManifestItemInput.expectedNames(MANIFEST_ITEM_COUNT);
-			assertEquals(expectedNames, new HashSet<>(observed), "the driver saw an unexpected or missing item");
-			final Map<String, Integer> counts = new HashMap<>();
-			observed.forEach(name -> counts.merge(name, 1, Integer::sum));
-			final int minCount = counts.values().stream().mapToInt(Integer::intValue).min().orElseThrow();
-			final int maxCount = counts.values().stream().mapToInt(Integer::intValue).max().orElseThrow();
-			assertTrue(
-							maxCount - minCount <= concurrency,
-							"circulation imbalance exceeds the in-flight boundary at T" + concurrency + ": " + counts);
-
-			assertEquals(COMPLETION_COUNT, driver.scheduledOpCount());
-			assertEquals(COMPLETION_COUNT, driver.completedOpCount());
-			assertEquals(0, driver.activeOpCount(), "all bounded concurrency permits must be released");
-		} finally {
-			stepContext.stop();
-			stepContext.shutdown();
-			stepContext.close();
-		}
+		return new CirculationFixture(driver, metrics, stepContext);
 	}
 
 	private static MetricsContext<AllMetricsSnapshot> buildMetrics(final int concurrency) {
@@ -144,6 +175,35 @@ class RecycleCirculationIntegrationTest {
 						.build();
 		metrics.start();
 		return metrics;
+	}
+
+	private static final class CirculationFixture implements AutoCloseable {
+		private final CirculationCanaryDriver driver;
+		private final MetricsContext<AllMetricsSnapshot> metrics;
+		private final LoadStepContextImpl<DataItem, Operation<DataItem>> stepContext;
+
+		CirculationFixture(
+						final CirculationCanaryDriver driver,
+						final MetricsContext<AllMetricsSnapshot> metrics,
+						final LoadStepContextImpl<DataItem, Operation<DataItem>> stepContext) {
+			this.driver = driver;
+			this.metrics = metrics;
+			this.stepContext = stepContext;
+		}
+
+		CirculationCanaryDriver driver() {
+			return driver;
+		}
+
+		void start() {
+			stepContext.start();
+		}
+
+		@Override
+		public void close() throws IOException {
+			stepContext.close();
+			metrics.close();
+		}
 	}
 
 	private static final class ManifestItemInput implements Input<DataItem> {
@@ -266,6 +326,8 @@ class RecycleCirculationIntegrationTest {
 		}
 
 		private void recordDispatch(final Operation<DataItem> op) {
+			// Operation.buildItemPath() prefixes pathless data-item names with "/"; compare the
+			// storage object-key form used by the source manifest.
 			final String itemName = op.item().name();
 			observedNames.add(itemName.startsWith("/") ? itemName.substring(1) : itemName);
 		}
@@ -367,6 +429,14 @@ class RecycleCirculationIntegrationTest {
 		@Override
 		public void enableFastRecycle(final int concurrencyThreshold) {
 			legacyDirectRecycle = concurrencyThreshold > 0;
+		}
+
+		void enableLegacyDirectRecycleForNegativeControl() {
+			legacyDirectRecycle = true;
+		}
+
+		boolean legacyDirectRecycleEnabled() {
+			return legacyDirectRecycle;
 		}
 
 		boolean awaitCompletions(final long timeout, final TimeUnit unit) throws InterruptedException {

--- a/engine/extensions/storage-drivers/primitives/coop/src/main/java/com/dell/spt/storage/driver/coop/CoopStorageDriverBase.java
+++ b/engine/extensions/storage-drivers/primitives/coop/src/main/java/com/dell/spt/storage/driver/coop/CoopStorageDriverBase.java
@@ -53,8 +53,9 @@ public abstract class CoopStorageDriverBase<I extends Item, O extends Operation<
 	private final int configuredMpuObjectLimit;
 	private final int configuredMpuPartLimit;
 	private volatile boolean mpuSchedulingInitialized = false;
+	/** @deprecated inert compatibility field for subclasses compiled against the removed fast-recycle path */
+	@Deprecated
 	protected volatile int fastRecycleConcurrencyThreshold = 0;
-	private volatile boolean fastRecycleQuiesceActive = false;
 
 	protected CoopStorageDriverBase(
 					final String testStepId,
@@ -482,56 +483,34 @@ public abstract class CoopStorageDriverBase<I extends Item, O extends Operation<
 		}
 	}
 
-	@Override
-	public void enableFastRecycle(final int concurrencyThreshold) {
-		this.fastRecycleConcurrencyThreshold = concurrencyThreshold;
-		Loggers.MSG.info("{}: fast-recycle enabled, concurrency threshold = {}", toString(), concurrencyThreshold);
-	}
-
-	/**
-	 * Returns {@code true} when fast-recycle has been enabled on this driver.
-	 * Used by the dispatch task to extend its idle wait when the driver is
-	 * cycling ops inline and no new work is expected via the queues.
-	 */
+	/** @deprecated always returns {@code false}; direct fast recycle was removed */
+	@Deprecated
 	protected boolean isFastRecycleEnabled() {
-		return fastRecycleConcurrencyThreshold > 0;
+		return false;
+	}
+
+	/** @deprecated always returns {@code false}; direct fast-recycle quiescing was removed */
+	@Deprecated
+	protected boolean isFastRecycleQuiesceActive() {
+		return false;
+	}
+
+	/**
+	 * @param op ignored
+	 * @deprecated always returns {@code false}; completed operations use shared circulation
+	 */
+	@Deprecated
+	protected boolean isFastRecycleEligible(final O op) {
+		return false;
 	}
 
 	@Override
-	public void enableFastRecycleQuiesce() {
-		this.fastRecycleQuiesceActive = true;
-		Loggers.MSG.info("{}: fast-recycle quiesce active (dispatch task will extend idle wait)", toString());
-	}
+	@Deprecated
+	public void enableFastRecycle(final int concurrencyThreshold) {}
 
-	/**
-	 * Returns {@code true} when quiesce mode is active — i.e. the configured
-	 * concurrency is low enough that fast-recycle handles most operations and
-	 * the dispatch/generator VTs may park on long waits.
-	 */
-	protected boolean isFastRecycleQuiesceActive() {
-		return fastRecycleQuiesceActive;
-	}
-
-	/**
-	 * Check whether the given completed operation is eligible for the fast-recycle
-	 * short-circuit.  Returns {@code true} only when:
-	 * <ul>
-	 *   <li>fast-recycle has been enabled (threshold &gt; 0)</li>
-	 *   <li>the current active-op count is &le; the threshold</li>
-	 *   <li>the op finished successfully</li>
-	 *   <li>the op is a simple (non-composite, non-partial) operation</li>
-	 *   <li>the driver is still running</li>
-	 * </ul>
-	 */
-	protected boolean isFastRecycleEligible(final O op) {
-		final int threshold = fastRecycleConcurrencyThreshold;
-		return threshold > 0
-						&& activeOpCount() <= threshold
-						&& op.status() == Operation.Status.SUCC
-						&& !(op instanceof CompositeOperation)
-						&& !(op instanceof PartialOperation)
-						&& isStarted();
-	}
+	@Override
+	@Deprecated
+	public void enableFastRecycleQuiesce() {}
 
 	@Override
 	protected void doShutdown() {

--- a/engine/extensions/storage-drivers/primitives/coop/src/main/java/com/dell/spt/storage/driver/coop/CoopStorageDriverBase.java
+++ b/engine/extensions/storage-drivers/primitives/coop/src/main/java/com/dell/spt/storage/driver/coop/CoopStorageDriverBase.java
@@ -53,9 +53,13 @@ public abstract class CoopStorageDriverBase<I extends Item, O extends Operation<
 	private final int configuredMpuObjectLimit;
 	private final int configuredMpuPartLimit;
 	private volatile boolean mpuSchedulingInitialized = false;
-	/** @deprecated inert compatibility field for subclasses compiled against the removed fast-recycle path */
+	/**
+	 * @deprecated retained for binary compatibility only; SPT never reads this field and writes
+	 *             have no effect
+	 */
 	@Deprecated
 	protected volatile int fastRecycleConcurrencyThreshold = 0;
+	private volatile boolean fastRecycleWarningLogged;
 
 	protected CoopStorageDriverBase(
 					final String testStepId,
@@ -506,11 +510,24 @@ public abstract class CoopStorageDriverBase<I extends Item, O extends Operation<
 
 	@Override
 	@Deprecated
-	public void enableFastRecycle(final int concurrencyThreshold) {}
+	public void enableFastRecycle(final int concurrencyThreshold) {
+		warnFastRecycleDisabled();
+	}
 
 	@Override
 	@Deprecated
-	public void enableFastRecycleQuiesce() {}
+	public void enableFastRecycleQuiesce() {
+		warnFastRecycleDisabled();
+	}
+
+	private synchronized void warnFastRecycleDisabled() {
+		if (!fastRecycleWarningLogged) {
+			fastRecycleWarningLogged = true;
+			Loggers.MSG.warn(
+							"{}: deprecated fast-recycle request ignored; completed operations use shared generator circulation",
+							toString());
+		}
+	}
 
 	@Override
 	protected void doShutdown() {

--- a/engine/extensions/storage-drivers/primitives/coop/src/test/java/com/dell/spt/storage/driver/coop/CoopStorageDriverBaseTest.java
+++ b/engine/extensions/storage-drivers/primitives/coop/src/test/java/com/dell/spt/storage/driver/coop/CoopStorageDriverBaseTest.java
@@ -425,6 +425,45 @@ class CoopStorageDriverBaseTest {
 		assertTrue(driver.isIdle(), "should be idle after release");
 	}
 
+	@Test
+	@SuppressWarnings("deprecation")
+	void deprecatedFastRecycleHooksWarnOnlyOncePerDriver() throws Exception {
+		final var dataInput = DataInput.instance(
+						null, "7a42d9c483244167", new SizeInBytes("64KB"), 4, false, 0.0, true);
+		final var appender = new CapturingAppender();
+		appender.start();
+		final var loggerCtx = LoggerContext.getContext(false);
+		final var logger = loggerCtx.getLogger(Loggers.MSG.getName());
+		final var originalLevel = logger.getLevel();
+
+		try (final var driver = new CoopStorageDriverMock<Item, Operation<Item>>(
+						"deprecated-fast-recycle",
+						dataInput,
+						storageConfigForMultipartLimits(0, 0),
+						false,
+						16)) {
+			logger.addAppender(appender);
+			logger.setLevel(Level.WARN);
+
+			driver.enableFastRecycle(4);
+			driver.enableFastRecycle(8);
+			driver.enableFastRecycleQuiesce();
+			awaitCapturedEvents(appender, 1, 2000);
+
+			final var warningMessages = appender.events().stream()
+							.filter(e -> Level.WARN.equals(e.getLevel()))
+							.map(e -> e.getMessage().getFormattedMessage())
+							.filter(msg -> msg.contains("deprecated fast-recycle request ignored"))
+							.toList();
+			assertEquals(1, warningMessages.size(), "deprecated hooks should warn once per driver");
+			assertTrue(warningMessages.get(0).contains("shared generator circulation"));
+		} finally {
+			logger.removeAppender(appender);
+			logger.setLevel(originalLevel);
+			appender.stop();
+		}
+	}
+
 	// ---------- Simple-op completion path ----------
 
 	@Test

--- a/engine/extensions/storage-drivers/primitives/coop/src/test/java/com/dell/spt/storage/driver/coop/CoopStorageDriverBaseTest.java
+++ b/engine/extensions/storage-drivers/primitives/coop/src/test/java/com/dell/spt/storage/driver/coop/CoopStorageDriverBaseTest.java
@@ -10,7 +10,6 @@ import com.dell.spt.base.item.Item;
 import com.dell.spt.base.item.op.OpType;
 import com.dell.spt.base.item.op.Operation;
 import com.dell.spt.base.item.op.composite.data.CompositeDataOperationImpl;
-import com.dell.spt.base.item.op.partial.PartialOperation;
 import com.dell.spt.base.item.op.partial.data.PartialDataOperationImpl;
 import com.dell.spt.base.logging.Loggers;
 import com.dell.spt.base.storage.driver.StorageDriverBase;
@@ -426,13 +425,13 @@ class CoopStorageDriverBaseTest {
 		assertTrue(driver.isIdle(), "should be idle after release");
 	}
 
-	// ---------- Simple-op completion path (characterization for fast-recycle) ----------
+	// ---------- Simple-op completion path ----------
 
 	@Test
 	void handleCompleted_simpleSuccessOpSendsResultToOutput() throws Exception {
 		final var driver = newRetryTestDriver();
 
-		// A simple (non-composite, non-partial) op — this is the path fast-recycle targets
+		// A simple (non-composite, non-partial) operation
 		final Operation<Item> op = mock(Operation.class);
 		final Operation<Item> resultCopy = mock(Operation.class);
 		when(op.status()).thenReturn(Operation.Status.SUCC);
@@ -640,160 +639,6 @@ class CoopStorageDriverBaseTest {
 
 		final var queue = childQueueOf(driver);
 		assertTrue(queue.contains(parent), "parent should be re-enqueued when all parts done");
-	}
-
-	// ---------- Fast-recycle eligibility tests ----------
-
-	@Test
-	void enableFastRecycle_setsThreshold() throws Exception {
-		final var driver = newFastRecycleDriver(4);
-		final var threshField = CoopStorageDriverBase.class.getDeclaredField("fastRecycleConcurrencyThreshold");
-		threshField.setAccessible(true);
-		assertEquals(4, threshField.getInt(driver), "threshold should be set by enableFastRecycle");
-	}
-
-	@Test
-	void isFastRecycleEligible_trueForSimpleSuccessUnderThreshold() throws Exception {
-		final var driver = newFastRecycleDriver(4);
-
-		final Operation<Item> op = mock(Operation.class);
-		when(op.status()).thenReturn(Operation.Status.SUCC);
-
-		assertTrue(driver.isFastRecycleEligible(op),
-						"simple SUCC op under threshold should be eligible");
-	}
-
-	@Test
-	void isFastRecycleEligible_falseWhenDisabled() throws Exception {
-		// threshold = 0 means disabled
-		final var driver = newFastRecycleDriver(0);
-
-		final Operation<Item> op = mock(Operation.class);
-		when(op.status()).thenReturn(Operation.Status.SUCC);
-
-		assertFalse(driver.isFastRecycleEligible(op),
-						"should not be eligible when fast-recycle is disabled");
-	}
-
-	@Test
-	void isFastRecycleEligible_falseForFailedOp() throws Exception {
-		final var driver = newFastRecycleDriver(4);
-
-		final Operation<Item> op = mock(Operation.class);
-		when(op.status()).thenReturn(Operation.Status.FAIL_IO);
-
-		assertFalse(driver.isFastRecycleEligible(op),
-						"failed op should not be eligible for fast-recycle");
-	}
-
-	@Test
-	void isFastRecycleEligible_falseForCompositeOp() throws Exception {
-		final var driver = newFastRecycleDriver(4);
-
-		final var baseItem = new DataItemImpl("obj", 0, 4096);
-		baseItem.dataInput(DataInput.instance(null, "7a42d9c483244167", new SizeInBytes("64KB"), 4, false, 0.0, true));
-		final var compositeOp = new CompositeDataOperationImpl<DataItem>(
-						0, OpType.CREATE, baseItem, null, "/bucket", null, null, 0, 1024);
-		compositeOp.status(Operation.Status.SUCC);
-
-		assertFalse(driver.isFastRecycleEligible((Operation<Item>) (Operation<?>) compositeOp),
-						"composite op should not be eligible for fast-recycle");
-	}
-
-	@Test
-	void isFastRecycleEligible_falseForPartialOp() throws Exception {
-		final var driver = newFastRecycleDriver(4);
-
-		final PartialOperation partialOp = mock(PartialOperation.class);
-		when(partialOp.status()).thenReturn(Operation.Status.SUCC);
-
-		assertFalse(driver.isFastRecycleEligible((Operation<Item>) partialOp),
-						"partial op should not be eligible for fast-recycle");
-	}
-
-	@Test
-	void isFastRecycleEligible_falseWhenActiveCountExceedsThreshold() throws Exception {
-		final var driver = newFastRecycleDriver(2);
-
-		// Acquire 3 permits to simulate 3 active ops (threshold=2)
-		final var semField = CoopStorageDriverBase.class.getDeclaredField("concurrencyThrottle");
-		semField.setAccessible(true);
-		final Semaphore sem = (Semaphore) semField.get(driver);
-		sem.acquire(3);
-
-		final Operation<Item> op = mock(Operation.class);
-		when(op.status()).thenReturn(Operation.Status.SUCC);
-
-		assertFalse(driver.isFastRecycleEligible(op),
-						"should not be eligible when active count exceeds threshold");
-
-		sem.release(3);
-	}
-
-	@Test
-	void isFastRecycleEligible_trueWhenActiveCountEqualsThreshold() throws Exception {
-		final var driver = newFastRecycleDriver(2);
-
-		// Acquire exactly 2 permits (threshold=2)
-		final var semField = CoopStorageDriverBase.class.getDeclaredField("concurrencyThrottle");
-		semField.setAccessible(true);
-		final Semaphore sem = (Semaphore) semField.get(driver);
-		sem.acquire(2);
-
-		final Operation<Item> op = mock(Operation.class);
-		when(op.status()).thenReturn(Operation.Status.SUCC);
-
-		assertTrue(driver.isFastRecycleEligible(op),
-						"should be eligible when active count equals threshold (boundary)");
-
-		sem.release(2);
-	}
-
-	// ---------- Fast-recycle quiesce tests ----------
-
-	@Test
-	void enableFastRecycleQuiesce_activatesQuiesceState() throws Exception {
-		final var driver = newFastRecycleDriver(4);
-
-		assertFalse(driver.isFastRecycleQuiesceActive(),
-						"quiesce should be inactive by default");
-
-		driver.enableFastRecycleQuiesce();
-
-		assertTrue(driver.isFastRecycleQuiesceActive(),
-						"quiesce should be active after enableFastRecycleQuiesce()");
-	}
-
-	@Test
-	void quiesceInactiveByDefault() throws Exception {
-		final var driver = newFastRecycleDriver(4);
-		assertFalse(driver.isFastRecycleQuiesceActive(),
-						"quiesce must be inactive when only enableFastRecycle was called");
-	}
-
-	/** Set up a driver with fast-recycle infrastructure for eligibility tests. */
-	private CoopStorageDriverBase<Item, Operation<Item>> newFastRecycleDriver(int threshold) throws Exception {
-		final var driver = mock(CoopStorageDriverBase.class, withSettings().defaultAnswer(CALLS_REAL_METHODS));
-
-		// concurrencyLimit
-		final var limitField = CoopStorageDriverBase.class.getSuperclass().getDeclaredField("concurrencyLimit");
-		limitField.setAccessible(true);
-		limitField.set(driver, 8);
-
-		// concurrencyThrottle
-		final var semField = CoopStorageDriverBase.class.getDeclaredField("concurrencyThrottle");
-		semField.setAccessible(true);
-		semField.set(driver, new Semaphore(8, true));
-
-		// fastRecycleConcurrencyThreshold
-		final var threshField = CoopStorageDriverBase.class.getDeclaredField("fastRecycleConcurrencyThreshold");
-		threshField.setAccessible(true);
-		threshField.set(driver, threshold);
-
-		// Mark as started so isStarted() returns true
-		when(driver.isStarted()).thenReturn(true);
-
-		return driver;
 	}
 
 	// ---------- Output-full side-effect tests ----------

--- a/engine/extensions/storage-drivers/primitives/coop/src/test/java/com/dell/spt/storage/driver/coop/OperationDispatchTaskTest.java
+++ b/engine/extensions/storage-drivers/primitives/coop/src/test/java/com/dell/spt/storage/driver/coop/OperationDispatchTaskTest.java
@@ -351,8 +351,7 @@ class OperationDispatchTaskTest {
 	@Test
 	void untimedAwaitWakesOnSignal() throws Exception {
 		// The dispatch task uses untimed await() — verify it still wakes
-		// promptly when signaled, regardless of fast-recycle quiesce state.
-		when(driverMock.isFastRecycleQuiesceActive()).thenReturn(true);
+		// promptly when signaled.
 
 		final Operation<Item> op = mock(Operation.class);
 		when(driverMock.submit(any(Operation.class))).thenReturn(true);

--- a/engine/extensions/storage-drivers/primitives/netty/src/main/java/com/dell/spt/storage/driver/coop/netty/NettyStorageDriverBase.java
+++ b/engine/extensions/storage-drivers/primitives/netty/src/main/java/com/dell/spt/storage/driver/coop/netty/NettyStorageDriverBase.java
@@ -683,48 +683,8 @@ public abstract class NettyStorageDriverBase<I extends Item, O extends Operation
 			channel.close();
 		}
 
-		// Fast-recycle path: keep the concurrency permit, release the channel,
-		// report metrics, then directly prepare + re-submit the original op.
-		// This avoids the VirtualThread scheduling overhead of the normal
-		// LoadGenerator recycleQueue → OperationDispatchTask path.
-		if (channel != null && isFastRecycleEligible(op)) {
-			if (!channel.attr(ATTR_KEY_RELEASED).getAndSet(Boolean.TRUE)) {
-				connPool.release(channel);
-			}
-			// isFastRecycleEligible() requires status == SUCC, so this is always a
-			// successful completion: clear load-op-retry's counter on the *original* op
-			// here too, same as LoadStepContextImpl.put() does for the result copy it
-			// sees - handleCompleted() below only hands that copy a snapshot, it never
-			// touches this live object, which is what actually gets reused below.
-			op.resetOpRetryCount();
-			// Mark BEFORE handleCompleted so the result copy carries the flag
-			op.driverRecycled(true);
-			handleCompleted(op);
-			// Prepare and re-submit directly (we still hold the concurrency permit)
-			prepare(op);
-			try {
-				final Channel conn = leaseActiveConnection();
-				conn.attr(ATTR_KEY_OPERATION).set(op);
-				op.nodeAddr(conn.attr(ATTR_KEY_NODE).get());
-				op.startRequest();
-				sendRequest(conn, op);
-			} catch (final ConnectException e) {
-				LogUtil.exception(Level.WARN, e, "Fast-recycle: failed to lease connection");
-				op.status(Operation.Status.FAIL_IO);
-				concurrencyThrottle.release();
-				handleCompleted(op);
-			} catch (final Throwable thrown) {
-				throwUncheckedIfInterrupted(thrown);
-				LogUtil.exception(Level.WARN, thrown, "Fast-recycle: failed to re-submit");
-				op.status(Operation.Status.FAIL_UNKNOWN);
-				concurrencyThrottle.release();
-				handleCompleted(op);
-			}
-			return;
-		}
-
-		// Normal path: release permit + channel, then let the LoadGenerator
-		// recycle queue handle re-dispatch.
+		// Release the permit and channel before reporting completion. Recycled
+		// operations return through the shared LoadGenerator queue for redispatch.
 		if (channel != null && !channel.attr(ATTR_KEY_RELEASED).getAndSet(Boolean.TRUE)) {
 			concurrencyThrottle.release();
 			connPool.release(channel);

--- a/engine/extensions/storage-drivers/primitives/netty/src/test/java/com/dell/spt/storage/driver/coop/netty/NettyCompletionPathTest.java
+++ b/engine/extensions/storage-drivers/primitives/netty/src/test/java/com/dell/spt/storage/driver/coop/netty/NettyCompletionPathTest.java
@@ -31,8 +31,8 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Characterization tests for {@link NettyStorageDriverBase#complete(io.netty.channel.Channel,
- * Operation)}. These capture the current completion path behavior as a safety net before
- * introducing fast-recycle dispatch.
+ * Operation)}. These capture the normal completion path and guard against deprecated
+ * fast-recycle hooks bypassing it.
  */
 @SuppressWarnings("unchecked")
 class NettyCompletionPathTest {
@@ -282,49 +282,11 @@ class NettyCompletionPathTest {
 		channel.close();
 	}
 
-	// ---------- Fast-recycle path tests ----------
-
-	private void enableFastRecycle(int threshold) throws Exception {
-		final var threshField = CoopStorageDriverBase.class.getDeclaredField("fastRecycleConcurrencyThreshold");
-		threshField.setAccessible(true);
-		threshField.set(driver, threshold);
-		when(driver.isStarted()).thenReturn(true);
-	}
-
 	@Test
-	void fastRecycle_setsDriverRecycledFlagOnOp() throws Exception {
-		enableFastRecycle(4);
-		// Use higher concurrency so we have room
-		final var limitField = StorageDriverBase.class.getDeclaredField("concurrencyLimit");
-		limitField.setAccessible(true);
-		limitField.set(driver, 4);
-		final var sem = new Semaphore(4, true);
-		sem.acquire(1); // 1 active op (under threshold=4)
-		final var semField = CoopStorageDriverBase.class.getDeclaredField("concurrencyThrottle");
-		semField.setAccessible(true);
-		semField.set(driver, sem);
-
-		final var channel = newChannelWithReleasedFlag();
-		final Operation<Item> op = mock(Operation.class);
-		final Operation<Item> resultCopy = mock(Operation.class);
-		when(op.status()).thenReturn(Operation.Status.SUCC);
-		when(op.result()).thenReturn(resultCopy);
-
-		// Mock connPool.lease() to return a new channel for re-submit
-		final var resubmitChannel = newResubmitChannel();
-		when(connPool.lease()).thenReturn(resubmitChannel);
-
-		driver.complete(channel, op);
-
-		// The op should have driverRecycled set to true before result() is called
-		verify(op).driverRecycled(true);
-		channel.close();
-		resubmitChannel.close();
-	}
-
-	@Test
-	void fastRecycle_keepsPermitAndReleasesChannel() throws Exception {
-		enableFastRecycle(4);
+	@SuppressWarnings("deprecation")
+	void deprecatedFastRecycleHookCannotBypassNormalCompletion() throws Exception {
+		// Compatibility calls from an extension must remain inert.
+		driver.enableFastRecycle(4);
 		final var limitField = StorageDriverBase.class.getDeclaredField("concurrencyLimit");
 		limitField.setAccessible(true);
 		limitField.set(driver, 4);
@@ -339,136 +301,10 @@ class NettyCompletionPathTest {
 		when(op.status()).thenReturn(Operation.Status.SUCC);
 		when(op.result()).thenReturn(mock(Operation.class));
 
-		// Mock connPool.lease() for re-submit
-		final var resubmitChannel = newResubmitChannel();
-		when(connPool.lease()).thenReturn(resubmitChannel);
-
 		driver.complete(channel, op);
 
-		// Channel should be released to the pool
-		verify(connPool).release(channel);
-		// Permit should NOT be released — it's held for the re-submitted op.
-		// Before complete: 3 available (4 total - 1 acquired).
-		// After fast-recycle: still 3 available (permit retained for new submit).
-		assertEquals(3, sem.availablePermits(),
-						"permit should be retained for the re-submitted op");
-		channel.close();
-		resubmitChannel.close();
-	}
-
-	@Test
-	void fastRecycle_resetsOpForResubmit() throws Exception {
-		enableFastRecycle(4);
-		final var limitField = StorageDriverBase.class.getDeclaredField("concurrencyLimit");
-		limitField.setAccessible(true);
-		limitField.set(driver, 4);
-		final var sem = new Semaphore(4, true);
-		sem.acquire(1);
-		final var semField = CoopStorageDriverBase.class.getDeclaredField("concurrencyThrottle");
-		semField.setAccessible(true);
-		semField.set(driver, sem);
-
-		final var channel = newChannelWithReleasedFlag();
-		final Operation<Item> op = mock(Operation.class);
-		when(op.status()).thenReturn(Operation.Status.SUCC);
-		when(op.result()).thenReturn(mock(Operation.class));
-
-		final var resubmitChannel = newResubmitChannel();
-		when(connPool.lease()).thenReturn(resubmitChannel);
-
-		driver.complete(channel, op);
-
-		// prepare() calls op.reset() internally — verify reset was called
-		verify(op).reset();
-		// Also verify the op was re-submitted (startRequest called on the re-prepared op)
-		verify(op, atLeast(1)).startRequest();
-		channel.close();
-		resubmitChannel.close();
-	}
-
-	@Test
-	void fastRecycleClearsReleasedChannelAndRebindsOperationToResubmissionChannel() throws Exception {
-		enableFastRecycle(4);
-		final var limitField = StorageDriverBase.class.getDeclaredField("concurrencyLimit");
-		limitField.setAccessible(true);
-		limitField.set(driver, 4);
-		final var sem = new Semaphore(4, true);
-		sem.acquire(1);
-		final var semField = CoopStorageDriverBase.class.getDeclaredField("concurrencyThrottle");
-		semField.setAccessible(true);
-		semField.set(driver, sem);
-
-		final var releasedChannel = newChannelWithReleasedFlag();
-		final Operation<Item> op = mock(Operation.class);
-		when(op.status()).thenReturn(Operation.Status.SUCC);
-		when(op.result()).thenReturn(mock(Operation.class));
-		releasedChannel.attr(NettyStorageDriver.ATTR_KEY_OPERATION).set(op);
-
-		final var resubmitChannel = newResubmitChannel();
-		when(connPool.lease()).thenReturn(resubmitChannel);
-		doAnswer(inv -> {
-			assertNull(releasedChannel.attr(NettyStorageDriver.ATTR_KEY_OPERATION).get());
-			return null;
-		}).when(connPool).release(releasedChannel);
-
-		driver.complete(releasedChannel, op);
-
-		assertSame(op, resubmitChannel.attr(NettyStorageDriver.ATTR_KEY_OPERATION).get());
-		releasedChannel.close();
-		resubmitChannel.close();
-	}
-
-	@Test
-	void fastRecycle_fallsBackToNormalPathWhenNotEligible() throws Exception {
-		// Fast-recycle enabled but op failed — should use normal path
-		enableFastRecycle(4);
-		final var limitField = StorageDriverBase.class.getDeclaredField("concurrencyLimit");
-		limitField.setAccessible(true);
-		limitField.set(driver, 4);
-		final var sem = new Semaphore(4, true);
-		sem.acquire(1);
-		final var semField = CoopStorageDriverBase.class.getDeclaredField("concurrencyThrottle");
-		semField.setAccessible(true);
-		semField.set(driver, sem);
-
-		final var channel = newChannelWithReleasedFlag();
-		final Operation<Item> op = mock(Operation.class);
-		when(op.status()).thenReturn(Operation.Status.FAIL_IO);
-		when(op.result()).thenReturn(mock(Operation.class));
-
-		driver.complete(channel, op);
-
-		// Normal path: permit released, no driverRecycled flag set
-		verify(op, never()).driverRecycled(anyBoolean());
-		assertEquals(4, sem.availablePermits(), "permit should be released in normal path");
-		channel.close();
-	}
-
-	@Test
-	void fastRecycle_releasesPermitOnLeaseFailure() throws Exception {
-		enableFastRecycle(4);
-		final var limitField = StorageDriverBase.class.getDeclaredField("concurrencyLimit");
-		limitField.setAccessible(true);
-		limitField.set(driver, 4);
-		final var sem = new Semaphore(4, true);
-		sem.acquire(1);
-		final var semField = CoopStorageDriverBase.class.getDeclaredField("concurrencyThrottle");
-		semField.setAccessible(true);
-		semField.set(driver, sem);
-
-		final var channel = newChannelWithReleasedFlag();
-		final Operation<Item> op = mock(Operation.class);
-		when(op.status()).thenReturn(Operation.Status.SUCC);
-		when(op.result()).thenReturn(mock(Operation.class));
-
-		// connPool.lease() throws — simulating no connections available
-		when(connPool.lease()).thenThrow(new java.net.ConnectException("no connections"));
-
-		driver.complete(channel, op);
-
-		// After lease failure, permit should be released
-		assertEquals(4, sem.availablePermits(),
-						"permit should be released after fast-recycle lease failure");
+		verify(connPool, never()).lease();
+		assertEquals(4, sem.availablePermits(), "deprecated hook must not retain the completion permit");
 		channel.close();
 	}
 
@@ -572,50 +408,6 @@ class NettyCompletionPathTest {
 						"all 3 permits should be released (no leak), returning to full capacity");
 		assertEquals(3, driver.completedOpCount(),
 						"all 3 ops should be counted as completed");
-	}
-
-	// ---------- Fast-recycle driverRecycled flag on result copy ----------
-
-	@Test
-	void fastRecycle_resultCopyCarriesDriverRecycledFlag() throws Exception {
-		enableFastRecycle(4);
-		final var limitField = StorageDriverBase.class.getDeclaredField("concurrencyLimit");
-		limitField.setAccessible(true);
-		limitField.set(driver, 4);
-		final var sem = new Semaphore(4, true);
-		sem.acquire(1);
-		final var semField = CoopStorageDriverBase.class.getDeclaredField("concurrencyThrottle");
-		semField.setAccessible(true);
-		semField.set(driver, sem);
-
-		final var channel = newChannelWithReleasedFlag();
-
-		// Use a real OperationImpl so driverRecycled flag is actually stored
-		final var item = new ItemImpl("recycle-flag-obj");
-		final OperationImpl<ItemImpl> realOp = new OperationImpl<>(
-						0, OpType.CREATE, item, null, "/bucket", null);
-		realOp.startRequest();
-		realOp.finishRequest();
-		realOp.startResponse();
-		realOp.status(Operation.Status.SUCC);
-
-		// Capture the result copy to verify the flag
-		final List<Operation<?>> capturedResults = new ArrayList<>();
-		when(opResultOut.put(any(Operation.class))).thenAnswer(inv -> {
-			capturedResults.add(inv.getArgument(0));
-			return true;
-		});
-
-		final var resubmitChannel = newResubmitChannel();
-		when(connPool.lease()).thenReturn(resubmitChannel);
-
-		driver.complete(channel, (Operation<Item>) (Operation<?>) realOp);
-
-		assertEquals(1, capturedResults.size(), "one result should be captured");
-		assertTrue(capturedResults.get(0).driverRecycled(),
-						"result copy must carry driverRecycled=true from fast-recycle path");
-		channel.close();
-		resubmitChannel.close();
 	}
 
 	// ---------- Channel release ordering ----------


### PR DESCRIPTION
# Description

Fix duration-based recycled reads so the complete input manifest enters circulation before any operation repeats.

The low-concurrency fast-recycle path could repeatedly resubmit the same permit-holding operations, reducing the effective working set to approximately the configured concurrency. This change disables and removes that bypass so completed operations return through the shared generator circulation path.

Deprecated extension-facing hooks remain as inert compatibility shims and emit a one-shot warning if invoked. The changelog records both the correctness fix and the possible low-concurrency throughput/CPU-efficiency change from removing the optimization.

## Operational note

Removing the bypass favors correct complete-manifest circulation over the former low-concurrency optimization. Users comparing v5.14.1 and v5.14.2 may observe a low-concurrency throughput or CPU-per-operation difference.
