### PR TITLE
Add completion-driven direct dispatch behind spt.dispatch.direct

### DIFF
--- a/engine/extensions/storage-drivers/implementations/s3-rdma/src/main/java/com/dell/spt/storage/driver/coop/netty/http/s3/rdma/S3RdmaStorageDriver.java
+++ b/engine/extensions/storage-drivers/implementations/s3-rdma/src/main/java/com/dell/spt/storage/driver/coop/netty/http/s3/rdma/S3RdmaStorageDriver.java
@@ -185,6 +185,17 @@ public class S3RdmaStorageDriver<I extends Item, O extends Operation<I>>
 		}
 	}
 
+	/**
+	 * RDMA buffer registration and token creation happen in {@link #submit(Operation)}, and
+	 * {@link #httpRequest} only adds the RDMA header when that context exists. Completion-driven
+	 * direct dispatch sends through {@code sendRequest} without calling {@code submit}, so an
+	 * operation dispatched that way would silently fall back to HTTP. Keep the dispatcher path.
+	 */
+	@Override
+	protected boolean supportsDirectDispatch() {
+		return false;
+	}
+
 	@Override
 	protected boolean submit(final O op) throws IllegalStateException {
 		if (shouldUseRdma(op)) {

--- a/engine/extensions/storage-drivers/implementations/s3-rdma/src/test/java/com/dell/spt/storage/driver/coop/netty/http/s3/rdma/S3RdmaStorageDriverOverrideTest.java
+++ b/engine/extensions/storage-drivers/implementations/s3-rdma/src/test/java/com/dell/spt/storage/driver/coop/netty/http/s3/rdma/S3RdmaStorageDriverOverrideTest.java
@@ -8,6 +8,7 @@ import com.dell.spt.base.item.op.data.DataOperationImpl;
 import com.dell.spt.base.integrity.IntegrityMetadataCodec;
 import com.dell.spt.base.integrity.IntegrityResponseObserver;
 import com.dell.spt.base.storage.Credential;
+import com.dell.spt.storage.driver.coop.CoopStorageDriverBase;
 import com.dell.spt.storage.driver.coop.netty.NettyStorageDriver;
 import com.dell.spt.storage.driver.coop.netty.http.s3.S3ResponseHandler;
 import com.github.akurilov.commons.io.Output;
@@ -121,6 +122,24 @@ public class S3RdmaStorageDriverOverrideTest {
 		assertTrue(found);
 		assertFalse(rdmaOps.containsKey(op));
 		Mockito.verify(transport).deregisterBuffer(buf, mrHandle);
+	}
+
+	@Test
+	void directDispatchStaysOffBecauseRdmaPreparationLivesInSubmit() throws Exception {
+		final var prior = System.setProperty("spt.dispatch.direct", "true");
+		try {
+			final var driver = newDriver(enabledConfig(), availableTransport());
+			final Method enabled = CoopStorageDriverBase.class.getDeclaredMethod("directDispatchEnabled");
+			enabled.setAccessible(true);
+			assertFalse((Boolean) enabled.invoke(driver),
+							"a directly dispatched op would bypass submitRdma() and fall back to HTTP");
+		} finally {
+			if (prior == null) {
+				System.clearProperty("spt.dispatch.direct");
+			} else {
+				System.setProperty("spt.dispatch.direct", prior);
+			}
+		}
 	}
 
 	@Test

--- a/engine/extensions/storage-drivers/implementations/s3-tables/src/main/java/com/dell/spt/storage/driver/coop/netty/http/s3/tables/S3TablesStorageDriver.java
+++ b/engine/extensions/storage-drivers/implementations/s3-tables/src/main/java/com/dell/spt/storage/driver/coop/netty/http/s3/tables/S3TablesStorageDriver.java
@@ -160,6 +160,12 @@ public class S3TablesStorageDriver<I extends Item, O extends Operation<I>>
 		}
 	}
 
+	/** Every mode below is driven from {@link #submit}; nothing here may be sent by completion. */
+	@Override
+	protected boolean supportsDirectDispatch() {
+		return false;
+	}
+
 	@Override
 	protected boolean submit(final O op) throws IllegalStateException {
 		// This implementation bypasses NettyStorageDriverBase.submit() for synchronous

--- a/engine/extensions/storage-drivers/primitives/coop/src/main/java/com/dell/spt/storage/driver/coop/CoopStorageDriverBase.java
+++ b/engine/extensions/storage-drivers/primitives/coop/src/main/java/com/dell/spt/storage/driver/coop/CoopStorageDriverBase.java
@@ -43,6 +43,8 @@ public abstract class CoopStorageDriverBase<I extends Item, O extends Operation<
 	static final int MAX_PART_RETRIES = 3;
 	static final String CHILD_OP_ENQUEUE_TIMEOUT_MILLIS_PROPERTY = "spt.mpu.child.enqueue.timeout.millis";
 	static final long DEFAULT_CHILD_OP_ENQUEUE_TIMEOUT_MILLIS = 30_000L;
+	/** Experimental: completion-driven direct dispatch for built-in transport drivers. */
+	static final String DIRECT_DISPATCH_PROPERTY = "spt.dispatch.direct";
 	private static final String KEY_FINALIZATION_ENQUEUED = "sptFinalizationEnqueued";
 
 	protected final Semaphore concurrencyThrottle;
@@ -59,6 +61,7 @@ public abstract class CoopStorageDriverBase<I extends Item, O extends Operation<
 	private final Object mpuSchedulingLock = new Object();
 	private final int configuredMpuObjectLimit;
 	private final int configuredMpuPartLimit;
+	private final boolean directDispatchEnabled = Boolean.getBoolean(DIRECT_DISPATCH_PROPERTY);
 	private volatile boolean mpuSchedulingInitialized = false;
 	/**
 	 * @deprecated retained for binary compatibility only; SPT never reads this field and writes
@@ -261,6 +264,59 @@ public abstract class CoopStorageDriverBase<I extends Item, O extends Operation<
 		return Math.max(
 						0,
 						Math.min(bufferedOperationCount, concurrencyThrottle.availablePermits()));
+	}
+
+	/**
+	 * Returns whether completion-driven direct dispatch is enabled for this driver. Read once from
+	 * {@value #DIRECT_DISPATCH_PROPERTY}; off by default so the dispatcher path is unchanged.
+	 */
+	protected final boolean directDispatchEnabled() {
+		return directDispatchEnabled;
+	}
+
+	/** Operations the dispatch task has drained but not yet submitted. */
+	protected final int dispatcherBacklog() {
+		final var task = this.opDispatchTask;
+		return task == null ? 0 : task.backlog();
+	}
+
+	/**
+	 * Takes the next plain operation for a caller which already holds a concurrency permit and a
+	 * transport channel, crossing the dispatch boundary under the admission lock. Returns
+	 * {@code null} when the caller must instead release its permit and wake the dispatcher: the
+	 * queue is empty, the head is composite, partial or NOOP work, child operations are pending,
+	 * the dispatcher retains a backlog, or admission has closed. A returned operation is already
+	 * {@code DISPATCHED}; the caller owns starting its transport or completing it as failed.
+	 */
+	protected final O pollForDirectDispatch() {
+		if (admissionLock == null || !isStarted() || dispatcherBacklog() > 0) {
+			return null;
+		}
+		admissionLock.lock();
+		try {
+			if (!admissionOpen || !childOpQueue.isEmpty()) {
+				return null;
+			}
+			final O head = inOpQueue.peek();
+			if (head == null || !isDirectDispatchEligible(head)) {
+				return null;
+			}
+			inOpQueue.poll();
+			if (markDispatchOwnership(head)) {
+				return head;
+			}
+			operationLifecycle().unattempted(head);
+			return null;
+		} finally {
+			admissionLock.unlock();
+		}
+	}
+
+	/** Plain operations only: composite and partial work keeps the dispatcher's MPU accounting. */
+	protected static boolean isDirectDispatchEligible(final Operation<?> op) {
+		return !(op instanceof CompositeOperation)
+						&& !(op instanceof PartialOperation)
+						&& !OpType.NOOP.equals(op.type());
 	}
 
 	/** Returns whether new transport dispatch may begin. */

--- a/engine/extensions/storage-drivers/primitives/coop/src/main/java/com/dell/spt/storage/driver/coop/CoopStorageDriverBase.java
+++ b/engine/extensions/storage-drivers/primitives/coop/src/main/java/com/dell/spt/storage/driver/coop/CoopStorageDriverBase.java
@@ -770,8 +770,17 @@ public abstract class CoopStorageDriverBase<I extends Item, O extends Operation<
 		return Long.getLong(CHILD_OP_ENQUEUE_TIMEOUT_MILLIS_PROPERTY, DEFAULT_CHILD_OP_ENQUEUE_TIMEOUT_MILLIS);
 	}
 
