### PR TITLE
Run and enforce Error Prone from root lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ help:
 	@echo "  make test-coverage-cli     Run only the CLI coverage workflow"
 	@echo "  make build-engine  Build only the engine bundle"
 	@echo "  make test-engine   Run only the engine test suite"
-	@echo "  make lint-engine   Run only the engine formatting/lint checks"
+	@echo "  make lint-engine   Run engine formatting and Error Prone checks"
 	@echo "  make test-coverage-engine  Run only the engine coverage workflow"
 
 setup:
@@ -69,7 +69,7 @@ lint-cli:
 	$(MAKE) -C $(CLI_DIR) lint
 
 lint-engine:
-	$(MAKE) -C $(ENGINE_DIR) check
+	$(MAKE) -C $(ENGINE_DIR) check errorprone
 
 test-coverage: test-coverage-cli test-coverage-engine
 

--- a/engine/core/spt-base/src/main/java/com/dell/spt/base/item/op/OperationImpl.java
+++ b/engine/core/spt-base/src/main/java/com/dell/spt/base/item/op/OperationImpl.java
@@ -139,12 +139,12 @@ public class OperationImpl<I extends Item> implements Operation<I> {
 	}
 
 	@Override
-	public final void incrementOpRetryCount() {
+	public final synchronized void incrementOpRetryCount() {
 		opRetryCount++;
 	}
 
 	@Override
-	public final void resetOpRetryCount() {
+	public final synchronized void resetOpRetryCount() {
 		opRetryCount = 0;
 	}
 

--- a/engine/core/spt-base/src/main/java/com/dell/spt/base/load/step/LoadStepBase.java
+++ b/engine/core/spt-base/src/main/java/com/dell/spt/base/load/step/LoadStepBase.java
@@ -28,6 +28,7 @@ import com.github.akurilov.confuse.impl.BasicConfig;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import org.apache.logging.log4j.Level;
@@ -251,7 +252,7 @@ public abstract class LoadStepBase extends DaemonBase implements LoadStep, Runna
 		if (!integrityModeEnabled || !emitsOperationArtifacts()) {
 			return;
 		}
-		final OpType opType = OpType.valueOf(config.stringVal("load-op-type").toUpperCase());
+		final OpType opType = OpType.valueOf(config.stringVal("load-op-type").toUpperCase(Locale.ROOT));
 		for (final var artifact : IntegrityCsvArtifacts.applicableHeaders(
 						opType, true, multipartEnabled())) {
 			switch (artifact.kind()) {

--- a/engine/core/spt-base/src/test/java/com/dell/spt/base/integrity/IntegrityMetadataCodecTest.java
+++ b/engine/core/spt-base/src/test/java/com/dell/spt/base/integrity/IntegrityMetadataCodecTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 
@@ -18,7 +19,8 @@ class IntegrityMetadataCodecTest {
 		final var entries = List.<Map.Entry<String, ?>> of(
 						new AbstractMap.SimpleImmutableEntry<>("X-Amz-Meta-SPT-Integrity-Version", " 1 "),
 						new AbstractMap.SimpleImmutableEntry<>("spt-integrity-algorithm", " SHA256 "),
-						new AbstractMap.SimpleImmutableEntry<>("SPT-INTEGRITY-DIGEST", EMPTY_SHA256.toUpperCase()),
+						new AbstractMap.SimpleImmutableEntry<>(
+										"SPT-INTEGRITY-DIGEST", EMPTY_SHA256.toUpperCase(Locale.ROOT)),
 						new AbstractMap.SimpleImmutableEntry<>("x-amz-meta-spt-integrity-size", " 0 "));
 
 		assertEquals(new IntegrityMetadata("1", "sha256", EMPTY_SHA256, 0),
@@ -31,7 +33,7 @@ class IntegrityMetadataCodecTest {
 		entries.add(new AbstractMap.SimpleImmutableEntry<>(
 						"x-amz-meta-spt-integrity-size", List.of("0", "0")));
 		entries.add(new AbstractMap.SimpleImmutableEntry<>(
-						"x-amz-meta-spt-integrity-digest", EMPTY_SHA256.toUpperCase()));
+						"x-amz-meta-spt-integrity-digest", EMPTY_SHA256.toUpperCase(Locale.ROOT)));
 		assertEquals(0, IntegrityMetadataCodec.decode(entries).size());
 
 		entries.add(new AbstractMap.SimpleImmutableEntry<>("SPT-INTEGRITY-SIZE", "1"));

--- a/engine/core/spt-base/src/test/java/com/dell/spt/base/item/op/OperationImplTest.java
+++ b/engine/core/spt-base/src/test/java/com/dell/spt/base/item/op/OperationImplTest.java
@@ -3,9 +3,40 @@ package com.dell.spt.base.item.op;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.dell.spt.base.item.ItemImpl;
+import java.util.ArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
 
 class OperationImplTest {
+
+	@Test
+	void retryCountPreservesConcurrentIncrements() throws Exception {
+		final int workerCount = 8;
+		final int incrementsPerWorker = 100_000;
+		final var op = new OperationImpl<>(0, OpType.CREATE, new ItemImpl("item"), null, null, null);
+		final var start = new CountDownLatch(1);
+		final var futures = new ArrayList<java.util.concurrent.Future<?>>();
+
+		try (final var executor = Executors.newFixedThreadPool(workerCount)) {
+			for (int worker = 0; worker < workerCount; worker++) {
+				futures.add(executor.submit(() -> {
+					start.await();
+					for (int increment = 0; increment < incrementsPerWorker; increment++) {
+						op.incrementOpRetryCount();
+					}
+					return null;
+				}));
+			}
+			start.countDown();
+			for (final var future : futures) {
+				future.get(10, TimeUnit.SECONDS);
+			}
+		}
+
+		assertEquals(workerCount * incrementsPerWorker, op.opRetryCount());
+	}
 
 	@Test
 	void create_doesNotDeriveSrcPathFromKey() {

--- a/engine/core/spt-base/src/test/java/com/dell/spt/base/load/step/local/context/LoadStepContextImplTest.java
+++ b/engine/core/spt-base/src/test/java/com/dell/spt/base/load/step/local/context/LoadStepContextImplTest.java
@@ -50,6 +50,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -1735,7 +1736,7 @@ public class LoadStepContextImplTest {
 		// stable across a retry's original attempt vs. its later copies. The item object
 		// reference itself, however, is shared (copy-constructed, not cloned) all the way
 		// through every result() copy in the chain, so identity is the stable key.
-		private final Map<DataItem, Integer> attemptsByItem = new java.util.IdentityHashMap<>();
+		private final IdentityHashMap<DataItem, Integer> attemptsByItem = new IdentityHashMap<>();
 		private final Object attemptsByItemLock = new Object();
 		private final AtomicInteger totalPutCalls = new AtomicInteger();
 		private final AtomicInteger successCount = new AtomicInteger();
@@ -1865,7 +1866,7 @@ public class LoadStepContextImplTest {
 		private final int failuresBeforeSuccess;
 		private final Operation.Status failureStatus;
 		private final long completionDelayMillis;
-		private final Map<DataItem, Integer> attemptsByItem = new java.util.IdentityHashMap<>();
+		private final IdentityHashMap<DataItem, Integer> attemptsByItem = new IdentityHashMap<>();
 		private final Object attemptsByItemLock = new Object();
 		private final AtomicInteger totalPutCalls = new AtomicInteger();
 		private final AtomicInteger successCount = new AtomicInteger();
@@ -2033,7 +2034,9 @@ public class LoadStepContextImplTest {
 				final DataOperation<DataItem> dataOp = (DataOperation<DataItem>) op;
 				try {
 					dataOp.countBytesDone(dataOp.item().size());
-				} catch (final IOException ignored) {}
+				} catch (final IOException e) {
+					throw new AssertionError("test item size should be readable", e);
+				}
 			}
 			op.status(Operation.Status.SUCC);
 			op.finishResponse();

--- a/engine/core/spt-base/src/test/java/com/dell/spt/base/metrics/MetricsManagerImplCsvTotalTest.java
+++ b/engine/core/spt-base/src/test/java/com/dell/spt/base/metrics/MetricsManagerImplCsvTotalTest.java
@@ -128,7 +128,7 @@ class MetricsManagerImplCsvTotalTest {
 	}
 
 	private static void configureSortOrder(final List<DistributedMetricsContext> contexts) {
-		final Map<DistributedMetricsContext, Integer> orderByContext = new IdentityHashMap<>();
+		final IdentityHashMap<DistributedMetricsContext, Integer> orderByContext = new IdentityHashMap<>();
 		for (int i = 0; i < contexts.size(); i++) {
 			orderByContext.put(contexts.get(i), i);
 		}

--- a/engine/tools/errorprone-init.gradle
+++ b/engine/tools/errorprone-init.gradle
@@ -19,9 +19,9 @@ allprojects { prj ->
                 errorprone 'com.google.errorprone:error_prone_core:2.36.0'
             }
             prj.tasks.withType(JavaCompile).configureEach { JavaCompile t ->
-                // Treat everything as warnings for triage
-                options.errorprone.allErrorsAsWarnings.set(true)
-                options.errorprone.disableWarningsInGeneratedCode.set(true)
+				// Keep the lint gate fail-closed: Error Prone warnings and errors fail compilation.
+				options.compilerArgs.add('-Werror')
+				options.errorprone.disableWarningsInGeneratedCode.set(true)
             }
         }
     }


### PR DESCRIPTION
## Summary

- run the engine Error Prone target from the repository-level lint workflow
- resolve the six existing Error Prone findings
- fail lint on future Error Prone warnings and errors
- make operation retry-count updates atomic and cover concurrent increments