-	@SuppressWarnings("unchecked")
 	protected final boolean handleCompleted(final O op) {
+		return handleCompleted(op, true);
+	}
+
+	/**
+	 * Completes {@code op}; {@code wakeDispatcher} is {@code false} only when the caller still owns
+	 * the completed operation's permit and will either hand it to the next operation directly or
+	 * release it and wake the dispatcher itself, so the per-completion unpark is not paid twice.
+	 */
+	@SuppressWarnings("unchecked")
+	protected final boolean handleCompleted(final O op, final boolean wakeDispatcher) {
 		final boolean accepted = super.handleCompleted(op);
 		if (!accepted) {
 			if (op instanceof CompositeOperation || op instanceof PartialOperation) {
@@ -835,7 +844,9 @@ public abstract class CoopStorageDriverBase<I extends Item, O extends Operation<
 				enqueueChildOp((O) parentOp, op, "completion operation");
 			}
 		}
-		signalDispatch();
+		if (wakeDispatcher) {
+			signalDispatch();
+		}
 		return true;
 	}
 

--- a/engine/extensions/storage-drivers/primitives/coop/src/main/java/com/dell/spt/storage/driver/coop/CoopStorageDriverBase.java
+++ b/engine/extensions/storage-drivers/primitives/coop/src/main/java/com/dell/spt/storage/driver/coop/CoopStorageDriverBase.java
@@ -61,7 +61,10 @@ public abstract class CoopStorageDriverBase<I extends Item, O extends Operation<
 	private final Object mpuSchedulingLock = new Object();
 	private final int configuredMpuObjectLimit;
 	private final int configuredMpuPartLimit;
-	private final boolean directDispatchEnabled = Boolean.getBoolean(DIRECT_DISPATCH_PROPERTY);
+	// Evaluated once so the per-operation path reads one final field. supportsDirectDispatch()
+	// must therefore be a constant for the subclass, which is all the capability declaration is.
+	private final boolean directDispatchEnabled = Boolean.getBoolean(DIRECT_DISPATCH_PROPERTY)
+					&& supportsDirectDispatch();
 	private volatile boolean mpuSchedulingInitialized = false;
 	/**
 	 * @deprecated retained for binary compatibility only; SPT never reads this field and writes
@@ -267,11 +270,23 @@ public abstract class CoopStorageDriverBase<I extends Item, O extends Operation<
 	}
 
 	/**
-	 * Returns whether completion-driven direct dispatch is enabled for this driver. Read once from
-	 * {@value #DIRECT_DISPATCH_PROPERTY}; off by default so the dispatcher path is unchanged.
+	 * Returns whether completion-driven direct dispatch is enabled for this driver: the JVM-wide
+	 * {@value #DIRECT_DISPATCH_PROPERTY} is set and the driver declares the capability through
+	 * {@link #supportsDirectDispatch()}. Off by default so the dispatcher path is unchanged; drivers
+	 * without a direct completion path keep the unchanged dispatcher scheduling even when the
+	 * property is set.
 	 */
 	protected final boolean directDispatchEnabled() {
 		return directDispatchEnabled;
+	}
+
+	/**
+	 * Declares that this driver's completion path calls {@link #pollForDirectDispatch()} and can
+	 * transfer its permit and transport to the returned operation. Must return a constant: it is
+	 * read once during {@code CoopStorageDriverBase} construction, before subclass fields exist.
+	 */
+	protected boolean supportsDirectDispatch() {
+		return false;
 	}
 
 	/** Operations the dispatch task has drained but not yet submitted. */
@@ -770,6 +785,7 @@ public abstract class CoopStorageDriverBase<I extends Item, O extends Operation<
 		return Long.getLong(CHILD_OP_ENQUEUE_TIMEOUT_MILLIS_PROPERTY, DEFAULT_CHILD_OP_ENQUEUE_TIMEOUT_MILLIS);
 	}
 
+	@Override
 	protected final boolean handleCompleted(final O op) {
 		return handleCompleted(op, true);
 	}

--- a/engine/extensions/storage-drivers/primitives/coop/src/main/java/com/dell/spt/storage/driver/coop/OperationDispatchTask.java
+++ b/engine/extensions/storage-drivers/primitives/coop/src/main/java/com/dell/spt/storage/driver/coop/OperationDispatchTask.java
@@ -66,6 +66,7 @@ public final class OperationDispatchTask<I extends Item, O extends Operation<I>>
 	private final Queue<O> deferredMpuQueue;
 	private volatile List<SubmittingOperation<O>> submittingOperations = List.of();
 	private volatile Thread dispatchThread;
+	private volatile int backlog;
 
 	/**
 	 * The {@code dispatchReady} condition is retained in the descriptor for existing extensions
@@ -124,10 +125,32 @@ public final class OperationDispatchTask<I extends Item, O extends Operation<I>>
 	 * {@link #stop()} still terminates the work loop promptly.
 	 */
 	private void awaitDispatchSignal() throws InterruptedException {
+		publishBacklog();
 		LockSupport.park(this);
 		if (Thread.currentThread().isInterrupted()) {
 			throw new InterruptedException();
 		}
+	}
+
+	/**
+	 * Operations this task has drained from the shared queues but not yet submitted, plus deferred
+	 * multipart work. Published before every park and after every iteration so a transport
+	 * completion can yield its permit to buffered work instead of dispatching past it.
+	 */
+	int backlog() {
+		return backlog;
+	}
+
+	private void publishBacklog() {
+		backlog = buff.size() + tempInOps.size() + deferredMpuQueue.size();
+	}
+
+	private int incomingDrainLimit(final int maxCount) {
+		// With completion-driven dispatch the event loop serves queued work directly, so the task
+		// takes only what it can submit now and leaves the rest visible in the shared queue.
+		return storageDriver.directDispatchEnabled()
+						? storageDriver.dispatchAttemptLimit(maxCount)
+						: maxCount;
 	}
 
 	@Override
@@ -151,6 +174,12 @@ public final class OperationDispatchTask<I extends Item, O extends Operation<I>>
 				drainIncomingOperations(Math.max(0, Math.min(batchSize, deferredQueueCapacity - deferredMpuQueue.size())));
 				if (tempInOps.isEmpty() && deferredMpuQueue.isEmpty()) {
 					if (childOpQueue.isEmpty() && inOpQueue.isEmpty()) {
+						awaitDispatchSignal();
+					} else if (childOpQueue.isEmpty()
+									&& storageDriver.directDispatchEnabled()
+									&& !storageDriver.hasAvailableDispatchCapacity()) {
+						// Queued work exists but every permit is in flight; completions will either
+						// dispatch it directly or release a permit and unpark this task.
 						awaitDispatchSignal();
 					}
 					// Drain again after waking
@@ -204,6 +233,7 @@ public final class OperationDispatchTask<I extends Item, O extends Operation<I>>
 					buff.add(op);
 				}
 			}
+			tempInOps.clear();
 
 			// submit all buffered ops (including retries from prior iterations)
 			final int buffSize = buff.size();
@@ -254,16 +284,18 @@ public final class OperationDispatchTask<I extends Item, O extends Operation<I>>
 							storageDriver.toString(), storageDriver.state());
 		} finally {
 			tempInOps.clear();
+			publishBacklog();
 		}
 	}
 
 	private void drainIncomingOperations(final int maxCount) {
-		if (maxCount <= 0) {
+		final int limit = incomingDrainLimit(maxCount);
+		if (limit <= 0) {
 			return;
 		}
 		dispatchLock.lock();
 		try {
-			inOpQueue.drainTo(tempInOps, maxCount);
+			inOpQueue.drainTo(tempInOps, limit);
 		} finally {
 			dispatchLock.unlock();
 		}

--- a/engine/extensions/storage-drivers/primitives/coop/src/test/java/com/dell/spt/storage/driver/coop/DirectDispatchSeamTest.java
+++ b/engine/extensions/storage-drivers/primitives/coop/src/test/java/com/dell/spt/storage/driver/coop/DirectDispatchSeamTest.java
@@ -1,0 +1,258 @@
+package com.dell.spt.storage.driver.coop;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import com.dell.spt.base.data.DataInput;
+import com.dell.spt.base.item.DataItem;
+import com.dell.spt.base.item.DataItemImpl;
+import com.dell.spt.base.item.op.OpType;
+import com.dell.spt.base.item.op.Operation;
+import com.dell.spt.base.item.op.composite.data.CompositeDataOperationImpl;
+import com.dell.spt.base.item.op.data.DataOperationImpl;
+import com.dell.spt.base.load.lifecycle.OperationLifecycleState;
+import com.dell.spt.storage.driver.coop.mock.CoopStorageDriverMock;
+import com.github.akurilov.commons.io.Output;
+import com.github.akurilov.commons.system.SizeInBytes;
+import com.github.akurilov.confuse.Config;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BooleanSupplier;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for the completion-driven direct dispatch seam on {@link CoopStorageDriverBase}. The
+ * caller of {@code pollForDirectDispatch()} models a transport completion which still holds a
+ * concurrency permit and asks for the next plain operation to send on the channel it already has.
+ */
+@SuppressWarnings("unchecked")
+class DirectDispatchSeamTest {
+
+	/** Refuses every submit so the dispatcher never consumes queued work on its own. */
+	private static final class RefusingDriver
+					extends CoopStorageDriverMock<DataItem, Operation<DataItem>> {
+		private RefusingDriver(final Config storageConfig) throws Exception {
+			super("direct-dispatch-step", dataInput(), storageConfig, false, 4);
+		}
+
+		@Override
+		protected boolean submit(final Operation<DataItem> op) {
+			return false;
+		}
+
+		@Override
+		protected int submit(final List<Operation<DataItem>> ops, final int from, final int to) {
+			return 0;
+		}
+
+		@Override
+		protected int submit(final List<Operation<DataItem>> ops) {
+			return 0;
+		}
+	}
+
+	/** Steals the only permit inside its first submit so the dispatcher retains a backlog. */
+	private static final class PermitStealingDriver
+					extends CoopStorageDriverMock<DataItem, Operation<DataItem>> {
+		private boolean stolen;
+
+		private PermitStealingDriver(final Config storageConfig) throws Exception {
+			super("direct-dispatch-backlog-step", dataInput(), storageConfig, false, 4);
+		}
+
+		@Override
+		protected boolean submit(final Operation<DataItem> op) {
+			if (!stolen) {
+				stolen = true;
+				assertTrue(concurrencyThrottle.tryAcquire());
+			}
+			return false;
+		}
+
+		@Override
+		protected int submit(final List<Operation<DataItem>> ops, final int from, final int to) {
+			return submit(ops.get(from)) ? 1 : 0;
+		}
+
+		@Override
+		protected int submit(final List<Operation<DataItem>> ops) {
+			return submit(ops, 0, ops.size());
+		}
+	}
+
+	private CoopStorageDriverBase<DataItem, Operation<DataItem>> driver;
+
+	@BeforeEach
+	void enableDirectDispatch() {
+		System.setProperty(CoopStorageDriverBase.DIRECT_DISPATCH_PROPERTY, "true");
+	}
+
+	@AfterEach
+	void closeDriver() throws Exception {
+		System.clearProperty(CoopStorageDriverBase.DIRECT_DISPATCH_PROPERTY);
+		if (driver != null) {
+			driver.close();
+		}
+	}
+
+	private static DataInput dataInput() throws Exception {
+		return DataInput.instance(null, "7a42d9c483244167", new SizeInBytes("64KB"), 4, false, 0.0, true);
+	}
+
+	private static Config storageConfig(final int concurrencyLimit) {
+		final var storageConfig = mock(Config.class);
+		final var driverConfig = mock(Config.class);
+		final var limitConfig = mock(Config.class);
+		final var authConfig = mock(Config.class);
+		final var integrityConfig = mock(Config.class);
+		final var integrityInputConfig = mock(Config.class);
+		when(storageConfig.configVal("driver")).thenReturn(driverConfig);
+		when(driverConfig.configVal("limit")).thenReturn(limitConfig);
+		when(storageConfig.stringVal("namespace")).thenReturn("test-ns");
+		when(storageConfig.configVal("auth")).thenReturn(authConfig);
+		when(storageConfig.configVal("integrity")).thenReturn(integrityConfig);
+		when(integrityConfig.stringVal("mode")).thenReturn("none");
+		when(integrityConfig.stringVal("algorithm")).thenReturn("sha256");
+		when(integrityConfig.configVal("input")).thenReturn(integrityInputConfig);
+		when(integrityInputConfig.stringVal("provenance")).thenReturn("none");
+		when(integrityInputConfig.stringVal("expectedProducerId")).thenReturn("");
+		when(authConfig.stringVal("uid")).thenReturn("user");
+		when(authConfig.stringVal("secret")).thenReturn("secret");
+		when(authConfig.stringVal("token")).thenReturn(null);
+		when(limitConfig.intVal("concurrency")).thenReturn(concurrencyLimit);
+		when(driverConfig.intVal("threads")).thenReturn(0);
+		when(storageConfig.intVal("driver-limit-queue-input")).thenReturn(16);
+		when(storageConfig.intVal("driver-limit-multipart-objects")).thenReturn(0);
+		when(storageConfig.intVal("driver-limit-multipart-parts")).thenReturn(0);
+		return storageConfig;
+	}
+
+	private static Operation<DataItem> plainOp(final String name) {
+		return new DataOperationImpl<>(
+						0, OpType.DELETE, new DataItemImpl(name, 0, 1), null, "/bucket", null, List.of(), 0);
+	}
+
+	private static Operation<DataItem> compositeOp(final String name) throws Exception {
+		final var item = new DataItemImpl(name, 0, 4096);
+		item.dataInput(dataInput());
+		return new CompositeDataOperationImpl<>(
+						0, OpType.CREATE, item, null, "/bucket", null, null, 0, 1024);
+	}
+
+	private static void awaitCondition(
+					final BooleanSupplier condition, final String failureMessage) throws InterruptedException {
+		final long deadlineNanos = System.nanoTime() + TimeUnit.SECONDS.toNanos(2);
+		while (!condition.getAsBoolean() && System.nanoTime() < deadlineNanos) {
+			Thread.sleep(10);
+		}
+		assertTrue(condition.getAsBoolean(), failureMessage);
+	}
+
+	/** Starts a driver whose single permit is held by the caller, as a completing op would hold it. */
+	private CoopStorageDriverBase<DataItem, Operation<DataItem>> startWithPermitHeld() throws Exception {
+		final var started = new RefusingDriver(storageConfig(1));
+		final Output<Operation<DataItem>> resultOutput = mock(Output.class);
+		when(resultOutput.put(any(Operation.class))).thenReturn(true);
+		started.operationResultOutput(resultOutput);
+		started.start();
+		assertTrue(started.concurrencyThrottle.tryAcquire());
+		driver = started;
+		return started;
+	}
+
+	@Test
+	void pollsQueuedPlainOperationAndMarksItDispatched() throws Exception {
+		final var driver = startWithPermitHeld();
+		final var op = plainOp("plain");
+		assertTrue(driver.put(op));
+		awaitCondition(
+						() -> driver.operationLifecycle().snapshot().driverQueued() == 1,
+						"operation should be queued while the permit is held");
+
+		assertSame(op, driver.pollForDirectDispatch());
+
+		assertEquals(OperationLifecycleState.DISPATCHED, driver.operationLifecycle().stateOf(op));
+		assertTrue(driver.operationLifecycle().hasExplicitDispatchBoundary(op));
+		assertNull(driver.pollForDirectDispatch(), "the queue is now empty");
+		driver.closeAdmission();
+		assertTrue(driver.recoverQueuedOperations().isEmpty(), "a dispatched op is not recovered");
+	}
+
+	@Test
+	void refusesWhenHeadIsCompositeAndLeavesItQueued() throws Exception {
+		final var driver = startWithPermitHeld();
+		final var composite = compositeOp("mpu");
+		final var plain = plainOp("behind-composite");
+		assertTrue(driver.put(composite));
+		assertTrue(driver.put(plain));
+		awaitCondition(
+						() -> driver.operationLifecycle().snapshot().driverQueued() == 2,
+						"both operations should be queued while the permit is held");
+
+		assertNull(driver.pollForDirectDispatch(), "composite work belongs to the dispatcher");
+
+		assertEquals(OperationLifecycleState.DRIVER_QUEUED, driver.operationLifecycle().stateOf(composite));
+		assertEquals(OperationLifecycleState.DRIVER_QUEUED, driver.operationLifecycle().stateOf(plain));
+		driver.closeAdmission();
+		assertEquals(2, driver.recoverQueuedOperations().size());
+	}
+
+	@Test
+	void refusesWhileChildOperationsArePending() throws Exception {
+		final var driver = startWithPermitHeld();
+		final var plain = plainOp("plain");
+		assertTrue(driver.put(plain));
+		awaitCondition(
+						() -> driver.operationLifecycle().snapshot().driverQueued() == 1,
+						"operation should be queued while the permit is held");
+		final var child = plainOp("child");
+		assertTrue(driver.operationLifecycle().driverQueued(child));
+		assertTrue(driver.childOpQueue.offer(child));
+
+		assertNull(driver.pollForDirectDispatch(), "child operations keep dispatcher priority");
+
+		assertEquals(OperationLifecycleState.DRIVER_QUEUED, driver.operationLifecycle().stateOf(plain));
+	}
+
+	@Test
+	void refusesAfterAdmissionCloseAndRecoveryStaysLossless() throws Exception {
+		final var driver = startWithPermitHeld();
+		final var op = plainOp("late");
+		assertTrue(driver.put(op));
+		awaitCondition(
+						() -> driver.operationLifecycle().snapshot().driverQueued() == 1,
+						"operation should be queued while the permit is held");
+
+		driver.closeAdmission();
+
+		assertNull(driver.pollForDirectDispatch(), "nothing crosses dispatch after admission closes");
+		assertEquals(List.of(op), driver.recoverQueuedOperations());
+		assertEquals(OperationLifecycleState.UNATTEMPTED, driver.operationLifecycle().stateOf(op));
+	}
+
+	@Test
+	void refusesWhileDispatcherRetainsBacklog() throws Exception {
+		final var stealing = new PermitStealingDriver(storageConfig(1));
+		driver = stealing;
+		final Output<Operation<DataItem>> resultOutput = mock(Output.class);
+		when(resultOutput.put(any(Operation.class))).thenReturn(true);
+		stealing.operationResultOutput(resultOutput);
+		stealing.start();
+		final var buffered = plainOp("buffered");
+		assertTrue(stealing.put(buffered));
+		awaitCondition(() -> stealing.dispatcherBacklog() == 1, "dispatcher should retain the refused op");
+		final var queued = plainOp("queued");
+		assertTrue(stealing.put(queued));
+		awaitCondition(
+						() -> stealing.operationLifecycle().snapshot().driverQueued() == 2,
+						"second operation should be queued");
+
+		assertNull(stealing.pollForDirectDispatch(), "buffered dispatcher work gets the next permit");
+
+		assertEquals(OperationLifecycleState.DRIVER_QUEUED, stealing.operationLifecycle().stateOf(queued));
+		stealing.closeAdmission();
+		assertEquals(2, stealing.recoverQueuedOperations().size(), "both identities recovered");
+	}
+}

--- a/engine/extensions/storage-drivers/primitives/coop/src/test/java/com/dell/spt/storage/driver/coop/DirectDispatchSeamTest.java
+++ b/engine/extensions/storage-drivers/primitives/coop/src/test/java/com/dell/spt/storage/driver/coop/DirectDispatchSeamTest.java
@@ -38,6 +38,11 @@ class DirectDispatchSeamTest {
 		}
 
 		@Override
+		protected boolean supportsDirectDispatch() {
+			return true;
+		}
+
+		@Override
 		protected boolean submit(final Operation<DataItem> op) {
 			return false;
 		}
@@ -63,6 +68,11 @@ class DirectDispatchSeamTest {
 		}
 
 		@Override
+		protected boolean supportsDirectDispatch() {
+			return true;
+		}
+
+		@Override
 		protected boolean submit(final Operation<DataItem> op) {
 			if (!stolen) {
 				stolen = true;
@@ -83,15 +93,20 @@ class DirectDispatchSeamTest {
 	}
 
 	private CoopStorageDriverBase<DataItem, Operation<DataItem>> driver;
+	private String priorPropertyValue;
 
 	@BeforeEach
 	void enableDirectDispatch() {
-		System.setProperty(CoopStorageDriverBase.DIRECT_DISPATCH_PROPERTY, "true");
+		priorPropertyValue = System.setProperty(CoopStorageDriverBase.DIRECT_DISPATCH_PROPERTY, "true");
 	}
 
 	@AfterEach
 	void closeDriver() throws Exception {
-		System.clearProperty(CoopStorageDriverBase.DIRECT_DISPATCH_PROPERTY);
+		if (priorPropertyValue == null) {
+			System.clearProperty(CoopStorageDriverBase.DIRECT_DISPATCH_PROPERTY);
+		} else {
+			System.setProperty(CoopStorageDriverBase.DIRECT_DISPATCH_PROPERTY, priorPropertyValue);
+		}
 		if (driver != null) {
 			driver.close();
 		}
@@ -160,6 +175,18 @@ class DirectDispatchSeamTest {
 		assertTrue(started.concurrencyThrottle.tryAcquire());
 		driver = started;
 		return started;
+	}
+
+	@Test
+	void propertyAloneDoesNotEnableDirectDispatchForDriversWithoutTheCapability() throws Exception {
+		final var plainMock = new CoopStorageDriverMock<DataItem, Operation<DataItem>>(
+						"no-capability-step", dataInput(), storageConfig(1), false, 4);
+		driver = plainMock;
+
+		assertFalse(plainMock.directDispatchEnabled(), "NIO and extension drivers keep dispatcher scheduling");
+		try (final var capable = new RefusingDriver(storageConfig(1))) {
+			assertTrue(capable.directDispatchEnabled());
+		}
 	}
 
 	@Test

--- a/engine/extensions/storage-drivers/primitives/coop/src/test/java/com/dell/spt/storage/driver/coop/OperationDispatchTaskTest.java
+++ b/engine/extensions/storage-drivers/primitives/coop/src/test/java/com/dell/spt/storage/driver/coop/OperationDispatchTaskTest.java
@@ -405,6 +405,82 @@ class OperationDispatchTaskTest {
 	}
 
 	@Test
+	void directDispatchCapsIncomingDrainAtAvailableCapacity() throws Exception {
+		when(driverMock.directDispatchEnabled()).thenReturn(true);
+		when(driverMock.dispatchAttemptLimit(anyInt()))
+						.thenAnswer(invocation -> Math.min(1, (int) invocation.getArgument(0)));
+		final var submitted = new ArrayList<Operation<Item>>();
+		captureSubmittedOps(submitted);
+		for (var i = 0; i < 4; i++) {
+			inOpQueue.add(mock(Operation.class));
+		}
+
+		task.doWork();
+
+		assertEquals(1, submitted.size(), "only the op which can take a permit is drained");
+		assertEquals(3, inOpQueue.size(), "the rest stay visible to completion-driven dispatch");
+		assertEquals(0, task.backlog());
+	}
+
+	@Test
+	void directDispatchParksWhenQueuedWorkHasNoCapacity() throws Exception {
+		when(driverMock.directDispatchEnabled()).thenReturn(true);
+		when(driverMock.dispatchAttemptLimit(anyInt())).thenReturn(0);
+		when(driverMock.hasAvailableDispatchCapacity()).thenReturn(false);
+		inOpQueue.add(mock(Operation.class));
+
+		final var returned = new AtomicBoolean();
+		final var worker = Thread.ofVirtual().start(() -> {
+			try {
+				task.doWork();
+				returned.set(true);
+			} catch (Exception e) {
+				throw new RuntimeException(e);
+			}
+		});
+		Thread.sleep(100);
+
+		assertFalse(returned.get(), "dispatcher must park rather than spin while the event loop owns every permit");
+		verify(driverMock, never()).submit(any(Operation.class));
+		assertEquals(1, inOpQueue.size());
+
+		task.unpark();
+		worker.join(5000);
+		assertTrue(returned.get());
+	}
+
+	@Test
+	void backlogPublishesRetainedBufferedOps() throws Exception {
+		final Operation<Item> op = mock(Operation.class);
+		when(driverMock.submit(any(Operation.class)))
+						.thenReturn(false)
+						.thenReturn(true);
+		when(driverMock.hasAvailableDispatchCapacity()).thenReturn(false);
+		inOpQueue.add(op);
+		assertEquals(0, task.backlog());
+
+		final var worker = Thread.ofVirtual().start(() -> {
+			try {
+				task.doWork();
+			} catch (Exception e) {
+				throw new RuntimeException(e);
+			}
+		});
+		Thread.sleep(50);
+
+		assertEquals(1, task.backlog(),
+						"a refused op retained in the buffer is published before the dispatcher parks");
+
+		task.unpark();
+		worker.join(5000);
+		assertEquals(1, task.backlog());
+
+		task.doWork();
+
+		assertEquals(0, task.backlog());
+	}
+
+	@Test
 	void backpressureRetainsBufferedOp() throws Exception {
 		final Operation<Item> op = mock(Operation.class);
 		when(driverMock.submit(any(Operation.class)))
@@ -546,7 +622,9 @@ class OperationDispatchTaskTest {
 		// Wait until the first attempt has entered backpressure before signaling the completion.
 		// Otherwise a busy suite may deliver this signal before the dispatcher starts awaiting it.
 		verify(driverMock, timeout(1000)).submit(any(Operation.class));
-		when(driverMock.hasAvailableDispatchCapacity()).thenReturn(true);
+		// doReturn: the dispatcher thread is invoking this mock concurrently, so when(...) could
+		// bind the stub to whichever call the other thread made last.
+		doReturn(true).when(driverMock).hasAvailableDispatchCapacity();
 		task.unpark();
 
 		// Should eventually succeed on retry

--- a/engine/extensions/storage-drivers/primitives/netty/src/main/java/com/dell/spt/storage/driver/coop/netty/NettyStorageDriverBase.java
+++ b/engine/extensions/storage-drivers/primitives/netty/src/main/java/com/dell/spt/storage/driver/coop/netty/NettyStorageDriverBase.java
@@ -810,6 +810,11 @@ public abstract class NettyStorageDriverBase<I extends Item, O extends Operation
 		handleCompleted(op);
 	}
 
+	@Override
+	protected final boolean supportsDirectDispatch() {
+		return true;
+	}
+
 	private void releaseTransport(final Channel channel) {
 		concurrencyThrottle.release();
 		connPool.release(channel);

--- a/engine/extensions/storage-drivers/primitives/netty/src/main/java/com/dell/spt/storage/driver/coop/netty/NettyStorageDriverBase.java
+++ b/engine/extensions/storage-drivers/primitives/netty/src/main/java/com/dell/spt/storage/driver/coop/netty/NettyStorageDriverBase.java
@@ -810,8 +810,14 @@ public abstract class NettyStorageDriverBase<I extends Item, O extends Operation
 		handleCompleted(op);
 	}
 
+	/**
+	 * Netty drivers can transfer a completed operation's permit and channel to the next queued
+	 * operation. Subclasses whose {@link #submit(Operation)} does per-operation preparation that
+	 * {@link #sendRequest} alone does not perform must override this to return {@code false}, or
+	 * directly dispatched operations would skip that preparation.
+	 */
 	@Override
-	protected final boolean supportsDirectDispatch() {
+	protected boolean supportsDirectDispatch() {
 		return true;
 	}
 

--- a/engine/extensions/storage-drivers/primitives/netty/src/main/java/com/dell/spt/storage/driver/coop/netty/NettyStorageDriverBase.java
+++ b/engine/extensions/storage-drivers/primitives/netty/src/main/java/com/dell/spt/storage/driver/coop/netty/NettyStorageDriverBase.java
@@ -793,7 +793,7 @@ public abstract class NettyStorageDriverBase<I extends Item, O extends Operation
 			// start on this event-loop thread without a dispatcher hand-off or a pool round trip.
 			var transferred = false;
 			try {
-				handleCompleted(op);
+				handleCompleted(op, false);
 				transferred = tryDirectDispatch(channel);
 			} finally {
 				if (!transferred) {

--- a/engine/extensions/storage-drivers/primitives/netty/src/main/java/com/dell/spt/storage/driver/coop/netty/NettyStorageDriverBase.java
+++ b/engine/extensions/storage-drivers/primitives/netty/src/main/java/com/dell/spt/storage/driver/coop/netty/NettyStorageDriverBase.java
@@ -783,14 +783,63 @@ public abstract class NettyStorageDriverBase<I extends Item, O extends Operation
 			channel.close();
 		}
 
+		final boolean transportHeld = channel != null
+						&& !channel.attr(ATTR_KEY_RELEASED).getAndSet(Boolean.TRUE);
+		if (transportHeld && directDispatchEnabled()
+						&& op.status() == Operation.Status.SUCC
+						&& channel.isActive()
+						&& isDirectDispatchEligible(op)) {
+			// Keep the permit and the channel across completion so the next queued operation can
+			// start on this event-loop thread without a dispatcher hand-off or a pool round trip.
+			var transferred = false;
+			try {
+				handleCompleted(op);
+				transferred = tryDirectDispatch(channel);
+			} finally {
+				if (!transferred) {
+					releaseTransport(channel);
+				}
+			}
+			return;
+		}
 		// Release the permit and channel before reporting completion. Recycled
 		// operations return through the shared LoadGenerator queue for redispatch.
-		if (channel != null && !channel.attr(ATTR_KEY_RELEASED).getAndSet(Boolean.TRUE)) {
-			concurrencyThrottle.release();
-			connPool.release(channel);
-			signalDispatchCapacityAvailable();
+		if (transportHeld) {
+			releaseTransport(channel);
 		}
 		handleCompleted(op);
+	}
+
+	private void releaseTransport(final Channel channel) {
+		concurrencyThrottle.release();
+		connPool.release(channel);
+		signalDispatchCapacityAvailable();
+	}
+
+	/**
+	 * Sends the next plain queued operation on {@code conn}, which the caller still owns together
+	 * with one concurrency permit. Returns {@code false} when no operation was taken and the caller
+	 * must release both; {@code true} when ownership passed to the next operation, including a send
+	 * failure which completes that operation and releases through the normal path.
+	 */
+	private boolean tryDirectDispatch(final Channel conn) {
+		final O nextOp = pollForDirectDispatch();
+		if (nextOp == null) {
+			return false;
+		}
+		conn.attr(ATTR_KEY_RELEASED).set(Boolean.FALSE);
+		try {
+			conn.attr(ATTR_KEY_OPERATION).set(nextOp);
+			nextOp.nodeAddr(conn.attr(ATTR_KEY_NODE).get());
+			nextOp.startRequest();
+			sendRequest(conn, nextOp);
+		} catch (final Throwable thrown) {
+			throwUncheckedIfInterrupted(thrown);
+			logSubmissionFailure(thrown);
+			nextOp.status(Operation.Status.FAIL_UNKNOWN);
+			completeAfterSubmissionSafely(conn, nextOp);
+		}
+		return true;
 	}
 
 	@Override

--- a/engine/extensions/storage-drivers/primitives/netty/src/test/java/com/dell/spt/storage/driver/coop/netty/NettyDirectDispatchTest.java
+++ b/engine/extensions/storage-drivers/primitives/netty/src/test/java/com/dell/spt/storage/driver/coop/netty/NettyDirectDispatchTest.java
@@ -176,6 +176,70 @@ class NettyDirectDispatchTest {
 	}
 
 	@Test
+	void noopHeadStaysForTheDispatcher() {
+		final var channel = heldChannel();
+		final var done = completedOp(Operation.Status.SUCC);
+		final Operation<Item> noop = nextOp();
+		when(noop.type()).thenReturn(OpType.NOOP);
+		inOpQueue.add(noop);
+
+		driver.complete(channel, done);
+
+		assertEquals(1, inOpQueue.size(), "NOOP completes synchronously inside submit and must not chain here");
+		verify(driver, never()).sendRequest(any(), any());
+		assertEquals(1, concurrencyThrottle.availablePermits());
+		verify(connPool).release(channel);
+		channel.close();
+	}
+
+	@Test
+	void inactiveChannelIsReleasedNotReused() {
+		final var channel = heldChannel();
+		channel.close();
+		final var done = completedOp(Operation.Status.SUCC);
+		inOpQueue.add(nextOp());
+
+		driver.complete(channel, done);
+
+		assertEquals(1, inOpQueue.size());
+		verify(driver, never()).sendRequest(any(), any());
+		assertEquals(1, concurrencyThrottle.availablePermits());
+		verify(connPool).release(channel);
+	}
+
+	@Test
+	void stoppedDriverDoesNotPoll() {
+		doReturn(false).when(driver).isStarted();
+		final var channel = heldChannel();
+		final var done = completedOp(Operation.Status.SUCC);
+		inOpQueue.add(nextOp());
+
+		driver.complete(channel, done);
+
+		assertEquals(1, inOpQueue.size(), "shutdown recovery owns queued work once the driver stops");
+		verify(driver, never()).sendRequest(any(), any());
+		assertEquals(1, concurrencyThrottle.availablePermits());
+		verify(connPool).release(channel);
+		channel.close();
+	}
+
+	@Test
+	void alreadyReleasedChannelNeverTransfers() {
+		final var channel = heldChannel();
+		channel.attr(NettyStorageDriver.ATTR_KEY_RELEASED).set(Boolean.TRUE);
+		final var done = completedOp(Operation.Status.SUCC);
+		inOpQueue.add(nextOp());
+
+		driver.complete(channel, done);
+
+		assertEquals(1, inOpQueue.size());
+		verify(driver, never()).sendRequest(any(), any());
+		assertEquals(0, concurrencyThrottle.availablePermits(), "a released channel owns no permit to give back");
+		verify(connPool, never()).release(channel);
+		channel.close();
+	}
+
+	@Test
 	void sendFailureCompletesNextOperationAsFailedAndReleasesTransport() {
 		final var channel = heldChannel();
 		final var done = completedOp(Operation.Status.SUCC);

--- a/engine/extensions/storage-drivers/primitives/netty/src/test/java/com/dell/spt/storage/driver/coop/netty/NettyDirectDispatchTest.java
+++ b/engine/extensions/storage-drivers/primitives/netty/src/test/java/com/dell/spt/storage/driver/coop/netty/NettyDirectDispatchTest.java
@@ -1,0 +1,210 @@
+package com.dell.spt.storage.driver.coop.netty;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import com.dell.spt.base.item.Item;
+import com.dell.spt.base.item.op.OpType;
+import com.dell.spt.base.item.op.Operation;
+import com.dell.spt.base.item.op.composite.CompositeOperation;
+import com.dell.spt.base.storage.driver.StorageDriverBase;
+import com.dell.spt.storage.driver.coop.CoopStorageDriverBase;
+import com.github.akurilov.commons.io.Output;
+import com.github.akurilov.netty.connection.pool.NonBlockingConnPool;
+import io.netty.channel.embedded.EmbeddedChannel;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.atomic.LongAdder;
+import java.util.concurrent.locks.ReentrantLock;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Completion-driven direct dispatch in {@link NettyStorageDriverBase#complete}: a successful
+ * completion on an active channel hands its permit and channel to the next plain queued operation
+ * instead of releasing both and waking the dispatcher.
+ */
+@SuppressWarnings("unchecked")
+class NettyDirectDispatchTest {
+
+	private NettyStorageDriverBase<Item, Operation<Item>> driver;
+	private Semaphore concurrencyThrottle;
+	private NonBlockingConnPool connPool;
+	private Output<Operation<Item>> opResultOut;
+	private ArrayBlockingQueue<Operation<Item>> inOpQueue;
+
+	@BeforeEach
+	void setUp() throws Exception {
+		driver = mock(NettyStorageDriverBase.class, withSettings().defaultAnswer(CALLS_REAL_METHODS));
+		concurrencyThrottle = new Semaphore(1, true);
+		concurrencyThrottle.acquire();
+		set(CoopStorageDriverBase.class, "concurrencyThrottle", concurrencyThrottle);
+		set(StorageDriverBase.class, "concurrencyLimit", 1);
+		connPool = mock(NonBlockingConnPool.class);
+		set(NettyStorageDriverBase.class, "connPool", connPool);
+		set(StorageDriverBase.class, "stepId", "test-step");
+		set(CoopStorageDriverBase.class, "completedOpCount", new LongAdder());
+		set(CoopStorageDriverBase.class, "childOpQueue", new ArrayBlockingQueue<>(100));
+		final var lock = new ReentrantLock();
+		set(CoopStorageDriverBase.class, "dispatchLock", lock);
+		set(CoopStorageDriverBase.class, "admissionLock", lock);
+		set(CoopStorageDriverBase.class, "admissionOpen", true);
+		inOpQueue = new ArrayBlockingQueue<>(100);
+		set(CoopStorageDriverBase.class, "inOpQueue", inOpQueue);
+		opResultOut = mock(Output.class);
+		when(opResultOut.put(any(Operation.class))).thenReturn(true);
+		set(StorageDriverBase.class, "opResultOut", opResultOut);
+		set(CoopStorageDriverBase.class, "directDispatchEnabled", true);
+		doReturn(true).when(driver).isStarted();
+	}
+
+	private void set(final Class<?> owner, final String name, final Object value) throws Exception {
+		final var field = owner.getDeclaredField(name);
+		field.setAccessible(true);
+		field.set(driver, value);
+	}
+
+	private static EmbeddedChannel heldChannel() {
+		final var channel = new EmbeddedChannel();
+		channel.attr(NettyStorageDriver.ATTR_KEY_RELEASED).set(Boolean.FALSE);
+		channel.attr(NonBlockingConnPool.ATTR_KEY_NODE).set("test-node:9020");
+		return channel;
+	}
+
+	private static Operation<Item> completedOp(final Operation.Status status) {
+		final Operation<Item> op = mock(Operation.class);
+		when(op.status()).thenReturn(status);
+		when(op.type()).thenReturn(OpType.CREATE);
+		when(op.result()).thenReturn(mock(Operation.class));
+		return op;
+	}
+
+	private static Operation<Item> nextOp() {
+		final Operation<Item> op = mock(Operation.class);
+		when(op.type()).thenReturn(OpType.CREATE);
+		when(op.status()).thenReturn(Operation.Status.PENDING);
+		when(op.result()).thenReturn(mock(Operation.class));
+		return op;
+	}
+
+	@Test
+	void successfulCompletionHandsPermitAndChannelToNextQueuedOperation() {
+		final var channel = heldChannel();
+		final var done = completedOp(Operation.Status.SUCC);
+		final var next = nextOp();
+		channel.attr(NettyStorageDriver.ATTR_KEY_OPERATION).set(done);
+		inOpQueue.add(next);
+
+		driver.complete(channel, done);
+
+		assertTrue(inOpQueue.isEmpty(), "next op was taken by the completion");
+		verify(opResultOut).put(any(Operation.class));
+		assertEquals(0, concurrencyThrottle.availablePermits(), "permit is transferred, not released");
+		verify(connPool, never()).release(channel);
+		verify(driver).sendRequest(channel, next);
+		verify(next).startRequest();
+		verify(next).nodeAddr("test-node:9020");
+		assertSame(next, channel.attr(NettyStorageDriver.ATTR_KEY_OPERATION).get());
+		assertEquals(Boolean.FALSE, channel.attr(NettyStorageDriver.ATTR_KEY_RELEASED).get(),
+						"the channel is held again on behalf of the next operation");
+		assertTrue(channel.isActive());
+		channel.close();
+	}
+
+	@Test
+	void emptyQueueFallsBackToReleaseAndDispatcherWake() {
+		final var channel = heldChannel();
+		final var done = completedOp(Operation.Status.SUCC);
+
+		driver.complete(channel, done);
+
+		assertEquals(1, concurrencyThrottle.availablePermits());
+		verify(connPool).release(channel);
+		verify(driver, never()).sendRequest(any(), any());
+		assertEquals(Boolean.TRUE, channel.attr(NettyStorageDriver.ATTR_KEY_RELEASED).get());
+		channel.close();
+	}
+
+	@Test
+	void disabledPropertyNeverPolls() throws Exception {
+		set(CoopStorageDriverBase.class, "directDispatchEnabled", false);
+		final var channel = heldChannel();
+		final var done = completedOp(Operation.Status.SUCC);
+		inOpQueue.add(nextOp());
+
+		driver.complete(channel, done);
+
+		assertEquals(1, inOpQueue.size(), "queued work stays for the dispatcher");
+		verify(driver, never()).sendRequest(any(), any());
+		assertEquals(1, concurrencyThrottle.availablePermits());
+		verify(connPool).release(channel);
+		channel.close();
+	}
+
+	@Test
+	void failedCompletionNeverPollsAndClosesChannel() {
+		final var channel = heldChannel();
+		final var done = completedOp(Operation.Status.FAIL_IO);
+		inOpQueue.add(nextOp());
+
+		driver.complete(channel, done);
+
+		assertEquals(1, inOpQueue.size());
+		verify(driver, never()).sendRequest(any(), any());
+		assertEquals(1, concurrencyThrottle.availablePermits());
+		verify(connPool).release(channel);
+		assertFalse(channel.isActive());
+	}
+
+	@Test
+	void compositeCompletionKeepsDispatcherPath() {
+		final var channel = heldChannel();
+		final Operation<Item> done = mock(CompositeOperation.class);
+		when(done.status()).thenReturn(Operation.Status.SUCC);
+		when(done.type()).thenReturn(OpType.CREATE);
+		when(done.result()).thenReturn(mock(Operation.class));
+		inOpQueue.add(nextOp());
+
+		driver.complete(channel, done);
+
+		assertEquals(1, inOpQueue.size());
+		verify(driver, never()).sendRequest(any(), any());
+		assertEquals(1, concurrencyThrottle.availablePermits());
+		verify(connPool).release(channel);
+		channel.close();
+	}
+
+	@Test
+	void sendFailureCompletesNextOperationAsFailedAndReleasesTransport() {
+		final var channel = heldChannel();
+		final var done = completedOp(Operation.Status.SUCC);
+		final var next = nextOp();
+		inOpQueue.add(next);
+		doThrow(new IllegalStateException("send failed")).when(driver).sendRequest(channel, next);
+
+		driver.complete(channel, done);
+
+		verify(next).status(Operation.Status.FAIL_UNKNOWN);
+		verify(driver).complete(channel, next);
+		assertEquals(1, concurrencyThrottle.availablePermits(), "permit returns through the failure path");
+		verify(connPool).release(channel);
+		verify(opResultOut, times(2)).put(any(Operation.class));
+	}
+
+	@Test
+	void resultPublicationFailureStillReleasesTransport() {
+		final var channel = heldChannel();
+		final var done = completedOp(Operation.Status.SUCC);
+		inOpQueue.add(nextOp());
+		when(opResultOut.put(any(Operation.class))).thenThrow(new IllegalStateException("output down"));
+
+		assertThrows(IllegalStateException.class, () -> driver.complete(channel, done));
+
+		assertEquals(1, concurrencyThrottle.availablePermits());
+		verify(connPool).release(channel);
+		verify(driver, never()).sendRequest(any(), any());
+		assertEquals(1, inOpQueue.size(), "nothing is polled once completion has failed");
+		channel.close();
+	}
+}


### PR DESCRIPTION
## Summary

Completion-driven direct dispatch for the built-in Netty drivers, gated by the JVM property `spt.dispatch.direct` (**default off**; behaviour with the property unset is unchanged).

When a request completes successfully on an event-loop thread, `NettyStorageDriverBase.complete()` keeps the concurrency permit and the channel, publishes the completed operation, and — under the existing admission lock — polls the next plain operation from the driver queue, marks it dispatched, and sends it on the same channel from the same thread. This removes the per-operation dispatcher hand-off and the second event-loop wake that the dispatcher's foreign-thread write used to cause. The dispatcher remains the path for composite/MPU work, child operations, NOOP, the batch `submit(List)` API, drivers that opt out, and any completion that refuses the direct path.

- `CoopStorageDriverBase`: `pollForDirectDispatch()`, `dispatcherBacklog()`, `directDispatchEnabled()`, `supportsDirectDispatch()` capability (default false), `handleCompleted(op, wakeDispatcher)`. No existing signature changed.
- `OperationDispatchTask`: with direct dispatch on, drains only what it can submit now, publishes its backlog before parking so completions yield to buffered work, and parks instead of spinning when queued work has no capacity.
- `NettyStorageDriverBase`: direct path in `complete()`, capability `true`.
- `S3RdmaStorageDriver` and `S3TablesStorageDriver` opt out: their `submit()` does per-op preparation (RDMA buffer/context; control-plane modes) that `sendRequest` alone does not perform. NIO/fs and third-party cooperative extensions are unaffected by the property.

The default stays **off**. Flipping it is tracked separately: capability audit done; integrated canaries (TLS, streamed payloads, cancellation, failure injection, soak, distributed real-target run) and READ-at-concurrency screens still to run.
